### PR TITLE
Add CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` running CodeQL against `javascript-typescript` with the `security-extended` query set
- Triggers on PRs to `main`, pushes to `main`, and a weekly Monday cron (catches newly published rules even when code hasn't changed)
- Standalone workflow rather than a job in `ci.yml` so a slow analysis run doesn't block other CI status, and the cron stays clean

## Follow-ups (not in this PR)
- After merge, confirm Code scanning is enabled in repo Settings → Code security
- Once a clean run lands and any initial findings are triaged, consider making CodeQL a required check on `main`

## Test plan
- [ ] Workflow appears in the Actions tab after merge to `main`
- [ ] First run completes and uploads results to the Security → Code scanning tab
- [ ] Re-run on this PR (once enabled) reports a status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)