### PR TITLE
Frontend testing remediation: phases 1-6, 11-14 + partial 3

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -314,6 +314,27 @@ module.exports = {
       },
     },
     {
+      name: "event-handlers-cross-module-via-adapter-only",
+      severity: "error",
+      comment:
+        "Cross-module event-handler imports must go through a *-event-adapter.ts file " +
+        "(ADR-0007 ACL pattern + Phase 11 of the remediation plan). Handlers consume " +
+        "the module's own trigger types from event-handlers/triggers/; only the " +
+        "adapter is allowed to import the publisher module's barrel. Tests are " +
+        "exempt — they may import publisher events directly to drive end-to-end flows.",
+      from: {
+        path: "^packages/server/src/modules/([^/]+)/event-handlers/",
+        pathNot: [
+          "\\.test\\.ts$",
+          "\\.integration\\.test\\.ts$",
+          "^packages/server/src/modules/[^/]+/event-handlers/[^/]+-event-adapter\\.ts$",
+        ],
+      },
+      to: {
+        path: "^packages/server/src/modules/(?!\\1/)[^/]+/index\\.ts$",
+      },
+    },
+    {
       name: "platform-ids-effect-only",
       severity: "error",
       comment:

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -314,6 +314,20 @@ module.exports = {
       },
     },
     {
+      name: "platform-ids-effect-only",
+      severity: "error",
+      comment:
+        "platform/ids/ is the minimal shared kernel for cross-module branded entity " +
+        "IDs (ADR-0020). It may only depend on `effect` from third-party packages. " +
+        "Drizzle column types, validation libs, contract schemas, etc. do not belong " +
+        "here — they leak module-internal shape into the shared kernel.",
+      from: { path: "^packages/server/src/platform/ids/" },
+      to: {
+        dependencyTypes: ["npm", "npm-dev", "npm-peer", "npm-optional"],
+        pathNot: "/node_modules/effect/",
+      },
+    },
+    {
       name: "no-circular",
       severity: "error",
       comment:

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -314,6 +314,33 @@ module.exports = {
       },
     },
     {
+      name: "web-no-cross-feature-imports",
+      severity: "error",
+      comment:
+        "Features under packages/web/features/ may not import each other. Cross-feature data flows belong in `services/data-access/`; shared rendering primitives belong in `@org/components/patterns/`. The feature boundary is the same kind of seam the server uses between modules.",
+      from: { path: "^packages/web/features/([^/]+)/" },
+      to: {
+        path: "^packages/web/features/([^/]+)/",
+        pathNot: "^packages/web/features/$1/",
+      },
+    },
+    {
+      name: "web-features-not-from-app",
+      severity: "error",
+      comment:
+        "Routes under packages/web/app/ compose features; features must not import app/ pages, layouts, or providers. The dependency direction is app → features, never reversed. Server-only or shared infra files in app/ are not feature dependencies — promote them to /services or /lib first.",
+      from: { path: "^packages/web/features/" },
+      to: { path: "^packages/web/app/" },
+    },
+    {
+      name: "web-features-no-server-data-access",
+      severity: "error",
+      comment:
+        "Features render in the client graph (`use client`). They must not transitively import `*-queries.server.ts` files — those carry `import 'server-only'` and would poison the client bundle. Use the client hooks in `services/data-access/use-*-queries.ts` instead, or run the prefetch in the route's `page.tsx` and read via `useEffectSuspenseQuery`.",
+      from: { path: "^packages/web/features/" },
+      to: { path: "^packages/web/services/data-access/.*\\.server\\.ts$" },
+    },
+    {
       name: "event-handlers-cross-module-via-adapter-only",
       severity: "error",
       comment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ The naming conventions are also the parity-rule detectors. Don't rename a file t
 - **Integration tests** (`*-repository-live.integration.test.ts`, `<endpoint>.endpoint.integration.test.ts`, `<query>.integration.test.ts`) hit a real DB. They self-skip when `DATABASE_URL_TEST` is unset; `pnpm test` succeeds with no auxiliary services.
 - **HTTP integration tests** use `useServerTestRuntime(["table1", "table2"])` from `test-utils/`, which wires `ManagedRuntime.make(TestServerLive)` + `beforeAll`/`afterAll` + per-test `truncate`. Tests then exercise the contract via `HttpApiClient.make(Api)` and seed prior state by calling _other endpoints_, not by reaching into module internals.
 - **Query/repository integration tests** seed via the live repository (or other production-path code), not via raw SQL. Using the repository as the seeding seam keeps the test honest about what production paths look like.
+- **Endpoint test naming.** A test file ending in `*.endpoint.integration.test.ts` exercises the real HTTP layer against a live database via `useServerTestRuntime(...)`. A file ending in `*.endpoint.test.ts` is a true unit test — no DB, no HTTP round-trip — typically a parity-rule token for endpoints whose meaningful coverage lives elsewhere (e.g. the OIDC `login` / `callback` / `logout` flows, covered by Playwright + `SessionRepositoryLive` integration tests). Any `.endpoint.test.ts` file must carry a header comment naming where the meaningful coverage lives; if a test starts hitting real HTTP + DB, rename it to `.endpoint.integration.test.ts`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A monorepo containing:
 
 - `packages/web`: Next.js (App Router) renderer; proxies `/api/*` to the BFF (see [ADR-0018](docs/adr/0018-frontend-nextjs-renderer-and-proxy.md))
 - `packages/server`: Effect-based BFF / API server (the auth authority — see ADR-0016)
-- `packages/contracts`: Shared HTTP API contracts consumed by both web and server
+- `packages/contracts`: Shared HTTP API contracts consumed by both web and server (the stack is intentionally isomorphic — see [ADR-0019](docs/adr/0019-isomorphic-stack.md))
 - `packages/database`: Database schema, migrations, and SQL access primitives
 - `packages/jobs`: Background-job runner (cron-style)
 - `packages/acceptance`: Playwright acceptance suite

--- a/docs/adr/0007-transaction-runner-and-synchronous-event-bus.md
+++ b/docs/adr/0007-transaction-runner-and-synchronous-event-bus.md
@@ -106,6 +106,42 @@ These are valid patterns but solve a different problem. If a future feature genu
 - **Fail-soft subscribers** (a failed subscriber logs and continues, the publisher's transaction commits anyway). Rejected. Immediate consistency is the goal; fail-soft is exactly the partial-failure-with-logged-silence behavior we're trying to prevent.
 - **Outbox from day one.** Rejected. Adds machinery (a table, a publisher process, retry semantics, dedup) for a problem we don't have. When the problem appears, the outbox is the right answer; today, it would be speculative complexity.
 
+## Anti-corruption layer for cross-module event consumption
+
+When a module subscribes to another module's domain event, that event's schema becomes load-bearing for the subscriber. A new field on `UserCreated` is harmless to `user`'s internal callers; it can be a breaking change for `wallet` if `wallet`'s handler reads field names off the event directly.
+
+To keep the publisher's event schema from leaking into the consumer's handlers, cross-module subscriptions go through an **adapter** file. The adapter is the only file allowed to import the publisher's barrel; handlers consume a wallet-internal trigger type instead.
+
+```
+modules/<consumer>/event-handlers/
+├── triggers/
+│   └── <publisher>-events.ts            # consumer-internal trigger types
+├── <publisher>-event-adapter.ts         # subscribes to publisher events
+└── <name>-when-<...>.ts                 # handler — imports the trigger type
+```
+
+The adapter subscribes to each publisher event, translates it into the consumer's trigger shape, and forwards to the handler:
+
+```ts
+const toTrigger = (event: UserCreated): UserCreatedTrigger => ({ userId: event.userId });
+
+export const UserEventAdapterLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const bus = yield* DomainEventBus;
+    const repo = yield* WalletRepository;
+    yield* bus.subscribe(UserCreated, (event) =>
+      handleUserCreated(toTrigger(event)).pipe(Effect.provideService(WalletRepository, repo)),
+    );
+  }),
+);
+```
+
+The handler depends only on the trigger type — never on `UserCreated`. If `user` adds a field, only the adapter changes; handlers stay stable.
+
+The pattern is enforced by the `event-handlers-cross-module-via-adapter-only` dep-cruiser rule: files under `event-handlers/` may not import another module's barrel unless they're a `*-event-adapter.ts` file. Tests are exempt (they often drive end-to-end flows that need the publisher's event constructor).
+
+This is Vernon's anti-corruption layer at module scope. It costs one file per (consumer, publisher) pair and one trigger-types file. The benefit is that the consumer's handler logic remains testable, stable, and decoupled from the publisher's evolving schema.
+
 ## Related
 
 - ADR-0003 (events as values) — the events arriving at `dispatch` come from pure aggregate ops.

--- a/docs/adr/0019-isomorphic-stack.md
+++ b/docs/adr/0019-isomorphic-stack.md
@@ -1,0 +1,126 @@
+# ADR-0019 — Isomorphic stack commitment
+
+Date: 2026-05-10
+Status: Accepted
+
+## Context
+
+The template runs Effect + TypeScript on both sides of the wire:
+
+- The server (`@org/server`) terminates HTTP, persists to Postgres,
+  composes business logic via the command/query/event buses.
+- The web renderer (`@org/web`) is a Next.js App Router app that
+  proxies `/api/*` to the BFF, renders server components from a
+  per-request runtime, and hydrates a client runtime that shares the
+  same `ApiClient` type.
+
+The contract package `@org/contracts` is the single source of truth
+for API shape, schemas, and the error union. Both server and web
+build against the same `HttpApi` definition; the server implements
+it, the web client consumes it.
+
+This isomorphism is load-bearing for a testing tier we want to
+introduce (Phases 7–9 of the frontend testing remediation plan):
+**integration tests that run the real backend handlers in-process
+from FE tests**. That tier is only possible because the backend code
+is callable as a function from a Node-side test process. If the
+backend lived in a different runtime (Go, Rust, JVM), we'd be stuck
+with a hand-written simulator that drifts from the real handlers, or
+we'd give up the tier entirely.
+
+The isomorphism deserves an explicit commitment so future
+contributors see the constraint and the rationale before proposing a
+polyglot backend.
+
+## Decision
+
+**Commit to an isomorphic stack: any backend service whose web tier
+has integration tests must run in the Node runtime and expose its
+HTTP request handler as a function callable from a workspace
+package.**
+
+In practice today:
+
+- The BFF (`@org/server`) is Node + Effect + `@effect/platform`.
+  Its `HttpApi.toHandler(Api)` produces a `(Request) => Promise<Response>`
+  that's already shaped for in-process invocation.
+- The contract package compiles to plain ESM and is depended on by
+  both packages without any code-gen step.
+- The web renderer's `ApiClient` is a `Context.Tag` whose live layer
+  is parameterized by transport. Production wires it to `fetch`
+  against `/api/...`; the integration tier wires it to a
+  `fetch`-shaped function that resolves inside the process via
+  `HttpApi.toHandler(Api)`.
+
+New backend services authored in another runtime forfeit the
+integration tier for their FE surface. They keep the presenter tier
+and the acceptance tier; they lose the in-process tier.
+
+## Consequences
+
+- **Locked to Node + TypeScript on the backend** until this ADR is
+  revised.
+- In return:
+  - **No OpenAPI codegen.** The contract is the schema. There's no
+    second tool to drift against.
+  - **No schema duplication.** Server and web build against the same
+    `Schema.Class`/`HttpApi` definitions.
+  - **No parallel fakes.** The FE-side integration tests use the
+    real backend handlers; the simulator IS the backend.
+  - **Branded domain types flow end-to-end** without translation.
+    `UserId` is a branded string in `@org/server` and a branded
+    string in `@org/web`; same brand, same nominal type.
+  - **`TestClock` / `RecordingEventBus` / FakeDatabase work
+    identically** on both sides — they're Effect services, and the
+    FE-side test harness consumes them via the same `Context.Tag`s
+    the server-side tests do.
+- **Future extraction.** If a future module is extracted to a
+  non-Node service (Go, Rust, Python ML service, etc.), that
+  module's FE-side integration tests drop to one of:
+  - An MSW-stateful simulator with contract-test parity against
+    the real service.
+  - The acceptance tier only (Playwright + the real deployed
+    service).
+
+  The presenter tier and the acceptance tier are unaffected. The
+  pain is local to the extracted module.
+
+## Alternatives considered
+
+- **Polyglot stack with hand-written FE-side simulators.** Rejected.
+  The simulator drifts from the real handler unless its contract
+  tests are exhaustive (they're never exhaustive). Drift produces
+  the classic "tests pass, prod fails" failure mode.
+- **WASM-compile the backend for in-process use.** Rejected. Loading
+  a WASM blob into Node, threading Postgres bindings through it,
+  and reproducing the Effect runtime inside WASM is a tar pit. The
+  ergonomic gap vs. native Node is large enough that maintenance
+  cost dominates.
+- **Skip the integration tier entirely.** Rejected. The gap is
+  exactly the one the remediation plan exists to close: presenter
+  tests over-mock; acceptance tests are too slow and stateful for
+  every behavior the FE depends on; integration is the missing rung.
+- **Generate a TypeScript client from an OpenAPI document.**
+  Rejected on its own merits: the Effect contract already produces
+  a typed client (`HttpApiClient.make(Api)`). Layering OpenAPI on
+  top would introduce a translation step in the source of truth.
+
+## Mechanics
+
+- The `test-backend` workspace package (added in Phase 8 of the
+  remediation plan) is the in-process surface: `TestBackend.start()`
+  returns a handle with a `fetch`-shaped function backed by
+  `HttpApi.toHandler(Api)`, plus direct programmatic access to the
+  FakeDatabase, TestClock, RecordingEventBus, and per-external-service
+  simulators.
+- The web `ApiClient` accepts a swappable transport tag. Production
+  uses `fetch`; tests use the `fetch` returned by `TestBackend.start()`.
+
+## Related
+
+- ADR-0010 (HTTP-only contracts) — the contract package is the
+  single source of truth for API shape.
+- ADR-0018 (Next.js renderer + proxy) — the web tier's runtime
+  shape and how it proxies `/api/*`.
+- Frontend testing remediation plan, Phases 7–9 — the integration
+  tier this ADR enables.

--- a/docs/adr/0020-platform-ids-governance.md
+++ b/docs/adr/0020-platform-ids-governance.md
@@ -1,0 +1,98 @@
+# ADR-0020 — `platform/ids/` governance
+
+Date: 2026-05-10
+Status: Accepted
+
+## Context
+
+`packages/server/src/platform/ids/` is the minimal shared kernel for
+branded entity IDs that cross module boundaries. It currently holds a
+single file, `user-id.ts`, which exports `UserId` — referenced by
+`wallet` (FK), `todos` (current user), and `auth` (the identity row's
+target user).
+
+The shared-kernel pattern is intentional (ADR-0002 has the long
+form): cross-module ID references need a stable, dependency-free
+location so two modules don't redeclare the same brand and drift. The
+folder is narrowly allowlisted in `.dependency-cruiser.cjs` — domain
+folders are otherwise sealed.
+
+What's missing is **governance**. Newman's "minimal stable shared
+kernel" guidance and Vernon's "anti-corruption layer" both warn that
+shared kernels grow into dumping grounds without explicit rules. This
+ADR locks in those rules before the second file lands.
+
+## Decision
+
+### What's allowed in `platform/ids/`
+
+- **Branded UUID types** whose corresponding aggregate lives in
+  another module, defined as
+  `Schema.UUID.pipe(Schema.brand("<Name>Id"))`.
+- Nothing else.
+
+### What's not allowed
+
+- Value objects (`Address`, `Money`, `Email`). These live in the
+  owning module's `domain/`.
+- Serialized shapes, DTOs, request/response payloads. Those are
+  contracts, not IDs.
+- Validation rules, predicates, parsing helpers. A branded ID's only
+  job is to mark a string at the type level.
+- Helper functions of any kind.
+- Module-internal IDs. If only one module references the ID, the ID
+  stays in `<module>/domain/`.
+
+### Adding a new ID
+
+- Add a new file only when a **second** module needs to reference an
+  ID owned by an existing aggregate. Single-module IDs stay in
+  `<module>/domain/<thing>-id.ts`.
+- The PR adding the new file must name both consumers in the PR
+  description. Reviewers reject the addition if only one cross-module
+  consumer can be named.
+
+### Audit policy
+
+- Periodic sweep (at least once per major refactor) removes IDs that
+  are now referenced by exactly one module. Such an ID is "no longer
+  cross-module" — it moves back to that module's `domain/`.
+- The sweep is mechanical: grep for `platform/ids/<file>` imports,
+  count distinct module roots, move when count == 1.
+
+### Mechanical enforcement
+
+A new `platform-ids-effect-only` dependency-cruiser rule restricts
+the folder to effect-only third-party imports. Content discipline
+(branded IDs only) still requires PR review, but the rule blocks
+accidental drift toward third-party-coupled shapes (e.g. Drizzle
+column types leaking in).
+
+## Consequences
+
+- The shared kernel stays a one-line-per-file folder for the
+  foreseeable future. That's by design.
+- New cross-module IDs are still cheap to add — one file, one PR,
+  reviewer scans for two distinct consumer modules.
+- If a future ID has a meaningful schema (e.g. a UUID with a checksum
+  byte), the rule still permits it: it's still `Schema.X.pipe(Schema.brand(...))`,
+  and the brand is the public surface.
+- ADR-0002 (typed-ID shared kernel addendum) remains the rationale
+  for _why_ the folder exists; this ADR is purely about _what stays
+  in it_.
+
+## Alternatives considered
+
+- **Eliminate the folder; each module redefines its own brand.**
+  Rejected: two modules would each have their own `UserId` brand, and
+  TypeScript would happily accept them as different types. Cross-FK
+  passing would require coercion at every boundary.
+- **Move IDs into `@org/contracts`.** Rejected: contracts are the
+  HTTP wire shape and live in a separate package consumed by both the
+  server and the web client. Branded IDs are a server-internal
+  invariant — pulling them into contracts would either leak the brand
+  to the client (where it's meaningless) or duplicate it.
+- **Allow value objects in `platform/ids/`.** Rejected: value objects
+  carry semantic invariants (e.g. `Email` validation) that belong with
+  the aggregate that owns them. Splitting them into a shared kernel
+  creates two places for the same concept to evolve.

--- a/packages/components/primitives/checkbox.stories.tsx
+++ b/packages/components/primitives/checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 import { Checkbox } from "./checkbox";
 import { Label } from "./label";
 
@@ -27,4 +28,30 @@ export const WithLabel: Story = {
       <Label htmlFor="terms">Accept terms and conditions</Label>
     </div>
   ),
+};
+
+// Play-test: clicking the label toggles the associated checkbox.
+// Confirms the htmlFor / id contract the rest of the design system
+// relies on (Form.Control wires labels by id).
+export const ToggleViaLabel: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="play-terms" />
+      <Label htmlFor="play-terms">Accept terms and conditions</Label>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole("checkbox", { name: /accept terms/i });
+
+    // Radix renders a button with aria-checked instead of a real
+    // input[type=checkbox]; both states are exposed via getByRole.
+    await expect(checkbox).toHaveAttribute("aria-checked", "false");
+
+    await userEvent.click(canvas.getByText("Accept terms and conditions"));
+    await expect(checkbox).toHaveAttribute("aria-checked", "true");
+
+    await userEvent.click(canvas.getByText("Accept terms and conditions"));
+    await expect(checkbox).toHaveAttribute("aria-checked", "false");
+  },
 };

--- a/packages/components/primitives/dialog.stories.tsx
+++ b/packages/components/primitives/dialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { Button } from "./button";
 import { Dialog } from "./dialog";
 
@@ -47,4 +48,49 @@ export const OpenByDefault: Story = {
       </Dialog.Content>
     </Dialog>
   ),
+};
+
+// Play-test: clicking the trigger opens the dialog, Escape closes
+// it. Covers the keyboard-dismiss path users rely on.
+export const OpenAndCloseViaEscape: Story = {
+  render: () => (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button variant="outline" data-testid="play-trigger">
+          Open dialog
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>Confirm</Dialog.Title>
+          <Dialog.Description>Press Escape to dismiss.</Dialog.Description>
+        </Dialog.Header>
+      </Dialog.Content>
+    </Dialog>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    // Radix portals the dialog into document.body, so reach for the
+    // body scope when asserting on dialog presence.
+    const body = within(canvasElement.ownerDocument.body);
+
+    await step("dialog is not in the document before clicking the trigger", async () => {
+      await expect(body.queryByRole("dialog")).toBeNull();
+    });
+
+    await step("clicking the trigger opens the dialog", async () => {
+      await userEvent.click(canvas.getByTestId("play-trigger"));
+      await expect(await body.findByRole("dialog")).toBeInTheDocument();
+    });
+
+    await step("pressing Escape dismisses the dialog", async () => {
+      await userEvent.keyboard("{Escape}");
+      // waitFor retries on synchronous throws; we void-cast the
+      // assertion to satisfy no-floating-promises (the assertion's
+      // promise is for chained matchers, which we don't need here).
+      await waitFor(() => {
+        void expect(body.queryByRole("dialog")).toBeNull();
+      });
+    });
+  },
 };

--- a/packages/components/primitives/form.stories.tsx
+++ b/packages/components/primitives/form.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+import { expect, userEvent, within } from "storybook/test";
 import { Button } from "./button";
 import { Form } from "./form";
 
@@ -33,4 +35,64 @@ export const Default: Story = {
       <Button type="submit">Submit</Button>
     </Form>
   ),
+};
+
+// Play-test: the Form.Error contract is "shows when error is a
+// non-empty string, hides when null/empty". Wraps the form in a
+// state-toggle so the play function exercises both branches.
+const ToggleErrorForm: React.FC = () => {
+  const [error, setError] = React.useState<string | null>(null);
+  return (
+    <Form className="w-72" onSubmit={() => undefined}>
+      <Form.Control>
+        <Form.Label htmlFor="play-email" required>
+          Email
+        </Form.Label>
+        <Form.Input id="play-email" type="email" />
+        <Form.Error error={error} />
+      </Form.Control>
+      <Button
+        type="button"
+        data-testid="trigger-error"
+        onClick={() => {
+          setError("Email is required");
+        }}
+      >
+        Trigger error
+      </Button>
+      <Button
+        type="button"
+        data-testid="clear-error"
+        onClick={() => {
+          setError(null);
+        }}
+      >
+        Clear error
+      </Button>
+    </Form>
+  );
+};
+
+export const ErrorContract: Story = {
+  render: () => <ToggleErrorForm />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("error is hidden initially", async () => {
+      // Form.Error renders `null` when error is null/empty — there
+      // should be no node with that error message yet.
+      await expect(canvas.queryByText("Email is required")).toBeNull();
+    });
+
+    await step("error appears after triggering", async () => {
+      await userEvent.click(canvas.getByTestId("trigger-error"));
+      await expect(await canvas.findByText("Email is required")).toBeInTheDocument();
+    });
+
+    await step("error disappears after clearing", async () => {
+      await userEvent.click(canvas.getByTestId("clear-error"));
+      // Form.Error returns null on empty/null — the node is unmounted.
+      await expect(canvas.queryByText("Email is required")).toBeNull();
+    });
+  },
 };

--- a/packages/components/primitives/input.stories.tsx
+++ b/packages/components/primitives/input.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 import { Input } from "./input";
 
 const meta: Meta<typeof Input> = {
@@ -30,3 +31,14 @@ export const Email: Story = { args: { type: "email", placeholder: "user@example.
 export const Password: Story = { args: { type: "password", placeholder: "••••••••" } };
 export const Disabled: Story = { args: { disabled: true, defaultValue: "Read only" } };
 export const Invalid: Story = { args: { defaultValue: "bad", "aria-invalid": true } };
+
+// Play-test: keyboard input lands in the input's value.
+export const TypeViaKeyboard: Story = {
+  args: { placeholder: "Type here…" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByPlaceholderText<HTMLInputElement>("Type here…");
+    await userEvent.type(input, "hello");
+    await expect(input.value).toBe("hello");
+  },
+};

--- a/packages/components/primitives/select.stories.tsx
+++ b/packages/components/primitives/select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 import { Select } from "./select";
 
 const meta = {
@@ -34,4 +35,39 @@ export const Default: Story = {
       </Select>
     </div>
   ),
+};
+
+// Play-test: Select's ARIA contract. The Radix listbox exposes
+// aria-haspopup/aria-expanded on the trigger; opening + arrow-down +
+// Enter selects the first item. Catches regressions in the
+// keyboard-nav and ARIA pieces that depend on Radix's primitives.
+export const KeyboardNavigation: Story = {
+  render: () => (
+    <div className="w-64">
+      <Select>
+        <Select.Trigger data-testid="play-trigger">
+          <Select.Value placeholder="Pick a fruit" />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="apple">Apple</Select.Item>
+          <Select.Item value="banana">Banana</Select.Item>
+          <Select.Item value="cherry">Cherry</Select.Item>
+        </Select.Content>
+      </Select>
+    </div>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByTestId("play-trigger");
+
+    await step("trigger is closed initially (aria-expanded=false)", async () => {
+      await expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    await step("opening via keyboard surfaces the options", async () => {
+      trigger.focus();
+      await userEvent.keyboard("{Enter}");
+      await expect(trigger).toHaveAttribute("aria-expanded", "true");
+    });
+  },
 };

--- a/packages/server/src/modules/auth/auth-module.ts
+++ b/packages/server/src/modules/auth/auth-module.ts
@@ -1,10 +1,19 @@
 import * as Layer from "effect/Layer";
+import { AuthIdentityRepositoryLive } from "./infrastructure/auth-identity-repository-live.js";
 import { OidcClient } from "./infrastructure/oidc-client.js";
 import { AuthHttpLive } from "./interface/auth-http-live.js";
 
-// AuthModuleLive only registers the HTTP handlers + the OIDC client (which is
-// private to the callback path). The repository implementations and the
-// CookieCodec live in `AuthSharedDepsLive` (auth-shared-deps.ts) so they can
-// be consumed by both the auth module and the platform middleware without a
-// duplicate provider — see plan §3.4 + the small depcruise exception.
-export const AuthModuleLive = AuthHttpLive.pipe(Layer.provide(OidcClient.Default));
+// AuthModuleLive registers the HTTP handlers and the auth-only
+// infrastructure they depend on. The OIDC client is private to the
+// callback path; AuthIdentityRepository is read only by sign-in and
+// never crosses the module boundary — both stay internal here.
+//
+// CookieCodec and SessionRepository are the two auth-infra services
+// that DO cross the boundary (the platform middleware needs the same
+// instances). Those live in `AuthSharedDepsLive` (auth-shared-deps.ts)
+// and are provided once at the API layer so both consumers share the
+// same references.
+export const AuthModuleLive = AuthHttpLive.pipe(
+  Layer.provide(OidcClient.Default),
+  Layer.provide(AuthIdentityRepositoryLive),
+);

--- a/packages/server/src/modules/auth/auth-shared-deps.ts
+++ b/packages/server/src/modules/auth/auth-shared-deps.ts
@@ -1,12 +1,22 @@
 import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 import * as Layer from "effect/Layer";
-import { AuthIdentityRepositoryLive } from "./infrastructure/auth-identity-repository-live.js";
 import { SessionRepositoryLive } from "./infrastructure/session-repository-live.js";
 
-// Shared by the auth module's HTTP handlers AND the platform auth middleware.
-// Provided once at the API layer so both consumers see the same instances.
-export const AuthSharedDepsLive = Layer.mergeAll(
-  CookieCodec.Default,
-  SessionRepositoryLive,
-  AuthIdentityRepositoryLive,
-);
+// The two auth-infra services that genuinely cross the module
+// boundary:
+//
+//   - CookieCodec — the auth module signs the session cookie at
+//     login/callback; the platform middleware verifies it on every
+//     request. They MUST share the same instance so the verify key
+//     matches the signing key.
+//   - SessionRepository — the auth module writes sessions at sign-in;
+//     the middleware reads them on every request via FindSessionQuery
+//     (whose handler also depends on SessionRepository). Same instance
+//     keeps the read and write paths consistent.
+//
+// Provided once at the API layer (server.ts / test-server.ts) so the
+// auth module's handlers AND the platform middleware see the same
+// service instances. AuthIdentityRepository is intentionally NOT in
+// this layer — it's a purely module-internal concern (only sign-in
+// reads it) and is provided inside AuthModuleLive.
+export const AuthSharedDepsLive = Layer.mergeAll(CookieCodec.Default, SessionRepositoryLive);

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -5,8 +5,11 @@ export { authQueryHandlers } from "./queries/auth-query-handlers.js";
 export { FindSessionQuery } from "./queries/find-session-query.js";
 
 export { AuthModuleLive } from "./auth-module.js";
+// AuthSharedDepsLive narrowly exposes the auth-infra services that
+// must be shared by reference with the platform middleware
+// (CookieCodec + SessionRepository). Other auth-infra services stay
+// internal to AuthModuleLive — see auth-shared-deps.ts.
 export { AuthSharedDepsLive } from "./auth-shared-deps.js";
-export { AuthIdentityRepository } from "./domain/auth-identity-repository.js";
 export {
   AuthIdentityNotFound,
   SessionExpired,

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.integration.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.integration.test.ts
@@ -1,7 +1,7 @@
 import { Api } from "@/api.js";
 import { UserCreated } from "@/modules/user/index.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
-import { CreateWalletWhenUserIsCreatedLive } from "@/modules/wallet/event-handlers/create-wallet-when-user-is-created.js";
+import { UserEventAdapterLive } from "@/modules/wallet/event-handlers/user-event-adapter.js";
 import { DomainEventBus, makeDomainEventBusLive } from "@/platform/domain-event-bus.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TransactionRunner, TransactionRunnerLive } from "@/platform/transaction-runner.js";
@@ -99,10 +99,7 @@ const FailingWalletRepository = Layer.succeed(
   }),
 );
 
-const RollbackTestLayer = Layer.mergeAll(
-  TransactionRunnerLive,
-  CreateWalletWhenUserIsCreatedLive,
-).pipe(
+const RollbackTestLayer = Layer.mergeAll(TransactionRunnerLive, UserEventAdapterLive).pipe(
   Layer.provideMerge(makeDomainEventBusLive()),
   Layer.provideMerge(FailingWalletRepository),
   Layer.provideMerge(TestDatabaseLive),

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.test.ts
@@ -1,29 +1,20 @@
-import { type UserCreated } from "@/modules/user/index.js";
-import { WalletAlreadyExistsForUser } from "@/modules/wallet/domain/wallet-errors.js";
 import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
 import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
-import { DomainEventBus, makeDomainEventBusLive } from "@/platform/domain-event-bus.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual, ok } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
-import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import { CreateWalletWhenUserIsCreatedLive, handle } from "./create-wallet-when-user-is-created.js";
+import { handleUserCreated } from "./create-wallet-when-user-is-created.js";
+import { type UserCreatedTrigger } from "./triggers/user-events.js";
 
 const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
-const bobId = UserId.make("22222222-2222-2222-2222-222222222222");
 
-const userCreated = (userId: UserId): UserCreated => ({
-  _tag: "UserCreated",
-  userId,
-  email: "alice@example.com",
-  address: { country: "USA", street: "123 Main St", postalCode: "12345" },
-});
+const trigger = (userId: UserId): UserCreatedTrigger => ({ userId });
 
 const seedWallet = (userId: UserId) =>
   Effect.gen(function* () {
@@ -34,10 +25,10 @@ const seedWallet = (userId: UserId) =>
     yield* repo.insert(wallet);
   });
 
-describe("createWalletWhenUserIsCreated (handle)", () => {
-  it.effect("inserts a wallet with balance=0 carrying the event's userId", () =>
+describe("createWalletWhenUserIsCreated (handleUserCreated)", () => {
+  it.effect("inserts a wallet with balance=0 carrying the trigger's userId", () =>
     Effect.gen(function* () {
-      yield* handle(userCreated(aliceId));
+      yield* handleUserCreated(trigger(aliceId));
       const repo = yield* WalletRepository;
       const stored = yield* repo.findByUserId(aliceId);
       ok(Option.isSome(stored));
@@ -46,73 +37,30 @@ describe("createWalletWhenUserIsCreated (handle)", () => {
     }).pipe(Effect.provide(WalletRepositoryFake)),
   );
 
-  it.effect("fails WalletAlreadyExistsForUser when a wallet already exists for the userId", () =>
-    Effect.gen(function* () {
-      yield* seedWallet(aliceId);
-      const exit = yield* Effect.exit(handle(userCreated(aliceId)));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
-        deepStrictEqual(error instanceof WalletAlreadyExistsForUser, true);
-      }
-    }).pipe(Effect.provide(WalletRepositoryFake)),
-  );
-});
-
-// The subscriber Layer wires `handle` into the bus and adds the
-// `WalletAlreadyExistsForUser` catch. These tests prove the catch is at the
-// subscriber boundary (idempotency) and that non-idempotency failures
-// propagate as defects (so the publisher's transaction would roll back).
-describe("CreateWalletWhenUserIsCreatedLive (subscriber boundary)", () => {
-  // The subscriber consumes DomainEventBus + WalletRepository at layer-build
-  // time (it calls bus.subscribe). provideMerge re-exports the dependencies so
-  // tests can call dispatch and inspect the repo.
-  const TestLayer = CreateWalletWhenUserIsCreatedLive.pipe(
-    Layer.provideMerge(WalletRepositoryFake),
-    Layer.provideMerge(makeDomainEventBusLive()),
-  );
-
   it.effect(
-    "catches WalletAlreadyExistsForUser so a duplicate UserCreated dispatch is a no-op",
+    "swallows WalletAlreadyExistsForUser so a duplicate trigger is a no-op (idempotent at the handler boundary)",
     () =>
       Effect.gen(function* () {
-        const bus = yield* DomainEventBus;
-
-        yield* bus.dispatch([userCreated(bobId)]);
-        const exit = yield* Effect.exit(bus.dispatch([userCreated(bobId)]));
+        yield* seedWallet(aliceId);
+        const exit = yield* Effect.exit(handleUserCreated(trigger(aliceId)));
         deepStrictEqual(Exit.isSuccess(exit), true);
-
-        const repo = yield* WalletRepository;
-        const stored = yield* repo.findByUserId(bobId);
-        ok(Option.isSome(stored));
-      }).pipe(Effect.provide(TestLayer)),
+      }).pipe(Effect.provide(WalletRepositoryFake)),
   );
 
   it.effect(
     "propagates non-idempotency failures as defects (publisher transaction would roll back)",
     () =>
       Effect.gen(function* () {
-        const FailingRepo = Layer.succeed(
-          WalletRepository,
-          WalletRepository.of({
-            insert: () => Effect.die("simulated infrastructure failure"),
-            findByUserId: () => Effect.succeed(Option.none()),
-          }),
-        );
-        const FailingTestLayer = CreateWalletWhenUserIsCreatedLive.pipe(
-          Layer.provideMerge(FailingRepo),
-          Layer.provideMerge(makeDomainEventBusLive()),
-        );
-
-        const exit = yield* Effect.flatMap(DomainEventBus, (bus) =>
-          Effect.exit(bus.dispatch([userCreated(aliceId)])),
-        ).pipe(Effect.provide(FailingTestLayer));
-
+        const FailingRepo = Effect.provideService(WalletRepository, {
+          insert: () => Effect.die("simulated infrastructure failure"),
+          findByUserId: () => Effect.succeed(Option.none()),
+        });
+        const exit = yield* Effect.exit(handleUserCreated(trigger(aliceId)).pipe(FailingRepo));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
-          // A defect (Die), not a typed Fail — the catchTag in the subscriber
-          // does not match, so the failure propagates out of dispatch and
-          // would reach the surrounding `tx.run` to trigger rollback.
+          // A defect (Die), not a typed Fail — the catchTag in the handler
+          // does not match, so the failure propagates out and would reach
+          // the surrounding `tx.run` to trigger rollback.
           deepStrictEqual(exit.cause._tag, "Die");
         }
       }),

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.ts
@@ -1,35 +1,29 @@
-import { UserCreated } from "@/modules/user/index.js";
+// Wallet's reaction to a "user was created" trigger. Imports the
+// wallet-internal `UserCreatedTrigger` from ./triggers/ — NOT
+// `UserCreated` from `@/modules/user/index.js`. The translation
+// happens in ./user-event-adapter.ts, which is the only file allowed
+// to cross the boundary.
+//
+// Runs synchronously inside the publisher's transaction (ADR-0007),
+// so an unexpected failure rolls back the originating user-creation.
+// The `WalletAlreadyExistsForUser` catch is a defensive idempotency
+// net for a case that shouldn't occur given a freshly-minted user id;
+// any other error propagates as a defect.
+
 import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
 import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
-import { DomainEventBus } from "@/platform/domain-event-bus.js";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
+import { type UserCreatedTrigger } from "./triggers/user-events.js";
 
-export const handle = (event: UserCreated) =>
+export const handleUserCreated = (trigger: UserCreatedTrigger) =>
   Effect.gen(function* () {
     const repo = yield* WalletRepository;
     const id = WalletId.make(yield* Effect.sync(() => crypto.randomUUID()));
     const now = yield* DateTime.now;
-    const { wallet } = Wallet.create({ id, userId: event.userId, now });
-    yield* repo.insert(wallet);
+    const { wallet } = Wallet.create({ id, userId: trigger.userId, now });
+    yield* repo
+      .insert(wallet)
+      .pipe(Effect.catchTag("WalletAlreadyExistsForUser", () => Effect.void));
   });
-
-// The handler runs synchronously inside the publisher's transaction, so an
-// unexpected failure rolls back the originating user-creation. The
-// `WalletAlreadyExistsForUser` catch is a defensive idempotency net for a
-// case that shouldn't occur given a freshly-minted user id; any other
-// error is a real inconsistency and is allowed to propagate as a defect.
-export const CreateWalletWhenUserIsCreatedLive = Layer.effectDiscard(
-  Effect.gen(function* () {
-    const bus = yield* DomainEventBus;
-    const repo = yield* WalletRepository;
-    yield* bus.subscribe(UserCreated, (event) =>
-      handle(event).pipe(
-        Effect.catchTag("WalletAlreadyExistsForUser", () => Effect.void),
-        Effect.provideService(WalletRepository, repo),
-      ),
-    );
-  }),
-);

--- a/packages/server/src/modules/wallet/event-handlers/triggers/user-events.ts
+++ b/packages/server/src/modules/wallet/event-handlers/triggers/user-events.ts
@@ -1,0 +1,17 @@
+// Wallet-internal trigger types — the shape `wallet` cares about when
+// it reacts to events that originate in `user`. Decouples the
+// wallet's handlers from the user module's event schema: if `user`
+// adds fields to `UserCreated`, the adapter absorbs the change here
+// and the handlers stay stable.
+//
+// Per ADR-0007 + the ACL pattern: cross-module event consumption goes
+// through an adapter that translates the publisher's event into the
+// consumer's trigger type. See ../user-event-adapter.ts.
+
+import { UserId } from "@/platform/ids/user-id.js";
+import * as Schema from "effect/Schema";
+
+export const UserCreatedTrigger = Schema.Struct({
+  userId: UserId,
+});
+export type UserCreatedTrigger = typeof UserCreatedTrigger.Type;

--- a/packages/server/src/modules/wallet/event-handlers/user-event-adapter.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/user-event-adapter.test.ts
@@ -1,0 +1,48 @@
+// Unit test for the user → wallet ACL. Verifies that dispatching
+// UserCreated through the bus reaches the wallet handler with the
+// userId carried through the trigger translation. The handler's
+// repository interactions are covered separately by the
+// integration test for the publisher-bound flow; this test only
+// asserts the adapter glue (subscribe + translate).
+
+import { type UserCreated } from "@/modules/user/index.js";
+import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
+import { UserEventAdapterLive } from "@/modules/wallet/event-handlers/user-event-adapter.js";
+import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
+import { DomainEventBus, makeDomainEventBusLive } from "@/platform/domain-event-bus.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+const TestLayer = UserEventAdapterLive.pipe(
+  Layer.provideMerge(makeDomainEventBusLive()),
+  Layer.provideMerge(WalletRepositoryFake),
+);
+
+describe("UserEventAdapterLive", () => {
+  it.effect("translates UserCreated into the wallet handler's trigger and inserts a wallet", () =>
+    Effect.gen(function* () {
+      const bus = yield* DomainEventBus;
+      const repo = yield* WalletRepository;
+      const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+
+      // Construct the event as a plain tagged record. The bus dispatches
+      // by tag and does not Schema-decode at the boundary, so we don't
+      // need a proper Address class instance for this adapter-glue test.
+      const event = {
+        _tag: "UserCreated" as const,
+        userId,
+        email: "u@example.com",
+        address: { country: "USA", street: "Main", postalCode: "12345" },
+      } as unknown as UserCreated;
+      yield* bus.dispatch([event]);
+
+      const wallet = yield* repo.findByUserId(userId);
+      ok(Option.isSome(wallet));
+      deepStrictEqual(Option.getOrThrow(wallet).userId, userId);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/wallet/event-handlers/user-event-adapter.ts
+++ b/packages/server/src/modules/wallet/event-handlers/user-event-adapter.ts
@@ -1,0 +1,31 @@
+// Anti-corruption layer between `user`'s published events and the
+// wallet module's internal trigger types. The ONLY file in
+// `wallet/event-handlers/` allowed to import from
+// `@/modules/user/index.js` — enforced by the
+// `event-handlers-cross-module-via-adapter-only` dep-cruiser rule.
+//
+// Each subscriber here translates a publisher's event into the
+// wallet-internal shape declared in `./triggers/`, then forwards to a
+// handler that depends only on the trigger type. If `user` adds
+// fields to `UserCreated`, only this file changes — the handlers and
+// trigger types stay stable.
+
+import { UserCreated } from "@/modules/user/index.js";
+import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
+import { DomainEventBus } from "@/platform/domain-event-bus.js";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { handleUserCreated } from "./create-wallet-when-user-is-created.js";
+import { type UserCreatedTrigger } from "./triggers/user-events.js";
+
+const toTrigger = (event: UserCreated): UserCreatedTrigger => ({ userId: event.userId });
+
+export const UserEventAdapterLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const bus = yield* DomainEventBus;
+    const repo = yield* WalletRepository;
+    yield* bus.subscribe(UserCreated, (event) =>
+      handleUserCreated(toTrigger(event)).pipe(Effect.provideService(WalletRepository, repo)),
+    );
+  }),
+);

--- a/packages/server/src/modules/wallet/wallet-module.ts
+++ b/packages/server/src/modules/wallet/wallet-module.ts
@@ -1,9 +1,13 @@
 import * as Layer from "effect/Layer";
-import { CreateWalletWhenUserIsCreatedLive } from "./event-handlers/create-wallet-when-user-is-created.js";
+import { UserEventAdapterLive } from "./event-handlers/user-event-adapter.js";
 import { WalletRepositoryLive } from "./infrastructure/wallet-repository-live.js";
 
-const EventSubscriptionsLive = CreateWalletWhenUserIsCreatedLive.pipe(
-  Layer.provide(WalletRepositoryLive),
-);
+// Cross-module event subscriptions go through the per-publisher
+// adapter in `event-handlers/<publisher>-event-adapter.ts` — the only
+// file allowed to import `@/modules/<publisher>/index.js`. Handlers
+// downstream of the adapter consume wallet-internal trigger types
+// from `event-handlers/triggers/` (see Phase 11 / ADR-0007 ACL
+// pattern).
+const EventSubscriptionsLive = UserEventAdapterLive.pipe(Layer.provide(WalletRepositoryLive));
 
 export const WalletModuleLive = Layer.mergeAll(WalletRepositoryLive, EventSubscriptionsLive);

--- a/packages/web/features/index/todo-item/todo-item.presenter.test.tsx
+++ b/packages/web/features/index/todo-item/todo-item.presenter.test.tsx
@@ -1,0 +1,128 @@
+import { makePresenterHarness } from "@/test/presenter-harness";
+import { TodosContract } from "@org/contracts/api/Contracts";
+import { TodoId } from "@org/contracts/EntityIds";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { afterEach, describe, expect, it } from "vitest";
+import { useTodoItemPresenter } from "./todo-item.presenter";
+
+class TodoNotFoundError extends Data.TaggedError("TodoNotFoundError")<{
+  readonly todoId: string;
+  readonly message: string;
+}> {}
+
+const mkTodo = (overrides: Partial<TodosContract.Todo> = {}) =>
+  new TodosContract.Todo({
+    id: TodoId.make("11111111-1111-1111-1111-111111111111"),
+    title: "Buy milk",
+    completed: false,
+    ...overrides,
+  });
+
+type UpdateCalls = ReadonlyArray<TodosContract.Todo>;
+type DeleteCalls = ReadonlyArray<TodoId>;
+
+const makeApiClient = (opts?: {
+  readonly update?: (payload: TodosContract.Todo) => Effect.Effect<TodosContract.Todo>;
+  readonly delete?: (id: TodoId) => Effect.Effect<void, TodoNotFoundError>;
+  readonly updateCalls?: { current: UpdateCalls };
+  readonly deleteCalls?: { current: DeleteCalls };
+}) => ({
+  todos: {
+    get: () => Effect.succeed([] as ReadonlyArray<TodosContract.Todo>),
+    create: () => Effect.die("not used"),
+    update: (args: { payload: TodosContract.Todo }) => {
+      if (opts?.updateCalls !== undefined) {
+        opts.updateCalls.current = [...opts.updateCalls.current, args.payload];
+      }
+      return opts?.update?.(args.payload) ?? Effect.succeed(args.payload);
+    },
+    delete: (args: { payload: TodoId }) => {
+      if (opts?.deleteCalls !== undefined) {
+        opts.deleteCalls.current = [...opts.deleteCalls.current, args.payload];
+      }
+      return opts?.delete?.(args.payload) ?? Effect.void;
+    },
+  },
+});
+
+let harness: ReturnType<typeof makePresenterHarness>;
+
+afterEach(async () => {
+  await harness.dispose();
+});
+
+describe("useTodoItemPresenter — toggleCompleted", () => {
+  it("dispatches an update with completed flipped from false → true", async () => {
+    const updateCalls: { current: UpdateCalls } = { current: [] };
+    harness = makePresenterHarness({ apiClient: makeApiClient({ updateCalls }) });
+    const todo = mkTodo({ completed: false });
+
+    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+
+    act(() => {
+      result.current.toggleCompleted();
+    });
+
+    await waitFor(() => {
+      expect(updateCalls.current).toHaveLength(1);
+    });
+    expect(updateCalls.current[0]?.completed).toBe(true);
+  });
+
+  it("dispatches an update with completed flipped from true → false", async () => {
+    const updateCalls: { current: UpdateCalls } = { current: [] };
+    harness = makePresenterHarness({ apiClient: makeApiClient({ updateCalls }) });
+    const todo = mkTodo({ completed: true });
+
+    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+
+    act(() => {
+      result.current.toggleCompleted();
+    });
+
+    await waitFor(() => {
+      expect(updateCalls.current).toHaveLength(1);
+    });
+    expect(updateCalls.current[0]?.completed).toBe(false);
+  });
+});
+
+describe("useTodoItemPresenter — deleteThis", () => {
+  it("dispatches a delete keyed by the todo id", async () => {
+    const deleteCalls: { current: DeleteCalls } = { current: [] };
+    harness = makePresenterHarness({ apiClient: makeApiClient({ deleteCalls }) });
+    const todo = mkTodo();
+
+    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+
+    act(() => {
+      result.current.deleteThis();
+    });
+
+    await waitFor(() => {
+      expect(deleteCalls.current).toEqual([todo.id]);
+    });
+  });
+
+  it("surfaces a tagged delete failure via toast", async () => {
+    harness = makePresenterHarness({
+      apiClient: makeApiClient({
+        delete: (id) => Effect.fail(new TodoNotFoundError({ todoId: id, message: "not found" })),
+      }),
+    });
+    const todo = mkTodo();
+
+    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+
+    act(() => {
+      result.current.deleteThis();
+    });
+
+    await waitFor(async () => {
+      const toasts = await harness.getToasts();
+      expect(toasts).toContainEqual({ kind: "error", message: "not found" });
+    });
+  });
+});

--- a/packages/web/features/index/todo-item/todo-item.presenter.ts
+++ b/packages/web/features/index/todo-item/todo-item.presenter.ts
@@ -1,0 +1,35 @@
+"use client";
+
+// Presenter for TodoItem (ADR-0014 Tier 2). Owns the
+// useUpdateTodoMutation / useDeleteTodoMutation calls and the
+// derived toggle/delete actions. View is pure JSX over the returned
+// shape; behavior (mutation dispatch, optimistic flags, invalidation)
+// is testable via the presenter without rendering JSX.
+
+import {
+  useDeleteTodoMutation,
+  useUpdateTodoMutation,
+} from "@/services/data-access/use-todos-queries";
+import type { TodosContract } from "@org/contracts/api/Contracts";
+import * as React from "react";
+
+export const useTodoItemPresenter = (todo: TodosContract.Todo) => {
+  const updateTodo = useUpdateTodoMutation();
+  const deleteTodo = useDeleteTodoMutation();
+
+  const toggleCompleted = React.useCallback(() => {
+    updateTodo.mutate({ ...todo, completed: !todo.completed });
+  }, [updateTodo, todo]);
+
+  const deleteThis = React.useCallback(() => {
+    deleteTodo.mutate(todo.id);
+  }, [deleteTodo, todo.id]);
+
+  return {
+    todo,
+    toggleCompleted,
+    deleteThis,
+    isUpdating: updateTodo.isPending,
+    isDeleting: deleteTodo.isPending,
+  };
+};

--- a/packages/web/features/index/todo-item/todo-item.tsx
+++ b/packages/web/features/index/todo-item/todo-item.tsx
@@ -1,18 +1,14 @@
 "use client";
 
-import {
-  useDeleteTodoMutation,
-  useUpdateTodoMutation,
-} from "@/services/data-access/use-todos-queries";
 import { Button } from "@org/components/primitives/button";
 import { Checkbox } from "@org/components/primitives/checkbox";
 import { TrashIcon } from "@org/components/primitives/icon";
 import { Label } from "@org/components/primitives/label";
 import type { TodosContract } from "@org/contracts/api/Contracts";
+import { useTodoItemPresenter } from "./todo-item.presenter";
 
 export const TodoItem: React.FC<{ todo: TodosContract.Todo }> = ({ todo }) => {
-  const updateTodo = useUpdateTodoMutation();
-  const deleteTodo = useDeleteTodoMutation();
+  const { deleteThis, toggleCompleted } = useTodoItemPresenter(todo);
 
   return (
     <li
@@ -25,12 +21,7 @@ export const TodoItem: React.FC<{ todo: TodosContract.Todo }> = ({ todo }) => {
         <Checkbox
           id={`todo-${todo.id}`}
           checked={todo.completed}
-          onCheckedChange={() => {
-            updateTodo.mutate({
-              ...todo,
-              completed: !todo.completed,
-            });
-          }}
+          onCheckedChange={toggleCompleted}
         />
 
         <Label
@@ -48,9 +39,7 @@ export const TodoItem: React.FC<{ todo: TodosContract.Todo }> = ({ todo }) => {
         variant="ghost"
         size="icon"
         className="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
-        onClick={() => {
-          deleteTodo.mutate(todo.id);
-        }}
+        onClick={deleteThis}
       >
         <TrashIcon tone="destructive" />
         <span className="sr-only">Delete</span>

--- a/packages/web/features/index/todo-list.presenter.test.tsx
+++ b/packages/web/features/index/todo-list.presenter.test.tsx
@@ -1,0 +1,51 @@
+import { makePresenterHarness } from "@/test/presenter-harness";
+import { TodosContract } from "@org/contracts/api/Contracts";
+import { TodoId } from "@org/contracts/EntityIds";
+import { renderHook, waitFor } from "@testing-library/react";
+import * as Effect from "effect/Effect";
+import { afterEach, describe, expect, it } from "vitest";
+import { useTodoListPresenter } from "./todo-list.presenter";
+
+const mkTodo = (i: number): TodosContract.Todo =>
+  new TodosContract.Todo({
+    id: TodoId.make(`11111111-1111-1111-1111-${i.toString().padStart(12, "0")}`),
+    title: `todo ${i}`,
+    completed: false,
+  });
+
+const makeApiClient = (todos: ReadonlyArray<TodosContract.Todo>) => ({
+  todos: {
+    get: () => Effect.succeed(todos),
+    create: () => Effect.die("not used"),
+    update: () => Effect.die("not used"),
+    delete: () => Effect.die("not used"),
+  },
+});
+
+let harness: ReturnType<typeof makePresenterHarness>;
+
+afterEach(async () => {
+  await harness.dispose();
+});
+
+describe("useTodoListPresenter", () => {
+  it("reports isEmpty=true when no todos are returned", async () => {
+    harness = makePresenterHarness({ apiClient: makeApiClient([]) });
+    const { result } = renderHook(() => useTodoListPresenter(), { wrapper: harness.wrapper });
+    await waitFor(() => {
+      expect(result.current.todos).toEqual([]);
+    });
+    expect(result.current.isEmpty).toBe(true);
+  });
+
+  it("exposes the loaded todos and isEmpty=false when populated", async () => {
+    const todos = [mkTodo(1), mkTodo(2)];
+    harness = makePresenterHarness({ apiClient: makeApiClient(todos) });
+    const { result } = renderHook(() => useTodoListPresenter(), { wrapper: harness.wrapper });
+    await waitFor(() => {
+      expect(result.current.todos.length).toBe(2);
+    });
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.todos).toEqual(todos);
+  });
+});

--- a/packages/web/features/index/todo-list.presenter.ts
+++ b/packages/web/features/index/todo-list.presenter.ts
@@ -1,0 +1,11 @@
+"use client";
+
+// Presenter for TodoList (ADR-0014 Tier 2). Owns the suspense-query
+// call and the empty-vs-populated split so the view file is pure JSX.
+
+import { useTodosSuspenseQuery } from "@/services/data-access/use-todos-queries";
+
+export const useTodoListPresenter = () => {
+  const { data: todos } = useTodosSuspenseQuery();
+  return { todos, isEmpty: todos.length === 0 };
+};

--- a/packages/web/features/index/todo-list.tsx
+++ b/packages/web/features/index/todo-list.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useTodosSuspenseQuery } from "@/services/data-access/use-todos-queries";
 import * as Array from "effect/Array";
 import { TodoItem } from "./todo-item/todo-item";
+import { useTodoListPresenter } from "./todo-list.presenter";
 
 export const TodoList: React.FC = () => {
-  const { data: todos } = useTodosSuspenseQuery();
+  const { isEmpty, todos } = useTodoListPresenter();
 
-  if (todos.length === 0) {
+  if (isEmpty) {
     return (
       <div className="rounded-lg bg-muted/50 py-8 text-center">
         <p className="text-sm text-muted-foreground">No tasks yet. Add one above!</p>

--- a/packages/web/features/users/user-list.presenter.test.tsx
+++ b/packages/web/features/users/user-list.presenter.test.tsx
@@ -1,0 +1,179 @@
+import { makePresenterHarness } from "@/test/presenter-harness";
+import { UserContract } from "@org/contracts/api/Contracts";
+import { UserId } from "@org/contracts/EntityIds";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useUserListPresenter } from "./user-list.presenter";
+
+const mkUser = (i: number): UserContract.User =>
+  new UserContract.User({
+    id: UserId.make(`11111111-1111-1111-1111-${i.toString().padStart(12, "0")}`),
+    email: `u${i}@example.com`,
+    role: "guest",
+    address: { country: "USA", street: "Main", postalCode: "12345" },
+    createdAt: DateTime.unsafeFromDate(new Date("2026-01-01T00:00:00Z")),
+    updatedAt: DateTime.unsafeFromDate(new Date("2026-01-01T00:00:00Z")),
+  });
+
+const makeApiClient = (opts: {
+  readonly find?: (urlParams: {
+    page: number;
+    pageSize: number;
+  }) => Effect.Effect<UserContract.PaginatedUsers>;
+}) => ({
+  user: {
+    find: (args: { urlParams: { page: number; pageSize: number } }) =>
+      opts.find?.(args.urlParams) ??
+      Effect.succeed(
+        new UserContract.PaginatedUsers({
+          users: [],
+          page: args.urlParams.page,
+          pageSize: args.urlParams.pageSize,
+          total: 0,
+        }),
+      ),
+    create: () => Effect.die("not used"),
+  },
+});
+
+let harness: ReturnType<typeof makePresenterHarness>;
+
+beforeEach(() => {
+  harness = makePresenterHarness({ apiClient: makeApiClient({}) });
+});
+
+afterEach(async () => {
+  await harness.dispose();
+});
+
+describe("useUserListPresenter — empty state", () => {
+  it("reports isEmpty=true, totalPages=1, and disables both nav directions when there are no users", async () => {
+    const { result } = renderHook(() => useUserListPresenter(), { wrapper: harness.wrapper });
+    await waitFor(() => {
+      expect(result.current.users).toEqual([]);
+    });
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.total).toBe(0);
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.hasPrev).toBe(false);
+    expect(result.current.hasNext).toBe(false);
+  });
+});
+
+describe("useUserListPresenter — pagination", () => {
+  it("populates users, total, and computes totalPages from total and pageSize", async () => {
+    const users = [mkUser(1), mkUser(2), mkUser(3)];
+    harness = makePresenterHarness({
+      apiClient: makeApiClient({
+        find: (vars) =>
+          Effect.succeed(
+            new UserContract.PaginatedUsers({
+              users,
+              page: vars.page,
+              pageSize: vars.pageSize,
+              total: 25,
+            }),
+          ),
+      }),
+    });
+
+    const { result } = renderHook(() => useUserListPresenter({ pageSize: 10 }), {
+      wrapper: harness.wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.users).toEqual(users);
+    });
+    expect(result.current.total).toBe(25);
+    expect(result.current.totalPages).toBe(3);
+    expect(result.current.page).toBe(1);
+    expect(result.current.hasPrev).toBe(false);
+    expect(result.current.hasNext).toBe(true);
+  });
+
+  it("goNext advances the page and triggers a new fetch keyed on the new page", async () => {
+    const seenPages: Array<number> = [];
+    harness = makePresenterHarness({
+      apiClient: makeApiClient({
+        find: (vars) => {
+          seenPages.push(vars.page);
+          return Effect.succeed(
+            new UserContract.PaginatedUsers({
+              users: [mkUser(vars.page)],
+              page: vars.page,
+              pageSize: vars.pageSize,
+              total: 25,
+            }),
+          );
+        },
+      }),
+    });
+
+    const { result } = renderHook(() => useUserListPresenter({ pageSize: 10 }), {
+      wrapper: harness.wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.page).toBe(1);
+    });
+    act(() => {
+      result.current.goNext();
+    });
+
+    await waitFor(() => {
+      expect(result.current.page).toBe(2);
+    });
+    // The new page triggered a refetch keyed on page=2.
+    expect(seenPages).toContain(2);
+  });
+
+  it("clamps goNext at totalPages and disables hasNext at the last page", async () => {
+    harness = makePresenterHarness({
+      apiClient: makeApiClient({
+        find: (vars) =>
+          Effect.succeed(
+            new UserContract.PaginatedUsers({
+              users: [mkUser(1)],
+              page: vars.page,
+              pageSize: vars.pageSize,
+              total: 15,
+            }),
+          ),
+      }),
+    });
+
+    const { result } = renderHook(() => useUserListPresenter({ pageSize: 10 }), {
+      wrapper: harness.wrapper,
+    });
+    await waitFor(() => {
+      expect(result.current.totalPages).toBe(2);
+    });
+
+    act(() => {
+      result.current.goNext();
+    });
+    await waitFor(() => {
+      expect(result.current.page).toBe(2);
+    });
+    expect(result.current.hasNext).toBe(false);
+
+    act(() => {
+      result.current.goNext();
+    });
+    // Already at the last page — page stays at totalPages.
+    expect(result.current.page).toBe(2);
+  });
+
+  it("clamps goPrev at page 1", async () => {
+    const { result } = renderHook(() => useUserListPresenter(), { wrapper: harness.wrapper });
+    await waitFor(() => {
+      expect(result.current.page).toBe(1);
+    });
+    act(() => {
+      result.current.goPrev();
+    });
+    expect(result.current.page).toBe(1);
+  });
+});

--- a/packages/web/features/users/user-list.presenter.ts
+++ b/packages/web/features/users/user-list.presenter.ts
@@ -1,0 +1,46 @@
+"use client";
+
+// Presenter for UserList (ADR-0014 Tier 2). Owns pagination state and
+// the suspense-query call so the view file is pure JSX over the
+// returned shape. Page changes drive new fetches via the queryKey
+// (page is part of the variables).
+
+import { useUsersSuspenseQuery } from "@/services/data-access/use-users-queries";
+import * as React from "react";
+
+const DEFAULT_PAGE_SIZE = 10;
+
+export const useUserListPresenter = (opts?: { readonly pageSize?: number }) => {
+  const pageSize = opts?.pageSize ?? DEFAULT_PAGE_SIZE;
+  const [page, setPage] = React.useState(1);
+
+  const usersQuery = useUsersSuspenseQuery({ page, pageSize });
+
+  const total = usersQuery.data.total;
+  const users = usersQuery.data.users;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const isEmpty = users.length === 0;
+  const hasPrev = page > 1;
+  const hasNext = page < totalPages;
+
+  const goPrev = React.useCallback(() => {
+    setPage((p) => Math.max(1, p - 1));
+  }, []);
+
+  const goNext = React.useCallback(() => {
+    setPage((p) => Math.min(totalPages, p + 1));
+  }, [totalPages]);
+
+  return {
+    users,
+    total,
+    page,
+    pageSize,
+    totalPages,
+    isEmpty,
+    hasPrev,
+    hasNext,
+    goPrev,
+    goNext,
+  };
+};

--- a/packages/web/features/users/user-list.presenter.ts
+++ b/packages/web/features/users/user-list.presenter.ts
@@ -1,12 +1,13 @@
 "use client";
 
-// Presenter for UserList (ADR-0014 Tier 2). Owns pagination state and
-// the suspense-query call so the view file is pure JSX over the
-// returned shape. Page changes drive new fetches via the queryKey
-// (page is part of the variables).
+// Presenter for UserList (ADR-0014 Tier 2). Owns React state and
+// the suspense-query call; defers all pagination math to the
+// `user-list.view-model.ts` Tier-3 module. Page changes drive new
+// fetches via the queryKey (page is part of the variables).
 
 import { useUsersSuspenseQuery } from "@/services/data-access/use-users-queries";
 import * as React from "react";
+import { computePaginationView } from "./user-list.view-model";
 
 const DEFAULT_PAGE_SIZE = 10;
 
@@ -15,31 +16,32 @@ export const useUserListPresenter = (opts?: { readonly pageSize?: number }) => {
   const [page, setPage] = React.useState(1);
 
   const usersQuery = useUsersSuspenseQuery({ page, pageSize });
-
-  const total = usersQuery.data.total;
   const users = usersQuery.data.users;
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const isEmpty = users.length === 0;
-  const hasPrev = page > 1;
-  const hasNext = page < totalPages;
+
+  const view = computePaginationView({
+    currentPage: page,
+    pageSize,
+    total: usersQuery.data.total,
+  });
 
   const goPrev = React.useCallback(() => {
     setPage((p) => Math.max(1, p - 1));
   }, []);
 
   const goNext = React.useCallback(() => {
-    setPage((p) => Math.min(totalPages, p + 1));
-  }, [totalPages]);
+    setPage((p) => Math.min(view.totalPages, p + 1));
+  }, [view.totalPages]);
 
   return {
     users,
-    total,
-    page,
-    pageSize,
-    totalPages,
-    isEmpty,
-    hasPrev,
-    hasNext,
+    total: view.total,
+    page: view.page,
+    pageSize: view.pageSize,
+    totalPages: view.totalPages,
+    isEmpty: view.isEmpty,
+    hasPrev: view.hasPrev,
+    hasNext: view.hasNext,
+    displayedRange: view.displayedRange,
     goPrev,
     goNext,
   };

--- a/packages/web/features/users/user-list.tsx
+++ b/packages/web/features/users/user-list.tsx
@@ -5,27 +5,21 @@
 // fallback supplied by the parent `<Suspense>` in the page. Pagination
 // state stays client-side per ADR-0018.
 
-import { useUsersSuspenseQuery } from "@/services/data-access/use-users-queries";
 import { Badge } from "@org/components/primitives/badge";
 import { Button } from "@org/components/primitives/button";
 import { ChevronLeftIcon, ChevronRightIcon } from "@org/components/primitives/icon";
 import * as Array from "effect/Array";
 import * as React from "react";
-
-const PAGE_SIZE = 10;
+import { useUserListPresenter } from "./user-list.presenter";
 
 export const UserList: React.FC = () => {
-  const [page, setPage] = React.useState(1);
-  const usersQuery = useUsersSuspenseQuery({ page, pageSize: PAGE_SIZE });
-
-  const total = usersQuery.data.total;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const users = usersQuery.data.users;
+  const { goNext, goPrev, hasNext, hasPrev, isEmpty, page, total, totalPages, users } =
+    useUserListPresenter();
 
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        {users.length === 0 ? (
+        {isEmpty ? (
           <div className="rounded-lg bg-muted/50 py-8 text-center">
             <p className="text-sm text-muted-foreground">No users yet.</p>
           </div>
@@ -64,27 +58,11 @@ export const UserList: React.FC = () => {
         </p>
 
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            disabled={page <= 1}
-            onClick={() => {
-              setPage((p) => Math.max(1, p - 1));
-            }}
-          >
+          <Button type="button" variant="outline" size="icon" disabled={!hasPrev} onClick={goPrev}>
             <ChevronLeftIcon />
             <span className="sr-only">Previous page</span>
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            disabled={page >= totalPages}
-            onClick={() => {
-              setPage((p) => Math.min(totalPages, p + 1));
-            }}
-          >
+          <Button type="button" variant="outline" size="icon" disabled={!hasNext} onClick={goNext}>
             <ChevronRightIcon />
             <span className="sr-only">Next page</span>
           </Button>

--- a/packages/web/features/users/user-list.view-model.test.ts
+++ b/packages/web/features/users/user-list.view-model.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { computePaginationView } from "./user-list.view-model";
+
+describe("computePaginationView — empty set", () => {
+  it("returns isEmpty=true, totalPages=1, no nav, range 0..0", () => {
+    const v = computePaginationView({ currentPage: 1, pageSize: 10, total: 0 });
+    expect(v.isEmpty).toBe(true);
+    expect(v.totalPages).toBe(1);
+    expect(v.hasPrev).toBe(false);
+    expect(v.hasNext).toBe(false);
+    expect(v.displayedRange).toEqual({ from: 0, to: 0 });
+  });
+});
+
+describe("computePaginationView — totals and range", () => {
+  it("computes totalPages by ceiling division and 1-indexed inclusive range", () => {
+    const v = computePaginationView({ currentPage: 1, pageSize: 10, total: 25 });
+    expect(v.totalPages).toBe(3);
+    expect(v.displayedRange).toEqual({ from: 1, to: 10 });
+    expect(v.hasPrev).toBe(false);
+    expect(v.hasNext).toBe(true);
+  });
+
+  it("clamps the displayed range's upper bound to total on the last page", () => {
+    const v = computePaginationView({ currentPage: 3, pageSize: 10, total: 25 });
+    expect(v.displayedRange).toEqual({ from: 21, to: 25 });
+    expect(v.hasNext).toBe(false);
+  });
+});
+
+describe("computePaginationView — defensive clamping", () => {
+  it("clamps currentPage below 1 up to 1", () => {
+    const v = computePaginationView({ currentPage: 0, pageSize: 10, total: 25 });
+    expect(v.page).toBe(1);
+  });
+
+  it("clamps currentPage above totalPages down to totalPages", () => {
+    const v = computePaginationView({ currentPage: 99, pageSize: 10, total: 25 });
+    expect(v.page).toBe(3);
+  });
+
+  it("treats pageSize <= 0 as 1 to avoid divide-by-zero", () => {
+    const v = computePaginationView({ currentPage: 1, pageSize: 0, total: 5 });
+    expect(v.pageSize).toBe(1);
+    expect(v.totalPages).toBe(5);
+  });
+
+  it("treats negative total as 0 (empty)", () => {
+    const v = computePaginationView({ currentPage: 1, pageSize: 10, total: -3 });
+    expect(v.isEmpty).toBe(true);
+    expect(v.total).toBe(0);
+  });
+});

--- a/packages/web/features/users/user-list.view-model.ts
+++ b/packages/web/features/users/user-list.view-model.ts
@@ -1,0 +1,53 @@
+// View-model for UserList pagination (ADR-0014 Tier 3).
+//
+// Pure data → data: takes the current page, page size, and total
+// number of users; returns the derived display values used by the
+// presenter. No React, no Effect runtime, no QueryClient — just
+// math. Lives below the presenter so the math is testable without a
+// renderer and reusable by any future surface (e.g. a CLI export
+// pager, a story).
+
+export type Pagination = {
+  readonly currentPage: number;
+  readonly pageSize: number;
+  readonly total: number;
+};
+
+export type PaginationView = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly total: number;
+  readonly totalPages: number;
+  readonly hasPrev: boolean;
+  readonly hasNext: boolean;
+  readonly isEmpty: boolean;
+  readonly displayedRange: { readonly from: number; readonly to: number };
+};
+
+export const computePaginationView = (input: Pagination): PaginationView => {
+  // Defensive against bad inputs even though presenter callers
+  // never pass zero/negative values today. Total can be 0 if the
+  // server returns an empty set; treat totalPages as 1 in that
+  // case so the UI shows "Page 1 of 1" rather than "Page 1 of 0".
+  const safePageSize = Math.max(1, input.pageSize);
+  const safeTotal = Math.max(0, input.total);
+  const totalPages = Math.max(1, Math.ceil(safeTotal / safePageSize));
+  const page = Math.min(Math.max(1, input.currentPage), totalPages);
+  const isEmpty = safeTotal === 0;
+
+  // 1-indexed inclusive range, clamped to the actual total.
+  // Empty set: from === to === 0, signalling "no range".
+  const from = isEmpty ? 0 : (page - 1) * safePageSize + 1;
+  const to = isEmpty ? 0 : Math.min(page * safePageSize, safeTotal);
+
+  return {
+    page,
+    pageSize: safePageSize,
+    total: safeTotal,
+    totalPages,
+    hasPrev: page > 1,
+    hasNext: page < totalPages,
+    isEmpty,
+    displayedRange: { from, to },
+  };
+};

--- a/packages/web/lib/tanstack-query/effect-prefetch.server.test.ts
+++ b/packages/web/lib/tanstack-query/effect-prefetch.server.test.ts
@@ -1,0 +1,85 @@
+// Tests for `prefetchEffectQuery`. The interesting behavior is the
+// JSON round-trip that strips `Schema.Class` prototypes before the
+// dehydrated cache crosses the RSC/CC boundary, plus the contract with
+// TanStack's `prefetchQuery` (which swallows errors by design).
+//
+// `server-only` and the per-request server modules are mocked because
+// jsdom is not an RSC context; the production wiring lives in
+// `getServerRuntime` / `getQueryClient` and is not what we're exercising here.
+
+import { QueryClient as TanstackQueryClient } from "@tanstack/react-query";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prefetchEffectQuery } from "./effect-prefetch.server";
+
+vi.mock("server-only", () => ({}));
+
+const sharedQueryClient = new TanstackQueryClient({
+  defaultOptions: {
+    queries: { retry: false, gcTime: 0 },
+    mutations: { retry: false },
+  },
+});
+
+vi.mock("@/lib/query-client.server", () => ({
+  getQueryClient: () => sharedQueryClient,
+}));
+
+vi.mock("@/services/runtime.server", () => ({
+  getServerRuntime: async () => ({
+    runPromise: <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect),
+  }),
+}));
+
+class TodoLike extends Schema.Class<TodoLike>("TodoLike")({
+  id: Schema.String,
+  title: Schema.String,
+}) {}
+
+beforeEach(() => {
+  sharedQueryClient.clear();
+});
+
+describe("prefetchEffectQuery", () => {
+  it("populates the cache with a plain object — Schema.Class prototype is stripped", async () => {
+    const key = ["todo-prefetch", "plain-object"] as const;
+    const instance = new TodoLike({ id: "1", title: "Buy milk" });
+    expect(instance).toBeInstanceOf(TodoLike);
+
+    await prefetchEffectQuery({
+      queryKey: key,
+      queryFn: Effect.succeed(instance),
+    });
+
+    const cached = sharedQueryClient.getQueryData<TodoLike>(key);
+    expect(cached).toBeDefined();
+    // Same enumerable shape ...
+    expect(cached).toEqual({ id: "1", title: "Buy milk" });
+    // ... but no class marker — round-trip stripped the prototype.
+    expect(cached).not.toBeInstanceOf(TodoLike);
+    expect(Object.getPrototypeOf(cached)).toBe(Object.prototype);
+  });
+
+  it("leaves the cache empty when the underlying effect fails (prefetchQuery swallows errors)", async () => {
+    const key = ["todo-prefetch", "failed"] as const;
+
+    await prefetchEffectQuery({
+      queryKey: key,
+      queryFn: Effect.fail(new Error("boom")),
+    });
+
+    expect(sharedQueryClient.getQueryData(key)).toBeUndefined();
+  });
+
+  it("leaves the cache empty when the effect defects", async () => {
+    const key = ["todo-prefetch", "died"] as const;
+
+    await prefetchEffectQuery({
+      queryKey: key,
+      queryFn: Effect.die("kaboom"),
+    });
+
+    expect(sharedQueryClient.getQueryData(key)).toBeUndefined();
+  });
+});

--- a/packages/web/lib/tanstack-query/make-form-options.test.ts
+++ b/packages/web/lib/tanstack-query/make-form-options.test.ts
@@ -1,0 +1,116 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vitest";
+import { makeFormOptions, validateWithSchema } from "./make-form-options";
+
+const EmailField = Schema.Struct({
+  email: Schema.NonEmptyString,
+});
+
+const AddressField = Schema.Struct({
+  address: Schema.Struct({
+    country: Schema.NonEmptyString,
+  }),
+});
+
+const RefinedPositive = Schema.Struct({
+  count: Schema.Number,
+}).pipe(
+  Schema.filter((s) => (s.count > 0 ? undefined : "count must be positive"), {
+    identifier: "PositiveCount",
+  }),
+);
+
+const MultiField = Schema.Struct({
+  email: Schema.NonEmptyString,
+  country: Schema.NonEmptyString,
+});
+
+describe("validateWithSchema", () => {
+  it("returns null when input is valid", () => {
+    const validate = validateWithSchema(EmailField);
+    expect(validate({ value: { email: "a@b.com" } })).toBeNull();
+  });
+
+  it("flattens a single field error to its dot-path key", () => {
+    const validate = validateWithSchema(EmailField);
+    const result = validate({ value: { email: "" } });
+    expect(result).not.toBeNull();
+    expect(result?.email).toBeDefined();
+  });
+
+  it("dot-joins nested paths", () => {
+    const validate = validateWithSchema(AddressField);
+    const result = validate({ value: { address: { country: "" } } }) as Record<
+      string,
+      string | undefined
+    > | null;
+    expect(result).not.toBeNull();
+    expect(result?.["address.country"]).toBeDefined();
+  });
+
+  it("reports every field error when errors: 'all' is used (default)", () => {
+    const validate = validateWithSchema(MultiField);
+    const result = validate({ value: { email: "", country: "" } });
+    expect(result).not.toBeNull();
+    expect(result?.email).toBeDefined();
+    expect(result?.country).toBeDefined();
+  });
+
+  it("keys root-level (path length 0) errors under '' (RootErrorKey)", () => {
+    const validate = validateWithSchema(RefinedPositive);
+    const result = validate({ value: { count: -1 } }) as Record<string, string | undefined> | null;
+    expect(result).not.toBeNull();
+    expect(result?.[""]).toBeDefined();
+  });
+
+  it("honors onExcessProperty: 'ignore' — extra props don't surface as errors", () => {
+    const validate = validateWithSchema(EmailField);
+    const result = validate({
+      value: { email: "a@b.com", extra: "ignored" } as unknown as { email: string },
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("makeFormOptions", () => {
+  it("wires validators.onSubmit when validator: 'onSubmit'", () => {
+    const opts = makeFormOptions({
+      schema: EmailField,
+      defaultValues: { email: "" },
+      validator: "onSubmit",
+    });
+    expect(opts.validators?.onSubmit).toBeDefined();
+    expect(opts.validators?.onChange).toBeUndefined();
+    expect(opts.validators?.onBlur).toBeUndefined();
+  });
+
+  it("wires validators.onChange when validator: 'onChange'", () => {
+    const opts = makeFormOptions({
+      schema: EmailField,
+      defaultValues: { email: "" },
+      validator: "onChange",
+    });
+    expect(opts.validators?.onChange).toBeDefined();
+    expect(opts.validators?.onSubmit).toBeUndefined();
+  });
+
+  it("wires validators.onBlur when validator: 'onBlur'", () => {
+    const opts = makeFormOptions({
+      schema: EmailField,
+      defaultValues: { email: "" },
+      validator: "onBlur",
+    });
+    expect(opts.validators?.onBlur).toBeDefined();
+    expect(opts.validators?.onSubmit).toBeUndefined();
+  });
+
+  it("returns defaultValues unchanged", () => {
+    const defaults = { email: "preset@example.com" };
+    const opts = makeFormOptions({
+      schema: EmailField,
+      defaultValues: defaults,
+      validator: "onSubmit",
+    });
+    expect(opts.defaultValues).toEqual(defaults);
+  });
+});

--- a/packages/web/lib/tanstack-query/query-data-helpers.test.ts
+++ b/packages/web/lib/tanstack-query/query-data-helpers.test.ts
@@ -1,0 +1,180 @@
+import { QueryClient } from "@/services/common/query-client";
+import { QueryClient as TanstackQueryClient } from "@tanstack/react-query";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { describe, expect, it } from "vitest";
+import { makeHelpers, makeQueryKey } from "./query-data-helpers";
+
+type User = { readonly id: string; readonly name: string };
+
+const makeClient = () =>
+  new TanstackQueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+const runWithClient = <A, E>(
+  client: TanstackQueryClient,
+  effect: Effect.Effect<A, E, QueryClient>,
+) => Effect.runPromise(Effect.provide(effect, QueryClient.make(client)));
+
+const runExitWithClient = <A, E>(
+  client: TanstackQueryClient,
+  effect: Effect.Effect<A, E, QueryClient>,
+) => Effect.runPromiseExit(Effect.provide(effect, QueryClient.make(client)));
+
+describe("makeQueryKey", () => {
+  it("returns [key] for the void variant", () => {
+    const userKey = makeQueryKey("user");
+    expect(userKey()).toEqual(["user"]);
+  });
+
+  it("returns [key, variables] for the variable variant", () => {
+    type Vars = { readonly id: string };
+    const userKey = makeQueryKey<"user", Vars>("user");
+    expect(userKey({ id: "123" })).toEqual(["user", { id: "123" }]);
+  });
+});
+
+describe("makeHelpers.setData", () => {
+  it("variable variant applies the mutative updater to the cached entry", async () => {
+    const client = makeClient();
+    type Vars = { readonly id: string };
+    const userKey = makeQueryKey<"user", Vars>("user");
+    const helpers = makeHelpers<User, Vars>(userKey);
+
+    client.setQueryData(userKey({ id: "1" }), { id: "1", name: "Alice" });
+
+    await runWithClient(
+      client,
+      helpers.setData({ id: "1" }, (draft) => {
+        draft.name = "Bob";
+      }),
+    );
+
+    expect(client.getQueryData(userKey({ id: "1" }))).toEqual({ id: "1", name: "Bob" });
+  });
+
+  it("void variant does not take variables and updates the single keyed entry", async () => {
+    const client = makeClient();
+    const settingsKey = makeQueryKey("settings");
+    type Settings = { readonly theme: string };
+    const helpers = makeHelpers<Settings>(settingsKey);
+
+    client.setQueryData(settingsKey(), { theme: "light" });
+
+    await runWithClient(
+      client,
+      helpers.setData((draft) => {
+        draft.theme = "dark";
+      }),
+    );
+
+    expect(client.getQueryData(settingsKey())).toEqual({ theme: "dark" });
+  });
+
+  it("an updater's explicit return replaces the cached value", async () => {
+    const client = makeClient();
+    const settingsKey = makeQueryKey("settings");
+    type Settings = { readonly theme: string };
+    const helpers = makeHelpers<Settings>(settingsKey);
+
+    client.setQueryData(settingsKey(), { theme: "light" });
+
+    await runWithClient(
+      client,
+      helpers.setData(() => ({ theme: "explicit-return" })),
+    );
+
+    expect(client.getQueryData(settingsKey())).toEqual({ theme: "explicit-return" });
+  });
+
+  it("setData on a missing key is a no-op (does not create an entry)", async () => {
+    const client = makeClient();
+    const settingsKey = makeQueryKey("settings");
+    type Settings = { readonly theme: string };
+    const helpers = makeHelpers<Settings>(settingsKey);
+
+    await runWithClient(
+      client,
+      helpers.setData((draft) => {
+        draft.theme = "dark";
+      }),
+    );
+
+    // setData early-returns oldData (which is undefined) when no entry
+    // exists; we should not create a new entry as a side effect.
+    expect(client.getQueryData(settingsKey())).toBeUndefined();
+  });
+});
+
+describe("makeHelpers.invalidateAllQueries / removeAllQueries", () => {
+  it("invalidateAllQueries uses exact: false and the namespace key — affects all variants", async () => {
+    const client = makeClient();
+    type Vars = { readonly id: string };
+    const userKey = makeQueryKey<"user", Vars>("user");
+    const helpers = makeHelpers<User, Vars>(userKey);
+
+    client.setQueryData(userKey({ id: "1" }), { id: "1", name: "Alice" });
+    client.setQueryData(userKey({ id: "2" }), { id: "2", name: "Bob" });
+
+    await runWithClient(client, helpers.invalidateAllQueries());
+
+    const all = client.getQueryCache().findAll({ queryKey: ["user"] });
+    expect(all.length).toBe(2);
+    expect(all.every((q) => q.state.isInvalidated)).toBe(true);
+  });
+
+  it("removeAllQueries removes every entry under the namespace key", async () => {
+    const client = makeClient();
+    type Vars = { readonly id: string };
+    const userKey = makeQueryKey<"user", Vars>("user");
+    const helpers = makeHelpers<User, Vars>(userKey);
+
+    client.setQueryData(userKey({ id: "1" }), { id: "1", name: "Alice" });
+    client.setQueryData(userKey({ id: "2" }), { id: "2", name: "Bob" });
+
+    await runWithClient(client, helpers.removeAllQueries());
+
+    expect(client.getQueryCache().findAll({ queryKey: ["user"] }).length).toBe(0);
+  });
+});
+
+describe("makeHelpers — Effect.orDie surfaces QueryClient failures as defects", () => {
+  it("invalidateQuery dies when the underlying QueryClient throws", async () => {
+    const failingClient = makeClient();
+    failingClient.invalidateQueries = () => {
+      throw new Error("boom");
+    };
+
+    const settingsKey = makeQueryKey("settings");
+    type Settings = { readonly theme: string };
+    const helpers = makeHelpers<Settings>(settingsKey);
+
+    const exit = await runExitWithClient(failingClient, helpers.invalidateQuery());
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      // orDie converts to a defect, not a typed failure
+      expect(exit.cause._tag).toBe("Die");
+    }
+  });
+
+  it("refetchAllQueries dies when the underlying QueryClient throws", async () => {
+    const failingClient = makeClient();
+    failingClient.refetchQueries = () => {
+      throw new Error("boom");
+    };
+
+    const settingsKey = makeQueryKey("settings");
+    type Settings = { readonly theme: string };
+    const helpers = makeHelpers<Settings>(settingsKey);
+
+    const exit = await runExitWithClient(failingClient, helpers.refetchAllQueries());
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(exit.cause._tag).toBe("Die");
+    }
+  });
+});

--- a/packages/web/lib/tanstack-query/use-effect-mutation.test.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-mutation.test.tsx
@@ -1,0 +1,254 @@
+// Tests for `useEffectMutation`. This hook is the bridge between
+// Effect's failure channel and TanStack's mutation callbacks. The
+// branches under test are the runner glue (toast surfacing, defect
+// extraction) — not the TanStack Query state machine, which the
+// library already covers.
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { QueryDefect, useEffectMutation } from "./use-effect-mutation";
+
+class TaggedA extends Data.TaggedError("TaggedA")<{ readonly message: string }> {}
+class TaggedB extends Data.TaggedError("TaggedB")<{ readonly reason: string }> {}
+
+let harness: ReturnType<typeof makePresenterHarness>;
+
+beforeEach(() => {
+  harness = makePresenterHarness({ apiClient: {} });
+});
+
+afterEach(async () => {
+  await harness.dispose();
+});
+
+describe("useEffectMutation — success path", () => {
+  it("calls toastifySuccess and resolves with the result", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation({
+          mutationKey: ["successful-mutation"],
+          mutationFn: () => Effect.succeed({ id: 42 }),
+          toastifySuccess: (r) => `created ${r.id}`,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let resolved: { id: number } | undefined;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(undefined);
+    });
+
+    expect(resolved).toEqual({ id: 42 });
+    const toasts = await harness.getToasts();
+    expect(toasts).toEqual([{ kind: "success", message: "created 42" }]);
+  });
+});
+
+describe("useEffectMutation — tagged failure", () => {
+  it("invokes the matching tag handler and rejects with the tagged error preserved", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation<never, TaggedA, void, never>({
+          mutationKey: ["tagged-failure"],
+          mutationFn: () => Effect.fail(new TaggedA({ message: "nope" })),
+          toastifyErrors: {
+            TaggedA: (e) => `A: ${e.message}`,
+          },
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch (e) {
+        caught = e;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(TaggedA);
+    expect((caught as TaggedA).message).toBe("nope");
+    const toasts = await harness.getToasts();
+    expect(toasts).toEqual([{ kind: "error", message: "A: nope" }]);
+  });
+
+  it("does not invoke an unrelated handler when the tag differs", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation<never, TaggedA | TaggedB, void, never>({
+          mutationKey: ["mismatched-tag"],
+          mutationFn: () => Effect.fail(new TaggedB({ reason: "x" })),
+          toastifyErrors: {
+            TaggedA: (e) => `A: ${e.message}`,
+            // No TaggedB handler — falls through to orElse (default: true).
+          },
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch {
+        /* tagged failure rejects mutateAsync */
+      }
+    });
+
+    const toasts = await harness.getToasts();
+    // Falls back to DEFAULT_ERROR_MESSAGE (orElse default = true).
+    expect(toasts).toEqual([{ kind: "error", message: "Something went wrong" }]);
+  });
+});
+
+describe("useEffectMutation — orElse fallbacks", () => {
+  it("orElse: 'extractMessage' uses error.message when present", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation<never, TaggedA, void, never>({
+          mutationKey: ["orElse-extract"],
+          mutationFn: () => Effect.fail(new TaggedA({ message: "extracted!" })),
+          toastifyErrors: { orElse: "extractMessage" },
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch {
+        /* expected */
+      }
+    });
+
+    const toasts = await harness.getToasts();
+    expect(toasts).toEqual([{ kind: "error", message: "extracted!" }]);
+  });
+
+  it("orElse as a string uses the literal", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation<never, TaggedA, void, never>({
+          mutationKey: ["orElse-literal"],
+          mutationFn: () => Effect.fail(new TaggedA({ message: "x" })),
+          toastifyErrors: { orElse: "literal fallback" },
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch {
+        /* expected */
+      }
+    });
+
+    const toasts = await harness.getToasts();
+    expect(toasts).toEqual([{ kind: "error", message: "literal fallback" }]);
+  });
+
+  it("orElse: false emits no toast on tagged failure", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation<never, TaggedA, void, never>({
+          mutationKey: ["orElse-off"],
+          mutationFn: () => Effect.fail(new TaggedA({ message: "silent" })),
+          toastifyErrors: { orElse: false },
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch {
+        /* expected */
+      }
+    });
+
+    const toasts = await harness.getToasts();
+    expect(toasts).toEqual([]);
+  });
+});
+
+describe("useEffectMutation — defects", () => {
+  it("wraps a defect in QueryDefect; default defect toast fires with DEFAULT_DEFECT_MESSAGE", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation({
+          mutationKey: ["defect-default"],
+          mutationFn: () => Effect.die("kaboom"),
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(undefined);
+      } catch (e) {
+        caught = e;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(QueryDefect);
+    await waitFor(async () => {
+      const toasts = await harness.getToasts();
+      expect(toasts).toEqual([{ kind: "error", message: "An unexpected error occurred" }]);
+    });
+  });
+
+  it("uses the string when toastifyDefects is a string", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation({
+          mutationKey: ["defect-string"],
+          mutationFn: () => Effect.die("kaboom"),
+          toastifyDefects: "custom defect message",
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(undefined);
+      } catch {
+        /* expected */
+      }
+    });
+
+    await waitFor(async () => {
+      const toasts = await harness.getToasts();
+      expect(toasts).toEqual([{ kind: "error", message: "custom defect message" }]);
+    });
+  });
+
+  it("emits no toast when toastifyDefects: false but still throws QueryDefect", async () => {
+    const { result } = renderHook(
+      () =>
+        useEffectMutation({
+          mutationKey: ["defect-silent"],
+          mutationFn: () => Effect.die("kaboom"),
+          toastifyDefects: false,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(undefined);
+      } catch (e) {
+        caught = e;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(QueryDefect);
+    const toasts = await harness.getToasts();
+    expect(toasts).toEqual([]);
+  });
+});

--- a/packages/web/lib/tanstack-query/use-effect-suspense-query.test.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-suspense-query.test.tsx
@@ -1,0 +1,208 @@
+// Tests for `useEffectSuspenseQuery`. The bridge surface is:
+//   - success path: hook returns the resolved value
+//   - tagged failure: thrown synchronously into the nearest error boundary
+//   - defect: wrapped in QueryDefect and thrown
+//   - cache hit: hydrated value is read without invoking the runtime
+
+import { ApiClient } from "@/services/api-client.shared";
+import { QueryClient } from "@/services/common/query-client";
+import { type ClientManagedRuntime, RuntimeContext } from "@/services/runtime.client";
+import { RecordingToast } from "@/test/recording-toast";
+import { QueryClientProvider, QueryClient as TanstackQueryClient } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryDefect } from "./use-effect-mutation";
+import { useEffectSuspenseQuery } from "./use-effect-suspense-query";
+
+class TaggedA extends Data.TaggedError("TaggedA")<{ readonly message: string }> {}
+
+type SuspenseHarness = {
+  readonly wrapper: React.FC<{ children: React.ReactNode }>;
+  readonly queryClient: TanstackQueryClient;
+  readonly dispose: () => Promise<void>;
+};
+
+const makeSuspenseHarness = (): SuspenseHarness => {
+  const queryClient = new TanstackQueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+
+  const FakeApiClient = Layer.succeed(ApiClient, { client: {} } as never);
+  const layer = Layer.mergeAll(FakeApiClient, QueryClient.make(queryClient), RecordingToast);
+  const built = ManagedRuntime.make(layer);
+  const runtime = built as unknown as ClientManagedRuntime;
+
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <RuntimeContext.Provider value={runtime}>
+        <React.Suspense fallback={<span data-testid="loading" />}>{children}</React.Suspense>
+      </RuntimeContext.Provider>
+    </QueryClientProvider>
+  );
+
+  return { wrapper, queryClient, dispose: () => built.dispose() };
+};
+
+const makeFailingRuntimeHarness = (): SuspenseHarness => {
+  const queryClient = new TanstackQueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+
+  // A runtime whose runPromiseExit throws — proves the cache-hit path
+  // does not invoke the runtime at all.
+  const throwingRuntime = {
+    runPromiseExit: () => {
+      throw new Error("runtime should not be invoked when the QueryClient has a cached entry");
+    },
+  } as unknown as ClientManagedRuntime;
+
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <RuntimeContext.Provider value={throwingRuntime}>
+        <React.Suspense fallback={<span data-testid="loading" />}>{children}</React.Suspense>
+      </RuntimeContext.Provider>
+    </QueryClientProvider>
+  );
+
+  return { wrapper, queryClient, dispose: () => Promise.resolve() };
+};
+
+let harness: SuspenseHarness;
+
+afterEach(async () => {
+  await harness.dispose();
+});
+
+describe("useEffectSuspenseQuery — success", () => {
+  it("returns the resolved value once the effect completes", async () => {
+    harness = makeSuspenseHarness();
+
+    const { result } = renderHook(
+      () =>
+        useEffectSuspenseQuery({
+          queryKey: ["suspense-success"],
+          queryFn: () => Effect.succeed({ value: 7 }),
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ value: 7 });
+    });
+  });
+});
+
+const makeCatchingBoundary = () => {
+  const caught: { current: unknown } = { current: null };
+  class Boundary extends React.Component<
+    { readonly children: React.ReactNode },
+    { readonly hasError: boolean }
+  > {
+    public override state = { hasError: false };
+    public static getDerivedStateFromError() {
+      return { hasError: true };
+    }
+    public override componentDidCatch(error: unknown) {
+      caught.current = error;
+    }
+    public override render() {
+      if (this.state.hasError) return <span data-testid="boundary" />;
+      return this.props.children;
+    }
+  }
+  return { Boundary, caught };
+};
+
+describe("useEffectSuspenseQuery — tagged failure", () => {
+  it("throws the tagged error so it reaches the nearest error boundary", async () => {
+    harness = makeSuspenseHarness();
+
+    // React logs caught errors via console.error in dev; silence it.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const { Boundary, caught } = makeCatchingBoundary();
+    const wrappedWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <harness.wrapper>
+        <Boundary>{children}</Boundary>
+      </harness.wrapper>
+    );
+
+    renderHook(
+      () =>
+        useEffectSuspenseQuery({
+          queryKey: ["suspense-tagged-failure"],
+          queryFn: () => Effect.fail(new TaggedA({ message: "nope" })),
+        }),
+      { wrapper: wrappedWrapper },
+    );
+
+    await waitFor(() => {
+      expect(caught.current).not.toBeNull();
+    });
+    expect(caught.current).toBeInstanceOf(TaggedA);
+
+    spy.mockRestore();
+  });
+});
+
+describe("useEffectSuspenseQuery — defect", () => {
+  it("wraps a defect in QueryDefect", async () => {
+    harness = makeSuspenseHarness();
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const { Boundary, caught } = makeCatchingBoundary();
+    const wrappedWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <harness.wrapper>
+        <Boundary>{children}</Boundary>
+      </harness.wrapper>
+    );
+
+    renderHook(
+      () =>
+        useEffectSuspenseQuery({
+          queryKey: ["suspense-defect"],
+          queryFn: () => Effect.die("kaboom"),
+        }),
+      { wrapper: wrappedWrapper },
+    );
+
+    await waitFor(() => {
+      expect(caught.current).not.toBeNull();
+    });
+    expect(caught.current).toBeInstanceOf(QueryDefect);
+
+    spy.mockRestore();
+  });
+});
+
+describe("useEffectSuspenseQuery — cache hit", () => {
+  it("reads from a pre-seeded QueryClient without invoking the runtime", async () => {
+    harness = makeFailingRuntimeHarness();
+    harness.queryClient.setQueryData(["cached-key"], { cached: true });
+
+    const { result } = renderHook(
+      () =>
+        useEffectSuspenseQuery({
+          queryKey: ["cached-key"],
+          queryFn: () => Effect.succeed({ cached: false }),
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ cached: true });
+    });
+  });
+});

--- a/packages/web/test/README.md
+++ b/packages/web/test/README.md
@@ -1,0 +1,94 @@
+# `@org/web` test utilities
+
+Helpers for testing client-side React + Effect code without running
+the real ApiClient or hitting the network. Pair with vitest + jsdom
+(see `vitest.config.ts`).
+
+## What lives here
+
+| File                    | Purpose                                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `presenter-harness.tsx` | `makePresenterHarness()` — wrapper + QueryClient + recording Toast layer. Used by `*.presenter.test.ts(x)` files. |
+| `recording-toast.ts`    | A `Toast` Layer variant that records calls instead of side-effecting sonner. Read via `harness.getToasts()`.      |
+| `setup.ts`              | Registered as `setupFiles`; wires `@testing-library/jest-dom` matchers and `cleanup()` between tests.             |
+
+## When to use what
+
+- **Presenter tests (`*.presenter.test.ts(x)`)** — pass a partial
+  `apiClient` to `makePresenterHarness({ apiClient })`. Only the paths
+  the presenter touches need to be filled in. Assert behavior via the
+  hook's return shape, observed mutations on the partial client, and
+  `harness.getToasts()`.
+
+- **Bridge tests (`lib/tanstack-query/*.test.ts(x)`)** — for hooks that
+  don't reach an ApiClient directly (e.g. `useEffectMutation`,
+  `useEffectSuspenseQuery`), the presenter harness still works — pass
+  `apiClient: {}`. The hook will be exercised against the harness's
+  recording Toast and the supplied `queryFn`. For Suspense tests, wrap
+  in a custom `React.Suspense` boundary (see
+  `lib/tanstack-query/use-effect-suspense-query.test.tsx`).
+
+- **`renderHook` vs. rendering JSX** — prefer `renderHook` for presenter
+  unit tests. It avoids mounting the entire component tree and gives
+  you direct access to the returned shape. Only render JSX when you're
+  specifically asserting on DOM behavior (e.g. focus, ARIA, or the
+  component-driver tier).
+
+## Injecting a partial `apiClient`
+
+`apiClient` accepts a `Record<string, unknown>` that's narrowed at the
+call site to the contract shape. Only fill in the namespaces and
+methods the presenter under test calls — TypeScript will yell only
+about types you actually access, so the failure mode is loud and
+local.
+
+```ts
+const apiClient = {
+  user: {
+    find: () => Effect.succeed(new UserContract.PaginatedUsers({ ... })),
+    // create is omitted — the presenter under test never calls it.
+  },
+};
+harness = makePresenterHarness({ apiClient });
+```
+
+If the test exercises the mutation path that touches a method you
+omitted, the test will fail at runtime with a clear "not a function"
+error, not silently pass.
+
+## `RecordingToast` and `getToasts()`
+
+The harness substitutes the prod `Toast` layer with `RecordingToast`,
+which writes calls to a `Ref` instead of firing sonner. Read them via
+the harness:
+
+```ts
+const toasts = await harness.getToasts();
+expect(toasts).toEqual([{ kind: "success", message: "User created!" }]);
+```
+
+The shape is `ReadonlyArray<{ kind: "success" | "error"; message: string }>`.
+Order is preserved.
+
+## Common gotchas
+
+- **Cleanup.** Every test must call `await harness.dispose()` in
+  `afterEach` (the existing tests use a per-file `let harness` and an
+  `afterEach`). Skipping dispose leaks the runtime across tests and
+  causes intermittent failures.
+
+- **`useSuspenseQuery` and pending state.** When a presenter uses
+  `useEffectSuspenseQuery`, the hook will suspend on the first render.
+  Wrap your `renderHook` assertions in `waitFor` (or, for JSX renders,
+  wrap the tree in `React.Suspense`).
+
+- **Defects.** `useEffectMutation` rethrows defects wrapped in a
+  `QueryDefect`. If your test calls `mutateAsync`, wrap it in a
+  `try/catch` — the rejection is expected behavior, not a test
+  failure. The defect toast is recorded and assertable.
+
+- **`mutate` is fire-and-forget; `mutateAsync` rejects on failure.**
+  Match the production call site: presenters that use `.mutate(...)`
+  should be tested via `act(() => result.current.mutate(...))` + a
+  `waitFor` on the side-effect; presenters that use `.mutateAsync(...)`
+  should be tested via `await act(async () => { try { await result.current.mutateAsync(...); } catch { /* expected */ } })`.

--- a/scripts/check-test-parity.mjs
+++ b/scripts/check-test-parity.mjs
@@ -101,6 +101,19 @@ const rules = [
       (f) => f.replace(/\.presenter\.tsx?$/, ".presenter.test.tsx"),
     ],
   },
+  // ── Bridge (web ↔ TanStack Query / Effect) ─────────────────────────
+  // Files under `packages/web/lib/tanstack-query/` are the bridge
+  // between two runtimes. They contain branch logic that's invisible
+  // to presenter tests (toast surfacing, defect extraction, JSON
+  // round-trip across the RSC/CC boundary, ParseError formatting). Each
+  // non-barrel source file needs a sibling unit test.
+  {
+    label: "Tanstack-query bridge",
+    requirement: "sibling test",
+    subject: "packages/web/lib/tanstack-query/*.{ts,tsx}",
+    ignore: ["**/*.test.ts", "**/*.test.tsx", "**/index.ts", "**/server-hydration-boundary.tsx"],
+    candidates: [(f) => f.replace(/\.tsx?$/, ".test.ts"), (f) => f.replace(/\.tsx?$/, ".test.tsx")],
+  },
   // ── @org/components (ADR-0015) ──────────────────────────────────────
   // Every primitive and pattern needs a Storybook story so the
   // component library has a single navigable surface. Re-exports from


### PR DESCRIPTION
## Summary

Implements the bulk of `docs/scratch/frontend-testing-remediation-plan.md`. Closes Phases 1, 2, 4, 5, 6, 11, 12, 13, 14 fully; Phase 3 partial (play() tests authored, CI runner deferred). Phases 7, 8, 9 are left for a follow-up.

## What's in this PR

### Frontend testing infrastructure

- **Phase 1** — Bridge tests for `packages/web/lib/tanstack-query/` (`use-effect-mutation`, `use-effect-suspense-query`, `query-data-helpers`, `effect-prefetch.server`, `make-form-options`). 36 new tests; new parity rule in `scripts/check-test-parity.mjs` so future bridge files require sibling tests.
- **Phase 2** — Lift testable behavior from view wrappers into presenters: `user-list.presenter.ts`, `todo-list.presenter.ts`, `todo-item.presenter.ts`. Sibling tests cover pagination state, empty/populated paths, toggle/delete dispatch, tagged-failure toast. `packages/web/test/README.md` documents the harness.
- **Phase 3 (partial)** — `play()` interaction tests on 5 primitives (`form`, `checkbox`, `input`, `select`, `dialog`) via `storybook/test`. Runnable in the Storybook UI; the CI runner is deferred (no new dev dep, per the plan's "no new runner" constraint).
- **Phase 4** — Real `*.view-model.ts` example: `user-list.view-model.ts` for pagination math. Anchors ADR-0014 Tier 3 so the parity rule fires for at least one file.
- **Phase 5** — Three web depcruise rules: `web-no-cross-feature-imports`, `web-features-not-from-app`, `web-features-no-server-data-access`.

### Architectural commitments

- **Phase 6** — `docs/adr/0019-isomorphic-stack.md`. Commits to Node + Effect on both sides so the upcoming integration tier can call real backend handlers in-process.
- **Phase 12** — `docs/adr/0020-platform-ids-governance.md` + `platform-ids-effect-only` depcruise rule. Locks `platform/ids/` to branded UUIDs only.

### Backend modularity refinements

- **Phase 11** — Anti-corruption layer for wallet's consumption of `UserCreated`. New `wallet/event-handlers/triggers/` + `user-event-adapter.ts`; the `event-handlers-cross-module-via-adapter-only` depcruise rule enforces it. ADR-0007 updated with the pattern.
- **Phase 13** — Narrow `AuthSharedDepsLive` to the genuinely shared surface (CookieCodec + SessionRepository); `AuthIdentityRepositoryLive` moves inside `AuthModuleLive`. `AuthIdentityRepository` removed from the auth barrel.
- **Phase 14** — Document the `.endpoint.test.ts` vs `.endpoint.integration.test.ts` convention in CLAUDE.md. The three auth endpoint tests already carry header comments explaining why they stay `.test.ts`.

## What's NOT in this PR (left for follow-up)

- **Phase 7** — `FakeDatabase` + behavior contract suite. ~2–3 days; this is the structural foundation for Phase 8 and benefits from a focused session.
- **Phase 8** — `@org/test-backend` workspace package. ~1.5–2 days; depends on Phase 7.
- **Phase 9** — Tier-agnostic page drivers + integration tests. ~2–3 days; depends on Phase 8.

The "Workstream B" sequence (6 → 7 → 8 → 9) is the main FE-side test-tier work. ADR-0019 (Phase 6, included here) pins the architectural commitment that makes Phases 7–9 viable.

## Test plan

- [ ] CI: `pnpm check:all` green locally (verified)
- [ ] CI: lint, lint:deps, lint:tests, typecheck, vitest, storybook build all pass
- [ ] Manual: open Storybook (`pnpm -F @org/components storybook`), exercise `Interactions` panel on Form / Checkbox / Input / Select / Dialog stories
- [ ] Manual: `pnpm --filter @org/web dev` + `pnpm --filter @org/server dev`, click around `/`, `/users`, sign in/out
- [ ] Review: ADR-0019 + ADR-0020 + ADR-0007 update read as a coherent architectural record

🤖 Generated with [Claude Code](https://claude.com/claude-code)