### PR TITLE
Frontend testing remediation: phases 7-9 (in-process integration tier)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -32,10 +32,14 @@ module.exports = {
     {
       name: "module-barrel-only-from-outside",
       severity: "error",
-      comment: "Files outside src/modules must import a module via its index.ts barrel.",
+      comment:
+        "Files outside src/modules must import a module via its index.ts barrel. " +
+        "Test infrastructure (`src/test-utils/`) is exempted because the shared " +
+        "FakeDatabase needs to know about each module's domain row shapes — that's " +
+        "the test surface for `@org/test-backend` and the behavior contract suite.",
       from: {
         path: "^packages/",
-        pathNot: "^packages/server/src/modules/[^/]+/",
+        pathNot: ["^packages/server/src/modules/[^/]+/", "^packages/server/src/test-utils/"],
       },
       to: {
         path: "^packages/server/src/modules/[^/]+/",

--- a/packages/acceptance/package.json
+++ b/packages/acceptance/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@org/contracts": "workspace:^",
+    "@org/test-drivers": "workspace:^",
     "@playwright/test": "^1.49.1",
     "@types/node": "^25.6.0",
     "@types/pg": "^8.11.10",

--- a/packages/acceptance/specs/add-user.spec.ts
+++ b/packages/acceptance/specs/add-user.spec.ts
@@ -1,5 +1,5 @@
-import { UsersPage } from "@/drivers/pages/users-page";
 import { truncate } from "@/test-utils/database";
+import { playwrightUsersDriver } from "@org/test-drivers/adapters/playwright/users-page-driver";
 import { test } from "@playwright/test";
 
 const DATABASE_URL_TEST =
@@ -14,9 +14,14 @@ test.beforeEach(async () => {
   await truncate(DATABASE_URL_TEST, ["wallets", "users"]);
 });
 
+// Phase 9 of the remediation plan: this acceptance spec exercises
+// the same scenario via the same `UsersPageDriver` contract used by
+// the integration-tier test in `@org/web`. Driver methods speak
+// business intent; the spec body is identical at both tiers, only
+// the adapter and setup differ.
 test("a user can be created from the users page", async ({ page }) => {
-  const users = new UsersPage(page);
-  await users.visit();
+  const users = playwrightUsersDriver(page);
+  await users.goto();
 
   await users.createUser({
     email: "alice@example.com",
@@ -25,5 +30,5 @@ test("a user can be created from the users page", async ({ page }) => {
     postalCode: "12345",
   });
 
-  await users.expectUserVisible("alice@example.com");
+  await users.expectUserInList("alice@example.com");
 });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "license": "MIT",
   "description": "The server template",
+  "exports": {
+    "./test-utils/*": "./src/test-utils/*.ts"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lucas-barake/effect-monorepo.git",

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.ts
@@ -1,35 +1,62 @@
+import { FakeDatabaseRelaxedLive, FakeDatabaseTag } from "@/test-utils/fake-database.js";
 import * as Effect from "effect/Effect";
-import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
-import * as Ref from "effect/Ref";
 import { type AuthIdentity, AuthIdentityRepository } from "../domain/auth-identity-repository.js";
 import { AuthIdentityNotFound } from "../domain/session-errors.js";
 
-// `AuthIdentityRepository` is read-only on the public contract — production
-// inserts happen out-of-band via the seed script (admin pre-seeded; non-admin
-// JIT is a documented evolution). The fake therefore exposes a constructor
-// that accepts initial state, so tests can seed identities without us having
-// to extend the public contract with an `insert` we don't actually want.
+// `AuthIdentityRepository` is read-only on the public contract —
+// production inserts happen out-of-band via the seed script (admin
+// pre-seeded; non-admin JIT is a documented evolution). The shared
+// variant therefore only exposes `findBySubject`; tests that need to
+// seed identities can either pass a `seed` to
+// `makeAuthIdentityRepositoryFake` or call `db.insertAuthIdentity(...)`
+// directly when working with a shared `FakeDatabase`.
+export const AuthIdentityRepositoryFakeShared: Layer.Layer<
+  AuthIdentityRepository,
+  never,
+  FakeDatabaseTag
+> = Layer.effect(
+  AuthIdentityRepository,
+  Effect.gen(function* () {
+    const db = yield* FakeDatabaseTag;
+
+    const findBySubject = (subject: string): Effect.Effect<AuthIdentity, AuthIdentityNotFound> => {
+      const identity = db.authIdentities.get(subject);
+      return identity === undefined
+        ? Effect.fail(new AuthIdentityNotFound({ subject }))
+        : Effect.succeed(identity);
+    };
+
+    return AuthIdentityRepository.of({ findBySubject });
+  }),
+);
+
+// Backward-compatible seedable constructor used by existing tests
+// (`makeAuthIdentityRepositoryFake([alice, bob])`). The seed pushes
+// rows straight into a private `FakeDatabase` — these tests don't
+// care about FK enforcement, only about the lookup behavior.
 export const makeAuthIdentityRepositoryFake = (
   seed: ReadonlyArray<AuthIdentity> = [],
-): Layer.Layer<AuthIdentityRepository> =>
-  Layer.effect(
+): Layer.Layer<AuthIdentityRepository> => {
+  const Seeded = Layer.effect(
     AuthIdentityRepository,
     Effect.gen(function* () {
-      const initial = HashMap.fromIterable(seed.map((i) => [i.subject, i] as const));
-      const store = yield* Ref.make(initial);
-
-      const findBySubject = (subject: string): Effect.Effect<AuthIdentity, AuthIdentityNotFound> =>
-        Effect.flatMap(Ref.get(store), (m) =>
-          Option.match(HashMap.get(m, subject), {
-            onNone: () => Effect.fail(new AuthIdentityNotFound({ subject })),
-            onSome: Effect.succeed,
-          }),
-        );
-
+      const db = yield* FakeDatabaseTag;
+      for (const identity of seed) {
+        db.authIdentities.set(identity.subject, identity);
+      }
+      const findBySubject = (
+        subject: string,
+      ): Effect.Effect<AuthIdentity, AuthIdentityNotFound> => {
+        const found = db.authIdentities.get(subject);
+        return found === undefined
+          ? Effect.fail(new AuthIdentityNotFound({ subject }))
+          : Effect.succeed(found);
+      };
       return AuthIdentityRepository.of({ findBySubject });
     }),
   );
+  return Seeded.pipe(Layer.provide(FakeDatabaseRelaxedLive));
+};
 
 export const AuthIdentityRepositoryFake = makeAuthIdentityRepositoryFake();

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
@@ -1,87 +1,89 @@
+import { FakeDatabaseRelaxedLive, FakeDatabaseTag } from "@/test-utils/fake-database.js";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
-import * as Ref from "effect/Ref";
 import { SessionNotFound } from "../domain/session-errors.js";
 import { type SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";
 import { Session } from "../domain/session.aggregate.js";
 
-export const SessionRepositoryFake = Layer.effect(
-  SessionRepository,
-  Effect.gen(function* () {
-    const store = yield* Ref.make(HashMap.empty<SessionId, Session>());
+// Shared-state variant. See user-repository-fake.ts header.
+export const SessionRepositoryFakeShared: Layer.Layer<SessionRepository, never, FakeDatabaseTag> =
+  Layer.effect(
+    SessionRepository,
+    Effect.gen(function* () {
+      const db = yield* FakeDatabaseTag;
 
-    const insert = (session: Session): Effect.Effect<void> =>
-      Ref.update(store, HashMap.set(session.id, session));
+      const insert = (session: Session) =>
+        db.insertSession(session).pipe(
+          // ON DELETE CASCADE from users → sessions guarantees we
+          // never insert a session whose user vanished. A missing
+          // user here is an architectural bug; die rather than
+          // fabricate a domain error.
+          Effect.catchTag("ForeignKeyViolation", (e) => Effect.die(e)),
+        );
 
-    const findById = (id: SessionId): Effect.Effect<Session, SessionNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new SessionNotFound({ sessionId: id })),
-          onSome: Effect.succeed,
-        }),
-      );
+      const findById = (id: SessionId) => {
+        const session = db.sessions.get(id);
+        return session === undefined
+          ? Effect.fail(new SessionNotFound({ sessionId: id }))
+          : Effect.succeed(session);
+      };
 
-    // Mirrors the live impl: an already-revoked session is reported as
-    // SessionNotFound (the SQL UPDATE matches `WHERE revoked_at IS NULL`,
-    // so a re-revoke returns zero rows and `orFail` raises NotFound).
-    const revoke = (id: SessionId): Effect.Effect<void, SessionNotFound> =>
-      Effect.gen(function* () {
-        const m = yield* Ref.get(store);
-        const existing = HashMap.get(m, id);
-        if (Option.isNone(existing) || existing.value.revokedAt !== null) {
-          return yield* Effect.fail(new SessionNotFound({ sessionId: id }));
-        }
-        const now = yield* DateTime.now;
-        yield* Ref.update(store, (m2) =>
-          HashMap.set(
-            m2,
+      // Mirrors the live impl: an already-revoked session is reported
+      // as SessionNotFound (the SQL UPDATE matches `WHERE revoked_at
+      // IS NULL`, so a re-revoke returns zero rows and `orFail` raises
+      // NotFound).
+      const revoke = (id: SessionId): Effect.Effect<void, SessionNotFound> =>
+        Effect.gen(function* () {
+          const existing = db.sessions.get(id);
+          if (existing?.revokedAt !== null) {
+            return yield* Effect.fail(new SessionNotFound({ sessionId: id }));
+          }
+          const now = yield* DateTime.now;
+          db.sessions.set(
             id,
             Session.make({
-              id: existing.value.id,
-              userId: existing.value.userId,
-              subject: existing.value.subject,
-              expiresAt: existing.value.expiresAt,
-              absoluteExpiresAt: existing.value.absoluteExpiresAt,
+              id: existing.id,
+              userId: existing.userId,
+              subject: existing.subject,
+              expiresAt: existing.expiresAt,
+              absoluteExpiresAt: existing.absoluteExpiresAt,
               revokedAt: now,
-              createdAt: existing.value.createdAt,
-              lastUsedAt: existing.value.lastUsedAt,
+              createdAt: existing.createdAt,
+              lastUsedAt: existing.lastUsedAt,
             }),
-          ),
-        );
-      });
+          );
+        });
 
-    // Mirrors the live impl: only updates rows where revoked_at IS NULL.
-    // A revoked or missing row fails SessionNotFound — callers on the touch
-    // path catch and ignore (benign race).
-    const update = (session: Session): Effect.Effect<void, SessionNotFound> =>
-      Effect.gen(function* () {
-        const m = yield* Ref.get(store);
-        const existing = HashMap.get(m, session.id);
-        if (Option.isNone(existing) || existing.value.revokedAt !== null) {
-          return yield* Effect.fail(new SessionNotFound({ sessionId: session.id }));
-        }
-        yield* Ref.update(store, (m2) =>
-          HashMap.set(
-            m2,
+      // Mirrors the live impl: only updates rows where revoked_at IS
+      // NULL. A revoked or missing row fails SessionNotFound — callers
+      // on the touch path catch and ignore (benign race).
+      const update = (session: Session): Effect.Effect<void, SessionNotFound> =>
+        Effect.gen(function* () {
+          const existing = db.sessions.get(session.id);
+          if (existing?.revokedAt !== null) {
+            return yield* Effect.fail(new SessionNotFound({ sessionId: session.id }));
+          }
+          db.sessions.set(
             session.id,
             Session.make({
-              id: existing.value.id,
-              userId: existing.value.userId,
-              subject: existing.value.subject,
+              id: existing.id,
+              userId: existing.userId,
+              subject: existing.subject,
               expiresAt: session.expiresAt,
-              absoluteExpiresAt: existing.value.absoluteExpiresAt,
-              revokedAt: existing.value.revokedAt,
-              createdAt: existing.value.createdAt,
+              absoluteExpiresAt: existing.absoluteExpiresAt,
+              revokedAt: existing.revokedAt,
+              createdAt: existing.createdAt,
               lastUsedAt: session.lastUsedAt,
             }),
-          ),
-        );
-      });
+          );
+        });
 
-    return SessionRepository.of({ insert, findById, revoke, update });
-  }),
+      return SessionRepository.of({ insert, findById, revoke, update });
+    }),
+  );
+
+export const SessionRepositoryFake = SessionRepositoryFakeShared.pipe(
+  Layer.provide(FakeDatabaseRelaxedLive),
 );

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
@@ -1,43 +1,42 @@
+import { FakeDatabaseRelaxedLive, FakeDatabaseTag } from "@/test-utils/fake-database.js";
 import * as Effect from "effect/Effect";
-import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
-import * as Ref from "effect/Ref";
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { type TodoId } from "../domain/todo-id.js";
 import { TodosRepository } from "../domain/todo-repository.js";
 import { type Todo } from "../domain/todo.js";
 
-export const TodosRepositoryFake = Layer.effect(
-  TodosRepository,
-  Effect.gen(function* () {
-    const store = yield* Ref.make(HashMap.empty<TodoId, Todo>());
+// Shared-state variant. See user-repository-fake.ts header.
+// Todos have no FK to users in the current schema, so this fake is
+// the simplest of the bunch.
+export const TodosRepositoryFakeShared: Layer.Layer<TodosRepository, never, FakeDatabaseTag> =
+  Layer.effect(
+    TodosRepository,
+    Effect.gen(function* () {
+      const db = yield* FakeDatabaseTag;
 
-    const insert = (todo: Todo): Effect.Effect<void> =>
-      Ref.update(store, HashMap.set(todo.id, todo));
+      const insert = (todo: Todo) =>
+        Effect.sync(() => {
+          db.insertTodo(todo);
+        });
 
-    const update = (todo: Todo): Effect.Effect<void, TodoNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        HashMap.has(m, todo.id)
-          ? Ref.update(store, HashMap.set(todo.id, todo))
-          : Effect.fail(new TodoNotFound({ todoId: todo.id })),
-      );
+      const update = (todo: Todo) =>
+        db.updateTodo(todo) ? Effect.void : Effect.fail(new TodoNotFound({ todoId: todo.id }));
 
-    const remove = (id: TodoId): Effect.Effect<void, TodoNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        HashMap.has(m, id)
-          ? Ref.update(store, HashMap.remove(id))
-          : Effect.fail(new TodoNotFound({ todoId: id })),
-      );
+      const remove = (id: TodoId) =>
+        db.deleteTodo(id) ? Effect.void : Effect.fail(new TodoNotFound({ todoId: id }));
 
-    const findById = (id: TodoId): Effect.Effect<Todo, TodoNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new TodoNotFound({ todoId: id })),
-          onSome: Effect.succeed,
-        }),
-      );
+      const findById = (id: TodoId) => {
+        const todo = db.todos.get(id);
+        return todo === undefined
+          ? Effect.fail(new TodoNotFound({ todoId: id }))
+          : Effect.succeed(todo);
+      };
 
-    return TodosRepository.of({ insert, update, remove, findById });
-  }),
+      return TodosRepository.of({ insert, update, remove, findById });
+    }),
+  );
+
+export const TodosRepositoryFake = TodosRepositoryFakeShared.pipe(
+  Layer.provide(FakeDatabaseRelaxedLive),
 );

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
@@ -1,60 +1,69 @@
 import { type UserId } from "@/platform/ids/user-id.js";
+import { FakeDatabaseRelaxedLive, FakeDatabaseTag } from "@/test-utils/fake-database.js";
 import * as Effect from "effect/Effect";
-import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import * as Ref from "effect/Ref";
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
 import { type User } from "../domain/user.aggregate.js";
 
-const findUserByEmail = (
-  store: HashMap.HashMap<UserId, User>,
-  email: string,
-): Option.Option<User> => {
-  for (const user of HashMap.values(store)) {
-    if (user.email === email) return Option.some(user);
-  }
-  return Option.none();
-};
+// Variant that consumes a shared `FakeDatabase` from context. Compose
+// with other `*FakeShared` repos under a single `FakeDatabaseLive` so
+// cross-repo invariants (FK, cascade) exercise the same in-memory
+// state. See `@/test-utils/fake-repositories.ts`.
+export const UserRepositoryFakeShared: Layer.Layer<UserRepository, never, FakeDatabaseTag> =
+  Layer.effect(
+    UserRepository,
+    Effect.gen(function* () {
+      const db = yield* FakeDatabaseTag;
 
-export const UserRepositoryFake = Layer.effect(
-  UserRepository,
-  Effect.gen(function* () {
-    const store = yield* Ref.make(HashMap.empty<UserId, User>());
+      const insert = (user: User) =>
+        db
+          .insertUser(user)
+          .pipe(
+            Effect.catchTag("UniqueViolation", () =>
+              Effect.fail(new UserAlreadyExists({ email: user.email })),
+            ),
+          );
 
-    const insert = (user: User): Effect.Effect<void, UserAlreadyExists> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.isSome(findUserByEmail(m, user.email))
-          ? Effect.fail(new UserAlreadyExists({ email: user.email }))
-          : Ref.update(store, HashMap.set(user.id, user)),
-      );
+      const update = (user: User) =>
+        db.updateUser(user).pipe(
+          // Mirror live: the UPDATE's unique-index collision surfaces
+          // as a DatabaseError that the live repo dies on. Use cases
+          // never observe UserAlreadyExists on update.
+          Effect.catchTag("UniqueViolation", (e) => Effect.die(e)),
+          Effect.flatMap((ok) =>
+            ok ? Effect.void : Effect.fail(new UserNotFound({ userId: user.id })),
+          ),
+        );
 
-    const update = (user: User): Effect.Effect<void, UserNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        HashMap.has(m, user.id)
-          ? Ref.update(store, HashMap.set(user.id, user))
-          : Effect.fail(new UserNotFound({ userId: user.id })),
-      );
+      const remove = (id: UserId) =>
+        db.deleteUser(id) ? Effect.void : Effect.fail(new UserNotFound({ userId: id }));
 
-    const remove = (id: UserId): Effect.Effect<void, UserNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        HashMap.has(m, id)
-          ? Ref.update(store, HashMap.remove(id))
-          : Effect.fail(new UserNotFound({ userId: id })),
-      );
+      const findById = (id: UserId) => {
+        const found = db.users.get(id);
+        return found === undefined
+          ? Effect.fail(new UserNotFound({ userId: id }))
+          : Effect.succeed(found);
+      };
 
-    const findById = (id: UserId): Effect.Effect<User, UserNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new UserNotFound({ userId: id })),
-          onSome: Effect.succeed,
-        }),
-      );
+      const findByEmail = (email: string) => {
+        for (const user of db.users.values()) {
+          if (user.email === email) return Effect.succeed(Option.some(user));
+        }
+        return Effect.succeed(Option.none<User>());
+      };
 
-    const findByEmail = (email: string): Effect.Effect<Option.Option<User>> =>
-      Effect.map(Ref.get(store), (m) => findUserByEmail(m, email));
+      return UserRepository.of({ insert, update, remove, findById, findByEmail });
+    }),
+  );
 
-    return UserRepository.of({ insert, update, remove, findById, findByEmail });
-  }),
+// Backward-compatible Layer: provides its own `FakeDatabase` so
+// existing call sites (`Effect.provide(UserRepositoryFake)`) keep
+// working unchanged. Tests that want cross-repo sharing should
+// compose `UserRepositoryFakeShared` over a single `FakeDatabaseLive`
+// — `FakeRepositoriesLive` in `@/test-utils/fake-repositories.ts`
+// is the canonical such composition.
+export const UserRepositoryFake = UserRepositoryFakeShared.pipe(
+  Layer.provide(FakeDatabaseRelaxedLive),
 );

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
@@ -1,39 +1,46 @@
 import { type UserId } from "@/platform/ids/user-id.js";
+import { FakeDatabaseRelaxedLive, FakeDatabaseTag } from "@/test-utils/fake-database.js";
 import * as Effect from "effect/Effect";
-import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import * as Ref from "effect/Ref";
 import { WalletAlreadyExistsForUser } from "../domain/wallet-errors.js";
-import { type WalletId } from "../domain/wallet-id.js";
 import { WalletRepository } from "../domain/wallet-repository.js";
 import { type Wallet } from "../domain/wallet.aggregate.js";
 
-const findByUserIdIn = (
-  store: HashMap.HashMap<WalletId, Wallet>,
-  userId: UserId,
-): Option.Option<Wallet> => {
-  for (const wallet of HashMap.values(store)) {
-    if (wallet.userId === userId) return Option.some(wallet);
-  }
-  return Option.none();
-};
+// Shared-state variant. See user-repository-fake.ts header for the
+// rationale; compose under a single `FakeDatabaseLive` so cross-repo
+// FK invariants exercise the same in-memory tables.
+export const WalletRepositoryFakeShared: Layer.Layer<WalletRepository, never, FakeDatabaseTag> =
+  Layer.effect(
+    WalletRepository,
+    Effect.gen(function* () {
+      const db = yield* FakeDatabaseTag;
 
-export const WalletRepositoryFake = Layer.effect(
-  WalletRepository,
-  Effect.gen(function* () {
-    const store = yield* Ref.make(HashMap.empty<WalletId, Wallet>());
+      const insert = (wallet: Wallet) =>
+        db.insertWallet(wallet).pipe(
+          Effect.catchTag("UniqueViolation", () =>
+            Effect.fail(new WalletAlreadyExistsForUser({ userId: wallet.userId })),
+          ),
+          // ForeignKeyViolation from the FakeDatabase mirrors what the
+          // live repository surfaces as a DatabaseError defect: the
+          // event handler that owns wallet creation runs in the same
+          // transaction as the user insert, so a missing user is an
+          // architectural bug, not a user-facing failure. Die in
+          // both fake and live.
+          Effect.catchTag("ForeignKeyViolation", (e) => Effect.die(e)),
+        );
 
-    const insert = (wallet: Wallet): Effect.Effect<void, WalletAlreadyExistsForUser> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.isSome(findByUserIdIn(m, wallet.userId))
-          ? Effect.fail(new WalletAlreadyExistsForUser({ userId: wallet.userId }))
-          : Ref.update(store, HashMap.set(wallet.id, wallet)),
-      );
+      const findByUserId = (userId: UserId) => {
+        for (const wallet of db.wallets.values()) {
+          if (wallet.userId === userId) return Effect.succeed(Option.some(wallet));
+        }
+        return Effect.succeed(Option.none<Wallet>());
+      };
 
-    const findByUserId = (userId: UserId): Effect.Effect<Option.Option<Wallet>> =>
-      Effect.map(Ref.get(store), (m) => findByUserIdIn(m, userId));
+      return WalletRepository.of({ insert, findByUserId });
+    }),
+  );
 
-    return WalletRepository.of({ insert, findByUserId });
-  }),
+export const WalletRepositoryFake = WalletRepositoryFakeShared.pipe(
+  Layer.provide(FakeDatabaseRelaxedLive),
 );

--- a/packages/server/src/test-utils/fake-database-service.ts
+++ b/packages/server/src/test-utils/fake-database-service.ts
@@ -1,0 +1,159 @@
+// A `Database.Database`-shaped service backed by `FakeDatabase`. The
+// in-process backend uses Fake repositories for mutation paths, so
+// the real `Database` is only needed by the read-side query handlers
+// (`findUsers`, `listTodos`) and by `PermissionsResolver`. This
+// service intercepts those callers' `execute(fn)` calls and returns
+// rows synthesized from the FakeDatabase Maps.
+//
+// Scope: only the SQL shapes our current query handlers run are
+// supported. If a handler runs an unfamiliar query against this
+// service, it `Effect.die`s with the SQL fragment so the gap is
+// visible and unambiguous — not a silent empty result that hides
+// a missing feature.
+
+import { type UserId } from "@/platform/ids/user-id.js";
+import { Database } from "@org/database/index";
+import type * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type { FakeDatabase } from "./fake-database.js";
+
+type DatabaseShape = Context.Tag.Service<typeof Database.Database>;
+
+// A minimal Slonik-client shape. Real Slonik clients have many more
+// methods; we surface only what the existing handlers reach for and
+// die on anything else.
+type FakeClient = {
+  readonly any: (query: unknown) => Promise<ReadonlyArray<unknown>>;
+  readonly one: (query: unknown) => Promise<unknown>;
+  readonly maybeOne: (query: unknown) => Promise<unknown>;
+  readonly query: (query: unknown) => Promise<unknown>;
+};
+
+const sqlText = (query: unknown): string => {
+  // Slonik's sql template produces objects with a `sql` field (the
+  // text) and a `values` array. Both `sql.unsafe` and `sql.type` use
+  // the same outer shape.
+  if (typeof query === "object" && query !== null && "sql" in query) {
+    return String(query.sql);
+  }
+  return "";
+};
+
+const sqlValues = (query: unknown): ReadonlyArray<unknown> => {
+  if (typeof query === "object" && query !== null && "values" in query) {
+    return (query as { values: ReadonlyArray<unknown> }).values;
+  }
+  return [];
+};
+
+const makeFakeClient = (db: FakeDatabase): FakeClient => ({
+  any: async (query) => {
+    const text = sqlText(query);
+    // findUsers: `SELECT * FROM users ORDER BY created_at DESC LIMIT $1 OFFSET $2`
+    if (/from\s+users/i.test(text) && /order\s+by\s+created_at\s+desc/i.test(text)) {
+      const values = sqlValues(query);
+      const limit = typeof values[0] === "number" ? values[0] : Number(values[0] ?? 10);
+      const offset = typeof values[1] === "number" ? values[1] : Number(values[1] ?? 0);
+      const sorted = Array.from(db.users.values()).sort(
+        (a, b) =>
+          new Date(b.createdAt.toString()).getTime() - new Date(a.createdAt.toString()).getTime(),
+      );
+      const window = sorted.slice(offset, offset + limit);
+      return window.map((u) => ({
+        id: u.id,
+        email: u.email,
+        role: u.role,
+        country: u.address.country,
+        street: u.address.street,
+        postal_code: u.address.postalCode,
+        created_at: new Date(u.createdAt.toString()),
+        updated_at: new Date(u.updatedAt.toString()),
+      }));
+    }
+    // listTodos: `SELECT * FROM todos ORDER BY created_at DESC`
+    if (/from\s+todos/i.test(text)) {
+      return Array.from(db.todos.values()).map((t) => ({
+        id: t.id,
+        title: t.title,
+        completed: t.completed,
+        // Todo aggregate doesn't carry created_at/updated_at; synthesize
+        // a stable epoch so the row schema decodes.
+        created_at: new Date(0),
+        updated_at: new Date(0),
+      }));
+    }
+    // Unknown: die with the SQL so the gap is visible.
+    throw new Error(`FakeDatabaseService.any: no mapping for query: ${text.slice(0, 200)}`);
+  },
+
+  one: async (query) => {
+    const text = sqlText(query);
+    // findUsers' count: `SELECT COUNT(*)::int AS value FROM users`
+    if (/count\s*\(\s*\*\s*\)/i.test(text) && /from\s+users/i.test(text)) {
+      return { value: db.users.size };
+    }
+    throw new Error(`FakeDatabaseService.one: no mapping for query: ${text.slice(0, 200)}`);
+  },
+
+  maybeOne: async (query) => {
+    const text = sqlText(query);
+    // PermissionsResolver: `SELECT role FROM users WHERE id = $1`
+    if (/select\s+role\s+from\s+users/i.test(text)) {
+      const values = sqlValues(query);
+      const userId = values[0] as UserId | undefined;
+      if (userId === undefined) return null;
+      const user = db.users.get(userId);
+      return user === undefined ? null : { role: user.role };
+    }
+    throw new Error(`FakeDatabaseService.maybeOne: no mapping for query: ${text.slice(0, 200)}`);
+  },
+
+  query: async (query) => {
+    throw new Error(
+      `FakeDatabaseService.query: writes go through Fake repositories, not Database directly. ` +
+        `Query was: ${sqlText(query).slice(0, 200)}`,
+    );
+  },
+});
+
+// Layer that provides `Database.Database` backed by the supplied
+// `FakeDatabase`. Wire BEFORE consumers that need it (the in-process
+// backend's API layer). All `execute` calls flow through the
+// FakeClient above; unknown SQL dies loudly.
+export const FakeDatabaseServiceLive = (db: FakeDatabase) =>
+  Layer.succeed(
+    Database.Database,
+    Database.Database.of({
+      execute: (<T>(fn: (client: FakeClient) => Promise<T>) =>
+        Effect.tryPromise({
+          try: () => fn(makeFakeClient(db)),
+          catch: (e) =>
+            new Error(
+              `FakeDatabaseService.execute: callback threw: ${e instanceof Error ? e.message : String(e)}`,
+            ),
+        }).pipe(Effect.orDie)) as unknown as DatabaseShape["execute"],
+      transaction: (effect: Effect.Effect<unknown, unknown, unknown>) =>
+        // The fake's mutations don't consult TransactionContext, so
+        // `transaction` is a pass-through. Match the live signature
+        // (which sets a TransactionContext); we just type-erase.
+        effect as Effect.Effect<unknown, unknown, never>,
+      setupConnectionListeners: Effect.void as DatabaseShape["setupConnectionListeners"],
+      makeQuery:
+        <A, E, R, Input = never>(
+          queryFn: (execute: DatabaseShape["execute"], input: Input) => Effect.Effect<A, E, R>,
+        ) =>
+        (...args: [Input] extends [never] ? [] : [Input]) => {
+          // No transaction context to thread; just call queryFn with
+          // execute directly. The `as never` cast satisfies the
+          // ExecuteFn type which is internal to Database.
+          const input = (args.length === 0 ? undefined : args[0]) as Input;
+          const execute = (<T>(fn: (client: FakeClient) => Promise<T>) =>
+            Effect.tryPromise({
+              try: () => fn(makeFakeClient(db)),
+              catch: (e) => e,
+            }).pipe(Effect.orDie)) as unknown as DatabaseShape["execute"];
+          return queryFn(execute, input);
+        },
+    } as unknown as DatabaseShape),
+  );

--- a/packages/server/src/test-utils/fake-database.ts
+++ b/packages/server/src/test-utils/fake-database.ts
@@ -1,0 +1,198 @@
+// In-memory state shared by every repository fake in a single test
+// scope. Models the cross-table invariants enforced by the real
+// schema (unique indexes, FK existence, FK cascade) so use-case unit
+// tests, in-process integration tests, and the upcoming
+// `@org/test-backend` harness all see the same constraint behavior
+// without booting Postgres.
+//
+// Scope discipline (ADR-0019 + remediation plan §7.2): we fake the
+// behaviors production code depends on, not all of Postgres. In
+// scope: unique indexes, FK existence, FK cascade-vs-restrict per
+// table, the domain errors that map from constraint violations. Out
+// of scope: transaction isolation levels (fakes are
+// serializable-by-construction), query planner behavior, advisory
+// locks, trigger semantics, native function semantics.
+//
+// The contract suite in `repository-behavior/` is the single source
+// of truth for "behaviors production code depends on" — if it isn't
+// asserted there, fidelity is not guaranteed.
+
+import { type UserId } from "@/platform/ids/user-id.js";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type { AuthIdentity } from "../modules/auth/domain/auth-identity-repository.js";
+import { type SessionId } from "../modules/auth/domain/session-id.js";
+import { type Session } from "../modules/auth/domain/session.aggregate.js";
+import { type TodoId } from "../modules/todos/domain/todo-id.js";
+import { type Todo } from "../modules/todos/domain/todo.js";
+import type { User } from "../modules/user/domain/user.aggregate.js";
+import { type WalletId } from "../modules/wallet/domain/wallet-id.js";
+import { type Wallet } from "../modules/wallet/domain/wallet.aggregate.js";
+
+// ──────────────────────────────────────────────────────────────────
+// Schema-level violation errors. Repo fakes catch these and map to
+// the module's domain errors (UserAlreadyExists, WalletAlreadyExistsForUser,
+// etc.), exactly the way the live repositories catch slonik's
+// DatabaseError variants.
+// ──────────────────────────────────────────────────────────────────
+export class UniqueViolation extends Data.TaggedError("UniqueViolation")<{
+  readonly table: string;
+  readonly column: string;
+}> {}
+
+export class ForeignKeyViolation extends Data.TaggedError("ForeignKeyViolation")<{
+  readonly table: string;
+  readonly column: string;
+}> {}
+
+// ──────────────────────────────────────────────────────────────────
+// FakeDatabase
+//
+// One instance per test scope. Each Map is a table; methods enforce
+// invariants by checking other Maps before mutating (e.g. inserting
+// into `wallets` requires the userId to exist in `users`). Cascade
+// is modeled explicitly in `deleteUser`.
+//
+// `enforceFks` defaults to true: cross-table FK existence is checked,
+// matching the real schema. The behavior contract suite and
+// `FakeRepositoriesLive` rely on this. Set to false for the
+// backward-compatible per-module fakes, which exist to let use-case
+// unit tests work with one repository in isolation without pre-
+// seeding rows in other tables.
+// ──────────────────────────────────────────────────────────────────
+export type FakeDatabaseOptions = {
+  readonly enforceFks?: boolean;
+};
+
+export class FakeDatabase {
+  public readonly users = new Map<UserId, User>();
+  public readonly todos = new Map<TodoId, Todo>();
+  public readonly wallets = new Map<WalletId, Wallet>();
+  public readonly authIdentities = new Map<string, AuthIdentity>();
+  public readonly sessions = new Map<SessionId, Session>();
+
+  public readonly enforceFks: boolean;
+
+  constructor(opts: FakeDatabaseOptions = {}) {
+    this.enforceFks = opts.enforceFks ?? true;
+  }
+
+  // ── users ──────────────────────────────────────────────────────
+  public insertUser(user: User): Effect.Effect<void, UniqueViolation> {
+    for (const existing of this.users.values()) {
+      if (existing.email === user.email) {
+        return Effect.fail(new UniqueViolation({ table: "users", column: "email" }));
+      }
+    }
+    this.users.set(user.id, user);
+    return Effect.void;
+  }
+
+  public updateUser(user: User): Effect.Effect<boolean, UniqueViolation> {
+    if (!this.users.has(user.id)) return Effect.succeed(false);
+    // Email change must not collide with another row.
+    for (const existing of this.users.values()) {
+      if (existing.id !== user.id && existing.email === user.email) {
+        return Effect.fail(new UniqueViolation({ table: "users", column: "email" }));
+      }
+    }
+    this.users.set(user.id, user);
+    return Effect.succeed(true);
+  }
+
+  // Schema: wallets.user_id, auth_identities.user_id, sessions.user_id
+  // all FK to users with ON DELETE CASCADE. Deleting a user must
+  // remove the dependents in the same call.
+  public deleteUser(id: UserId): boolean {
+    if (!this.users.has(id)) return false;
+    this.users.delete(id);
+    for (const [walletId, w] of this.wallets) {
+      if (w.userId === id) this.wallets.delete(walletId);
+    }
+    for (const [subject, identity] of this.authIdentities) {
+      if (identity.userId === id) this.authIdentities.delete(subject);
+    }
+    for (const [sid, s] of this.sessions) {
+      if (s.userId === id) this.sessions.delete(sid);
+    }
+    return true;
+  }
+
+  // ── todos (no FK to users in the current schema) ───────────────
+  public insertTodo(todo: Todo): void {
+    this.todos.set(todo.id, todo);
+  }
+
+  public updateTodo(todo: Todo): boolean {
+    if (!this.todos.has(todo.id)) return false;
+    this.todos.set(todo.id, todo);
+    return true;
+  }
+
+  public deleteTodo(id: TodoId): boolean {
+    return this.todos.delete(id);
+  }
+
+  // ── wallets ────────────────────────────────────────────────────
+  public insertWallet(wallet: Wallet): Effect.Effect<void, UniqueViolation | ForeignKeyViolation> {
+    if (this.enforceFks && !this.users.has(wallet.userId)) {
+      return Effect.fail(new ForeignKeyViolation({ table: "wallets", column: "user_id" }));
+    }
+    for (const existing of this.wallets.values()) {
+      if (existing.userId === wallet.userId) {
+        return Effect.fail(new UniqueViolation({ table: "wallets", column: "user_id" }));
+      }
+    }
+    this.wallets.set(wallet.id, wallet);
+    return Effect.void;
+  }
+
+  // ── auth identities ────────────────────────────────────────────
+  public insertAuthIdentity(identity: AuthIdentity): Effect.Effect<void, ForeignKeyViolation> {
+    if (this.enforceFks && !this.users.has(identity.userId)) {
+      return Effect.fail(new ForeignKeyViolation({ table: "auth_identities", column: "user_id" }));
+    }
+    this.authIdentities.set(identity.subject, identity);
+    return Effect.void;
+  }
+
+  // ── sessions ───────────────────────────────────────────────────
+  public insertSession(session: Session): Effect.Effect<void, ForeignKeyViolation> {
+    if (this.enforceFks && !this.users.has(session.userId)) {
+      return Effect.fail(new ForeignKeyViolation({ table: "sessions", column: "user_id" }));
+    }
+    this.sessions.set(session.id, session);
+    return Effect.void;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// FakeDatabase as a Layer-provided service.
+//
+// Repository fakes that want to participate in the shared-state
+// model construct from `FakeDatabase` via `Layer.effect`. Tests can
+// use `FakeDatabaseLive` to get a fresh instance per scope, or
+// pre-build one and use `Layer.succeed(FakeDatabase, db)` to seed
+// state before any repo is built.
+// ──────────────────────────────────────────────────────────────────
+export class FakeDatabaseTag extends Context.Tag("@org/test-utils/FakeDatabase")<
+  FakeDatabaseTag,
+  FakeDatabase
+>() {}
+
+export const FakeDatabaseLive: Layer.Layer<FakeDatabaseTag> = Layer.effect(
+  FakeDatabaseTag,
+  Effect.sync(() => new FakeDatabase()),
+);
+
+// Per-module fake repositories layer over this one. FK checks are
+// off so use-case unit tests work in isolation without seeding
+// users for every session/wallet/auth-identity insert. The behavior
+// contract suite and `FakeRepositoriesLive` use the strict default
+// instead.
+export const FakeDatabaseRelaxedLive: Layer.Layer<FakeDatabaseTag> = Layer.effect(
+  FakeDatabaseTag,
+  Effect.sync(() => new FakeDatabase({ enforceFks: false })),
+);

--- a/packages/server/src/test-utils/fake-repositories.ts
+++ b/packages/server/src/test-utils/fake-repositories.ts
@@ -1,0 +1,36 @@
+// One-stop composition: every `*RepositoryFakeShared` Layer wired
+// over a single `FakeDatabaseLive`. Use this in the behavior
+// contract suite, in `@org/test-backend`, or in any test that needs
+// cross-repo invariants (FK existence, cascade, unique indexes
+// spanning the schema) to be enforced consistently across repos.
+//
+// Backward compatibility: per-module `XxxRepositoryFake` exports
+// continue to bake in their own `FakeDatabaseLive` so existing
+// use-case unit tests (`Effect.provide(UserRepositoryFake)`) work
+// unchanged. They just don't share state across repos — which is
+// fine, since use-case tests rarely need to.
+
+import { AuthIdentityRepositoryFakeShared } from "@/modules/auth/infrastructure/auth-identity-repository-fake.js";
+import { SessionRepositoryFakeShared } from "@/modules/auth/infrastructure/session-repository-fake.js";
+import { TodosRepositoryFakeShared } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { UserRepositoryFakeShared } from "@/modules/user/infrastructure/user-repository-fake.js";
+import { WalletRepositoryFakeShared } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
+import * as Layer from "effect/Layer";
+import { FakeDatabaseLive, type FakeDatabaseTag } from "./fake-database.js";
+
+const SharedRepositoriesLive = Layer.mergeAll(
+  UserRepositoryFakeShared,
+  WalletRepositoryFakeShared,
+  TodosRepositoryFakeShared,
+  SessionRepositoryFakeShared,
+  AuthIdentityRepositoryFakeShared,
+);
+
+// All fake repos backed by a single `FakeDatabase`. `FakeDatabaseTag`
+// is re-exported in the success channel so tests can read/seed the
+// database directly via `Effect.flatMap(FakeDatabaseTag, ...)`.
+export const FakeRepositoriesLive: Layer.Layer<
+  Layer.Layer.Success<typeof SharedRepositoriesLive> | FakeDatabaseTag,
+  never,
+  never
+> = SharedRepositoriesLive.pipe(Layer.provideMerge(FakeDatabaseLive));

--- a/packages/server/src/test-utils/in-process-backend.test.ts
+++ b/packages/server/src/test-utils/in-process-backend.test.ts
@@ -1,0 +1,113 @@
+// Smoke test for the in-process backend. Drives one round-trip per
+// HTTP verb (GET / POST / PUT / DELETE) through the real backend
+// handlers over the FakeDatabase. Sized to catch wiring regressions,
+// not to be exhaustive — the per-handler contract is covered by the
+// existing endpoint integration tests.
+
+import { Api } from "@/api.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { startInProcessBackend } from "@/test-utils/in-process-backend.js";
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { TodosContract, UserContract } from "@org/contracts/api/Contracts";
+import { TodoId } from "@org/contracts/EntityIds";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { afterEach, beforeEach } from "vitest";
+
+const adminUserId = UserId.make("00000000-0000-0000-0000-000000000001");
+
+let backend: Awaited<ReturnType<typeof startInProcessBackend>>;
+
+beforeEach(async () => {
+  backend = await startInProcessBackend({
+    signedInAs: { userId: adminUserId },
+  });
+});
+
+afterEach(async () => {
+  await backend.dispose();
+});
+
+// Build the HttpApiClient wired to the in-process backend's fetch.
+const makeClient = () => {
+  const HttpClientLive = FetchHttpClient.layer.pipe(
+    Layer.provide(Layer.succeed(FetchHttpClient.Fetch, backend.fetch)),
+  );
+  return HttpApiClient.make(Api, { baseUrl: "http://in-process.test" }).pipe(
+    Effect.provide(HttpClientLive),
+  );
+};
+
+describe("startInProcessBackend — smoke", () => {
+  it.effect("POST /users creates a user the FakeDatabase can see", () =>
+    Effect.gen(function* () {
+      const client = yield* makeClient();
+
+      const result = yield* client.user.create({
+        payload: UserContract.CreateUserPayload.make({
+          email: "alice@example.com",
+          country: "USA",
+          street: "Main",
+          postalCode: "12345",
+        }),
+      });
+
+      // The response includes the new userId; the FakeDatabase has it.
+      const userId = UserId.make(result.id);
+      ok(backend.db.users.has(userId));
+    }),
+  );
+
+  it.effect("POST /todos then GET /todos round-trip returns the created todo", () =>
+    Effect.gen(function* () {
+      const client = yield* makeClient();
+
+      const created = yield* client.todos.create({
+        payload: TodosContract.CreateTodoPayload.make({ title: "Buy milk" }),
+      });
+      ok(created.title === "Buy milk");
+
+      const list = yield* client.todos.get();
+      const titles = list.map((t) => t.title);
+      ok(titles.includes("Buy milk"));
+    }),
+  );
+
+  it.effect("PUT /todos/:id updates the todo via the real handler", () =>
+    Effect.gen(function* () {
+      const client = yield* makeClient();
+
+      const created = yield* client.todos.create({
+        payload: TodosContract.CreateTodoPayload.make({ title: "Old title" }),
+      });
+
+      const updated = yield* client.todos.update({
+        payload: TodosContract.UpdateTodoPayload.make({
+          id: TodoId.make(created.id),
+          title: "New title",
+          completed: true,
+        }),
+      });
+      deepStrictEqual(updated.title, "New title");
+      deepStrictEqual(updated.completed, true);
+    }),
+  );
+
+  it.effect("DELETE /todos/:id removes the todo from the FakeDatabase", () =>
+    Effect.gen(function* () {
+      const client = yield* makeClient();
+
+      const created = yield* client.todos.create({
+        payload: TodosContract.CreateTodoPayload.make({ title: "To be deleted" }),
+      });
+      const id = TodoId.make(created.id);
+      ok(backend.db.todos.has(id));
+
+      yield* client.todos.delete({ payload: id });
+      ok(!backend.db.todos.has(id));
+    }),
+  );
+});

--- a/packages/server/src/test-utils/in-process-backend.ts
+++ b/packages/server/src/test-utils/in-process-backend.ts
@@ -16,24 +16,29 @@
 
 import { Api } from "@/api.js";
 import { EnvVars } from "@/common/env-vars.js";
-import { authCommandHandlers, authQueryHandlers } from "@/modules/auth/index.js";
+// Bypass the per-module `index.js` barrels and import the bits we
+// actually use directly. The barrels re-export `XxxModuleLive` which
+// transitively pulls in `XxxRepositoryLive` → `@org/database` —
+// loading that would force a database dependency even though
+// in-process tests never reach it.
+import { authCommandHandlers } from "@/modules/auth/commands/auth-command-handlers.js";
 import { AuthIdentityRepositoryFakeShared } from "@/modules/auth/infrastructure/auth-identity-repository-fake.js";
 import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
 import { SessionRepositoryFakeShared } from "@/modules/auth/infrastructure/session-repository-fake.js";
 import { AuthHttpLive } from "@/modules/auth/interface/auth-http-live.js";
-import { todoCommandHandlers, todoQueryHandlers } from "@/modules/todos/index.js";
+import { authQueryHandlers } from "@/modules/auth/queries/auth-query-handlers.js";
+import { todoCommandHandlers } from "@/modules/todos/commands/todo-command-handlers.js";
 import { TodosRepositoryFakeShared } from "@/modules/todos/infrastructure/todos-repository-fake.js";
 import { TodosHttpLive } from "@/modules/todos/interface/todos-http-live.js";
-import {
-  userCommandHandlers,
-  userEventSpanAttributes,
-  userQueryHandlers,
-} from "@/modules/user/index.js";
+import { todoQueryHandlers } from "@/modules/todos/queries/todo-query-handlers.js";
+import { userCommandHandlers } from "@/modules/user/commands/user-command-handlers.js";
 import { UserRepositoryFakeShared } from "@/modules/user/infrastructure/user-repository-fake.js";
 import { UserHttpLive } from "@/modules/user/interface/user-http-live.js";
+import { userQueryHandlers } from "@/modules/user/queries/user-query-handlers.js";
+import { userEventSpanAttributes } from "@/modules/user/user-event-span-attributes.js";
 import { UserEventAdapterLive } from "@/modules/wallet/event-handlers/user-event-adapter.js";
-import { walletEventSpanAttributes } from "@/modules/wallet/index.js";
 import { WalletRepositoryFakeShared } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
+import { walletEventSpanAttributes } from "@/modules/wallet/wallet-event-span-attributes.js";
 import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 import { PermissionsResolver } from "@/platform/auth/permissions-resolver.js";
 import { CommandBus, makeCommandBus } from "@/platform/command-bus.js";

--- a/packages/server/src/test-utils/in-process-backend.ts
+++ b/packages/server/src/test-utils/in-process-backend.ts
@@ -1,0 +1,277 @@
+// In-process backend harness. Builds the real HTTP handlers from
+// `@/api.js` over the FakeDatabase + per-service fakes, exposes a
+// `fetch`-shaped function that resolves inside this process via
+// `HttpApiBuilder.toWebHandler`, plus direct programmatic access to
+// the underlying state (db, events, clock, auth control).
+//
+// This is the foundation of the integration testing tier from the
+// remediation plan §8. FE tests (in `@org/web`) wire their
+// `ApiClient` to this `fetch` function and exercise the real
+// presenter + data-access + backend handlers in a single process —
+// no port, no socket, no child process, no schema duplication.
+//
+// Per ADR-0019, the isomorphic stack is what makes this possible:
+// the backend handlers ARE the simulator. No drift hazard, no
+// hand-written fakes that lag the real handlers' evolution.
+
+import { Api } from "@/api.js";
+import { EnvVars } from "@/common/env-vars.js";
+import { authCommandHandlers, authQueryHandlers } from "@/modules/auth/index.js";
+import { AuthIdentityRepositoryFakeShared } from "@/modules/auth/infrastructure/auth-identity-repository-fake.js";
+import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
+import { SessionRepositoryFakeShared } from "@/modules/auth/infrastructure/session-repository-fake.js";
+import { AuthHttpLive } from "@/modules/auth/interface/auth-http-live.js";
+import { todoCommandHandlers, todoQueryHandlers } from "@/modules/todos/index.js";
+import { TodosRepositoryFakeShared } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { TodosHttpLive } from "@/modules/todos/interface/todos-http-live.js";
+import {
+  userCommandHandlers,
+  userEventSpanAttributes,
+  userQueryHandlers,
+} from "@/modules/user/index.js";
+import { UserRepositoryFakeShared } from "@/modules/user/infrastructure/user-repository-fake.js";
+import { UserHttpLive } from "@/modules/user/interface/user-http-live.js";
+import { UserEventAdapterLive } from "@/modules/wallet/event-handlers/user-event-adapter.js";
+import { walletEventSpanAttributes } from "@/modules/wallet/index.js";
+import { WalletRepositoryFakeShared } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
+import { CookieCodec } from "@/platform/auth/cookie-codec.js";
+import { PermissionsResolver } from "@/platform/auth/permissions-resolver.js";
+import { CommandBus, makeCommandBus } from "@/platform/command-bus.js";
+import { makeDomainEventBusLive } from "@/platform/domain-event-bus.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+import { makeQueryBus, QueryBus } from "@/platform/query-bus.js";
+import { IdentityTransactionRunner } from "@/test-utils/identity-transaction-runner.js";
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+import * as HttpServer from "@effect/platform/HttpServer";
+import { type Permission, UserAuthMiddleware } from "@org/contracts/Policy";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as LogLevel from "effect/LogLevel";
+import * as Ref from "effect/Ref";
+import { FakeDatabaseServiceLive } from "./fake-database-service.js";
+import { FakeDatabase, FakeDatabaseTag } from "./fake-database.js";
+
+// ──────────────────────────────────────────────────────────────────
+// Auth control surface — lets FE tests sign in as any user without
+// running the OIDC dance. Holds a Ref of "currently authenticated"
+// state; the in-process middleware reads it for every request.
+// ──────────────────────────────────────────────────────────────────
+export type AuthControl = {
+  readonly signInAs: (user: {
+    readonly userId: UserId;
+    readonly permissions?: Set<Permission>;
+  }) => void;
+  readonly signOut: () => void;
+};
+
+type AuthState = {
+  readonly userId: UserId;
+  readonly permissions: Set<Permission>;
+} | null;
+
+const makeAuthMiddleware = (stateRef: Ref.Ref<AuthState>) =>
+  Layer.succeed(
+    UserAuthMiddleware,
+    Effect.flatMap(Ref.get(stateRef), (state) => {
+      if (state === null) {
+        return Effect.die("TestBackend: no signed-in user (call backend.auth.signInAs first)");
+      }
+      return Effect.succeed({
+        sessionId: "test-session",
+        userId: state.userId,
+        permissions: state.permissions,
+      });
+    }),
+  );
+
+// ──────────────────────────────────────────────────────────────────
+// Layer composition. Mirrors `test-server.ts` but:
+//   - swaps the live repositories for the FK-enforcing Shared fakes,
+//   - swaps `AuthSharedDepsLive` for a layer that doesn't need
+//     Postgres,
+//   - swaps the real auth middleware for our state-Ref-driven one.
+//
+// Everything else (CommandBus, QueryBus, DomainEventBus, the HTTP
+// modules) is exactly what production runs.
+// ──────────────────────────────────────────────────────────────────
+const CommandBusLive = Layer.succeed(
+  CommandBus,
+  makeCommandBus({ ...userCommandHandlers, ...todoCommandHandlers, ...authCommandHandlers }),
+);
+const QueryBusLive = Layer.succeed(
+  QueryBus,
+  makeQueryBus({ ...userQueryHandlers, ...todoQueryHandlers, ...authQueryHandlers }),
+);
+const DomainEventBusLive = makeDomainEventBusLive({
+  spanAttributes: { ...userEventSpanAttributes, ...walletEventSpanAttributes },
+});
+
+const FakeRepositoriesShared = Layer.mergeAll(
+  UserRepositoryFakeShared,
+  WalletRepositoryFakeShared,
+  TodosRepositoryFakeShared,
+  SessionRepositoryFakeShared,
+  AuthIdentityRepositoryFakeShared,
+);
+
+// In-process auth-infra wiring. Production layers
+// `AuthSharedDepsLive` (CookieCodec + SessionRepositoryLive), but
+// SessionRepository is supplied here by the fake repository umbrella
+// and CookieCodec needs EnvVars (HMAC secret) we don't want to wire
+// in tests. The FE never carries a session cookie in this tier — the
+// `FakeAuthMiddleware` bypasses verification — so a stub that always
+// rejects is sufficient to satisfy the auth module's typecheck.
+const CookieCodecStub = Layer.succeed(
+  CookieCodec,
+  CookieCodec.of({
+    sign: (id: string) => `${id}.stub`,
+    verify: () => null,
+  } as unknown as Context.Tag.Service<typeof CookieCodec>),
+);
+
+// OidcClient is used by the auth module's login + callback paths,
+// neither of which are driven from in-process tests (the
+// FakeAuthMiddleware bypasses the OIDC dance via
+// `backend.auth.signInAs`). Stub everything to die so any accidental
+// reach into these paths produces a clear test-side failure.
+const OidcClientStub = Layer.succeed(
+  OidcClient,
+  OidcClient.of({
+    authorize: () => Effect.die("OidcClient not wired in in-process backend"),
+    exchangeCode: () => Effect.die("OidcClient not wired in in-process backend"),
+    revokeRefreshToken: () => Effect.die("OidcClient not wired in in-process backend"),
+    revokeSession: () => Effect.die("OidcClient not wired in in-process backend"),
+  } as unknown as Context.Tag.Service<typeof OidcClient>),
+);
+
+// EnvVars.Default reads via `Config.redacted("DATABASE_URL")` etc.
+// None of those vars need real values in the in-process backend
+// (the consumers — CookieCodec, OIDC client, real Database layer —
+// are replaced or never reached). Override the global ConfigProvider
+// with a map containing benign placeholders so `EnvVars.Default`
+// boots without `DATABASE_URL` set in process.env.
+const InProcessConfig = ConfigProvider.fromMap(
+  new Map<string, string>([
+    ["DATABASE_URL", "postgresql://in-process/test"],
+    ["ZITADEL_ISSUER", "http://localhost:8080"],
+    ["ZITADEL_CLIENT_ID", "in-process"],
+    ["ZITADEL_CLIENT_SECRET", "in-process"],
+    ["SESSION_COOKIE_SECRET", "in-process-secret"],
+  ]),
+);
+const InProcessConfigLayer = Layer.setConfigProvider(InProcessConfig);
+const buildInProcessBackend = (db: FakeDatabase, authStateRef: Ref.Ref<AuthState>) => {
+  const FakeDatabaseFixedLive = Layer.succeed(FakeDatabaseTag, db);
+  const FakeAuthMiddleware = makeAuthMiddleware(authStateRef);
+
+  // We compose the HTTP groups + the wallet event adapter directly
+  // (not via per-module `XxxModuleLive`), so we can swap the Live
+  // repositories that each module bakes in for the Shared fakes.
+  // The OidcClient is omitted entirely — the FakeAuthMiddleware
+  // bypasses the OIDC dance and `/auth/login` / `/auth/callback`
+  // are not driven from in-process tests.
+  const ApiLive = HttpApiBuilder.api(Api).pipe(
+    Layer.provide([TodosHttpLive, UserHttpLive, AuthHttpLive, UserEventAdapterLive]),
+    Layer.provide([FakeAuthMiddleware, DomainEventBusLive, IdentityTransactionRunner]),
+    Layer.provideMerge(Layer.mergeAll(CommandBusLive, QueryBusLive)),
+    Layer.provide(PermissionsResolver.Default),
+    Layer.provide(CookieCodecStub),
+    Layer.provide(OidcClientStub),
+    Layer.provide(FakeRepositoriesShared),
+    // PermissionsResolver and the read-side query handlers consume
+    // `Database.Database`. Provide a fake backed by the same
+    // FakeDatabase the repos use so read paths return rows that
+    // reflect mutations made via the FE.
+    Layer.provide(FakeDatabaseServiceLive(db)),
+    Layer.provide(FakeDatabaseFixedLive),
+    Layer.provide(EnvVars.Default),
+    Layer.provide(InProcessConfigLayer),
+    // Mirror server defaults: log warnings/errors to console so
+    // in-process handler failures surface in test output instead of
+    // being swallowed as opaque 500s.
+    Layer.provide(Logger.minimumLogLevel(LogLevel.Warning)),
+  );
+
+  return ApiLive;
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Public handle: what tests interact with.
+// ──────────────────────────────────────────────────────────────────
+export type InProcessBackend = {
+  // Front door — what the FE's ApiClient consumes. Same signature
+  // as window.fetch; the call terminates inside this process via
+  // HttpApiBuilder.toWebHandler.
+  readonly fetch: typeof fetch;
+
+  // Service door — direct programmatic access to internals.
+  readonly db: FakeDatabase;
+  readonly events: ReadonlyArray<unknown>; // populated by RecordingEventBus (future)
+  readonly auth: AuthControl;
+
+  readonly dispose: () => Promise<void>;
+};
+
+export type StartOptions = {
+  readonly seed?: (db: FakeDatabase) => void;
+  readonly signedInAs?: {
+    readonly userId: UserId;
+    readonly permissions?: Set<Permission>;
+  };
+};
+
+const DEFAULT_PERMISSIONS = new Set<Permission>(["__test:read", "__test:manage", "__test:delete"]);
+
+export const startInProcessBackend = async (opts: StartOptions = {}): Promise<InProcessBackend> => {
+  const db = new FakeDatabase();
+  if (opts.seed !== undefined) opts.seed(db);
+
+  const initialAuth: AuthState =
+    opts.signedInAs !== undefined
+      ? {
+          userId: opts.signedInAs.userId,
+          permissions: opts.signedInAs.permissions ?? DEFAULT_PERMISSIONS,
+        }
+      : null;
+  const authStateRef = Effect.runSync(Ref.make<AuthState>(initialAuth));
+
+  const ApiLive = buildInProcessBackend(db, authStateRef);
+
+  // `toWebHandler` builds the actual `(Request) => Promise<Response>`
+  // function. It expects a Layer providing `HttpApi.Api` and the
+  // HttpRouter DefaultServices (HttpPlatform / FileSystem / Path /
+  // Generator) — `HttpServer.layerContext` supplies the latter.
+  const { dispose, handler } = HttpApiBuilder.toWebHandler(
+    Layer.mergeAll(ApiLive, HttpServer.layerContext),
+  );
+
+  const auth: AuthControl = {
+    signInAs: (user) => {
+      Effect.runSync(
+        Ref.set(authStateRef, {
+          userId: user.userId,
+          permissions: user.permissions ?? DEFAULT_PERMISSIONS,
+        }),
+      );
+    },
+    signOut: () => {
+      Effect.runSync(Ref.set(authStateRef, null));
+    },
+  };
+
+  const fetchFn: typeof fetch = async (input, init) => {
+    const request = new Request(input, init);
+    return handler(request, Context.empty());
+  };
+
+  return {
+    fetch: fetchFn,
+    db,
+    events: [],
+    auth,
+    dispose,
+  };
+};

--- a/packages/server/src/test-utils/repository-behavior/cross-repository-invariants.contract.ts
+++ b/packages/server/src/test-utils/repository-behavior/cross-repository-invariants.contract.ts
@@ -1,0 +1,147 @@
+// Cross-repository invariants — behaviors that span more than one
+// table and are owned by the schema, not any single repository. The
+// suite is parameterized over a fully-closed Layer (all repos) plus
+// a reset effect and a wallet-count inspector that abstract over
+// the "look in a Map" (fake) vs "SELECT FROM wallets" (live) split.
+//
+// Scope discipline (remediation plan §7.2): we exercise only the
+// invariants production code depends on or could regress against:
+//   - users.email UNIQUE
+//   - wallets.user_id UNIQUE + FK → users
+//   - sessions.user_id FK → users + ON DELETE CASCADE
+//   - auth_identities.user_id FK → users + ON DELETE CASCADE
+//
+// Out of scope: query planner behavior, advisory locks, trigger
+// semantics, isolation levels. The fake is serializable-by-
+// construction; the live tier inherits Postgres semantics.
+
+import { SessionId } from "@/modules/auth/domain/session-id.js";
+import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
+import { Session } from "@/modules/auth/domain/session.aggregate.js";
+import type { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
+import { UserAlreadyExists } from "@/modules/user/domain/user-errors.js";
+import { UserRepository } from "@/modules/user/domain/user-repository.js";
+import * as User from "@/modules/user/domain/user.aggregate.js";
+import { Address } from "@/modules/user/domain/value-objects/address.js";
+import { WalletAlreadyExistsForUser } from "@/modules/wallet/domain/wallet-errors.js";
+import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
+import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import type * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
+const bobId = UserId.make("22222222-2222-2222-2222-222222222222");
+const walletAId = WalletId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const walletBId = WalletId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+const address = Address.make({ country: "USA", street: "Main", postalCode: "12345" });
+
+const makeUser = (id: UserId, email: string) => User.create({ id, email, address, now }).user;
+
+const makeWallet = (id: WalletId, userId: UserId) => Wallet.create({ id, userId, now }).wallet;
+
+// Aliases for legibility — `RepoSet` is what every consumer must
+// provide at minimum. The inspector and reset effects must require
+// no additional services (they bake in their own dependencies via
+// the layer or closures the caller constructs).
+type RepoSet = UserRepository | WalletRepository | SessionRepository | TodosRepository;
+
+export type CrossRepositoryInvariantsOptions = {
+  readonly name: string;
+  readonly layer: Layer.Layer<RepoSet>;
+  readonly reset: Effect.Effect<void>;
+  readonly inspectWalletCountForUser: (userId: UserId) => Effect.Effect<number>;
+};
+
+export const crossRepositoryInvariantsSuite = (opts: CrossRepositoryInvariantsOptions) =>
+  describe(`Cross-repository invariants (${opts.name})`, () => {
+    it.effect("users.email is unique — second insert fails UserAlreadyExists", () =>
+      Effect.gen(function* () {
+        yield* opts.reset;
+        const users = yield* UserRepository;
+        yield* users.insert(makeUser(aliceId, "alice@example.com"));
+
+        const exit = yield* Effect.exit(users.insert(makeUser(bobId, "alice@example.com")));
+        ok(Exit.isFailure(exit));
+        if (Exit.isFailure(exit)) {
+          const failure = exit.cause._tag === "Fail" ? (exit.cause.error as unknown) : null;
+          ok(failure instanceof UserAlreadyExists);
+        }
+      }).pipe(Effect.provide(opts.layer)),
+    );
+
+    it.effect("wallets.user_id is unique — second insert for the same user fails", () =>
+      Effect.gen(function* () {
+        yield* opts.reset;
+        const users = yield* UserRepository;
+        const wallets = yield* WalletRepository;
+        yield* users.insert(makeUser(aliceId, "alice@example.com"));
+        yield* wallets.insert(makeWallet(walletAId, aliceId));
+
+        const exit = yield* Effect.exit(wallets.insert(makeWallet(walletBId, aliceId)));
+        ok(Exit.isFailure(exit));
+        if (Exit.isFailure(exit)) {
+          const failure = exit.cause._tag === "Fail" ? (exit.cause.error as unknown) : null;
+          ok(failure instanceof WalletAlreadyExistsForUser);
+        }
+      }).pipe(Effect.provide(opts.layer)),
+    );
+
+    it.effect(
+      "deleting a user cascades to wallets (ON DELETE CASCADE) — the wallet is removed",
+      () =>
+        Effect.gen(function* () {
+          yield* opts.reset;
+          const users = yield* UserRepository;
+          const wallets = yield* WalletRepository;
+
+          yield* users.insert(makeUser(aliceId, "alice@example.com"));
+          yield* wallets.insert(makeWallet(walletAId, aliceId));
+
+          const beforeCount = yield* opts.inspectWalletCountForUser(aliceId);
+          deepStrictEqual(beforeCount, 1);
+
+          yield* users.remove(aliceId);
+
+          const afterCount = yield* opts.inspectWalletCountForUser(aliceId);
+          deepStrictEqual(afterCount, 0);
+
+          // Also unreachable via the public read.
+          const lookup = yield* wallets.findByUserId(aliceId);
+          ok(Option.isNone(lookup));
+        }).pipe(Effect.provide(opts.layer)),
+    );
+
+    it.effect("inserting a session for a non-existent user is rejected (FK enforcement)", () =>
+      Effect.gen(function* () {
+        yield* opts.reset;
+        const sessions = yield* SessionRepository;
+
+        const sessionId = SessionId.make("ccccccc1-cccc-cccc-cccc-cccccccccccc");
+        const session = Session.make({
+          id: sessionId,
+          userId: aliceId,
+          subject: "unknown-subject",
+          expiresAt: DateTime.add(now, { seconds: 3600 }),
+          absoluteExpiresAt: DateTime.add(now, { seconds: 43200 }),
+          revokedAt: null,
+          createdAt: now,
+          lastUsedAt: now,
+        });
+
+        const exit = yield* Effect.exit(sessions.insert(session));
+        // Either a typed Fail or a Die — both communicate "this
+        // can't happen at runtime"; the contract is that production
+        // code (which always inserts users in the same transaction)
+        // never sees a successful FK-violating session insert.
+        ok(Exit.isFailure(exit));
+      }).pipe(Effect.provide(opts.layer)),
+    );
+  });

--- a/packages/server/src/test-utils/repository-behavior/cross-repository-invariants.integration.test.ts
+++ b/packages/server/src/test-utils/repository-behavior/cross-repository-invariants.integration.test.ts
@@ -1,0 +1,113 @@
+// Runs the cross-repository invariants contract suite against:
+//
+//   1. `FakeRepositoriesLive` — always. Proves the FakeDatabase's
+//      enforcement of unique indexes, FK existence, and cascade
+//      delete matches the schema's documented behavior.
+//
+//   2. A live composition over Postgres — gated on
+//      `DATABASE_URL_TEST`. Proves the schema actually behaves the
+//      way the fake's contract claims. If these two diverge, either
+//      the schema regressed or the fake is lying.
+//
+// File naming: `.integration.test.ts` because the live tier runs SQL.
+// On a no-DB machine, vitest will still run the fake suite — the
+// describe block guarded by `hasTestDatabase` simply skips.
+
+import { AuthIdentityRepositoryFakeShared } from "@/modules/auth/infrastructure/auth-identity-repository-fake.js";
+import { SessionRepositoryFakeShared } from "@/modules/auth/infrastructure/session-repository-fake.js";
+import { SessionRepositoryLive } from "@/modules/auth/infrastructure/session-repository-live.js";
+import { TodosRepositoryFakeShared } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
+import { UserRepositoryFakeShared } from "@/modules/user/infrastructure/user-repository-fake.js";
+import { UserRepositoryLive } from "@/modules/user/infrastructure/user-repository-live.js";
+import { WalletRepositoryFakeShared } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
+import { WalletRepositoryLive } from "@/modules/wallet/infrastructure/wallet-repository-live.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+import { FakeDatabase, FakeDatabaseTag } from "@/test-utils/fake-database.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { Database, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { crossRepositoryInvariantsSuite } from "./cross-repository-invariants.contract.js";
+
+// ─── Fake wiring ──────────────────────────────────────────────────
+// A single FakeDatabase instance shared by every repo in the suite,
+// captured here so the `reset` and `inspect` effects can mutate /
+// read the same Maps the repositories see.
+const fakeDatabaseInstance = new FakeDatabase();
+const FakeDatabaseFixedLive = Layer.succeed(FakeDatabaseTag, fakeDatabaseInstance);
+
+const FakeRepositoriesShared = Layer.mergeAll(
+  UserRepositoryFakeShared,
+  WalletRepositoryFakeShared,
+  TodosRepositoryFakeShared,
+  SessionRepositoryFakeShared,
+  AuthIdentityRepositoryFakeShared,
+);
+
+const FakeLayer = FakeRepositoriesShared.pipe(Layer.provide(FakeDatabaseFixedLive));
+
+const fakeReset = Effect.sync(() => {
+  fakeDatabaseInstance.users.clear();
+  fakeDatabaseInstance.wallets.clear();
+  fakeDatabaseInstance.todos.clear();
+  fakeDatabaseInstance.sessions.clear();
+  fakeDatabaseInstance.authIdentities.clear();
+});
+
+const fakeInspectWalletCountForUser = (userId: UserId) =>
+  Effect.sync(() => {
+    let count = 0;
+    for (const wallet of fakeDatabaseInstance.wallets.values()) {
+      if (wallet.userId === userId) count += 1;
+    }
+    return count;
+  });
+
+crossRepositoryInvariantsSuite({
+  name: "FakeDatabase",
+  layer: FakeLayer,
+  reset: fakeReset,
+  inspectWalletCountForUser: fakeInspectWalletCountForUser,
+});
+
+// ─── Live wiring ──────────────────────────────────────────────────
+// Skipped without DATABASE_URL_TEST. Schema invariants are exercised
+// against real Postgres so the fake's claims about UNIQUE / FK /
+// CASCADE behavior can't silently drift from the migrations.
+if (hasTestDatabase) {
+  const LiveRepoLayer = Layer.mergeAll(
+    UserRepositoryLive,
+    WalletRepositoryLive,
+    TodosRepositoryLive,
+    SessionRepositoryLive,
+  );
+  // A DB connection failure is an environment defect, not a typed
+  // contract failure; orDie keeps the contract type (`Layer<..., never>`)
+  // satisfied while preserving the original cause in the defect.
+  const LiveLayer = LiveRepoLayer.pipe(Layer.provideMerge(TestDatabaseLive), Layer.orDie);
+
+  const liveReset = truncate("wallets", "sessions", "auth_identities", "users", "todos");
+
+  const CountStd = Schema.standardSchemaV1(Schema.Struct({ value: Schema.Number }));
+  const liveInspectWalletCountForUser = (userId: UserId) =>
+    Effect.gen(function* () {
+      const db = yield* Database.Database;
+      const row = yield* db
+        .execute((c) =>
+          c.one(sql.type(CountStd)`
+            SELECT COUNT(*)::int AS value FROM wallets WHERE user_id = ${userId}
+          `),
+        )
+        .pipe(Effect.orDie);
+      return row.value;
+    }).pipe(Effect.provide(TestDatabaseLive), Effect.orDie);
+
+  crossRepositoryInvariantsSuite({
+    name: "LiveDatabase",
+    layer: LiveLayer,
+    reset: liveReset.pipe(Effect.provide(TestDatabaseLive), Effect.orDie),
+    inspectWalletCountForUser: liveInspectWalletCountForUser,
+  });
+}

--- a/packages/test-backend/package.json
+++ b/packages/test-backend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@org/test-backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "description": "In-process backend harness for FE integration tests. Re-exports @org/server/test-utils/in-process-backend over a workspace boundary so @org/web's test code doesn't deep-import server internals.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc -b tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --quiet"
+  },
+  "dependencies": {
+    "@org/contracts": "workspace:^",
+    "@org/server": "workspace:^",
+    "effect": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/test-backend/src/index.ts
+++ b/packages/test-backend/src/index.ts
@@ -1,0 +1,27 @@
+// `@org/test-backend` — the public surface FE integration tests
+// import. The actual implementation lives in
+// `@org/server/test-utils/in-process-backend.ts` so it has direct
+// access to the modules, repositories, and platform services it
+// composes.
+//
+// This package re-exports the bits the FE side needs. It's marked
+// `private` and is only consumed as a devDependency by `@org/web`.
+//
+// Per ADR-0019 (isomorphic stack commitment), this package is the
+// realization of the in-process integration tier: same runtime,
+// same contracts, no codegen, no parallel fakes.
+
+export {
+  startInProcessBackend,
+  type AuthControl,
+  type InProcessBackend,
+  type StartOptions,
+} from "@org/server/test-utils/in-process-backend";
+
+export {
+  FakeDatabase,
+  FakeDatabaseTag,
+  ForeignKeyViolation,
+  UniqueViolation,
+  type FakeDatabaseOptions,
+} from "@org/server/test-utils/fake-database";

--- a/packages/test-backend/tsconfig.json
+++ b/packages/test-backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@org/server/test-utils/*": ["../server/src/test-utils/*.js"],
+      "@org/server/*": ["../server/src/*.js"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  }
+}

--- a/packages/test-drivers/package.json
+++ b/packages/test-drivers/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@org/test-drivers",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "description": "Tier-agnostic page driver contracts + per-tier adapters (Playwright for acceptance, React Testing Library for in-process integration). The contract is expressed in business intent (createUser, expectUserInList) so the same spec body runs at multiple tiers.",
+  "exports": {
+    "./contracts/*": "./src/contracts/*.ts",
+    "./adapters/playwright/*": "./src/adapters/playwright/*.ts",
+    "./adapters/rtl/*": "./src/adapters/rtl/*.ts"
+  },
+  "scripts": {
+    "check": "tsc -b tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --quiet"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    },
+    "@testing-library/react": {
+      "optional": true
+    },
+    "@testing-library/user-event": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.6.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/test-drivers/src/README.md
+++ b/packages/test-drivers/src/README.md
@@ -1,0 +1,57 @@
+# `@org/test-drivers` — tier-agnostic page drivers
+
+Each driver speaks **business intent** (`createUser`,
+`expectUserInList`) at **user-perceivable granularity** (visible text,
+ARIA roles, presence/absence). The same set of methods is implemented
+at every test tier.
+
+## Setup-context tiers
+
+The driver is tier-agnostic. The **setup** context is not — that's
+the divergence point between integration and acceptance.
+
+| Tier        | Setup context              | What "seed" / "control" means                                                              |
+| ----------- | -------------------------- | ------------------------------------------------------------------------------------------ |
+| Presenter   | Layer-substituted services | Pre-seed the `FakeApiClient`; recording fakes for assertions.                              |
+| Integration | `TestBackend` handle       | Direct reference to `backend.db`, `backend.events`; fake auth via `backend.auth.signInAs`. |
+| Acceptance  | Real backend, real DB      | Seed via real HTTP endpoints (API arrangement), Stripe test cards, Zitadel test users.     |
+
+## Worked example: `createUser`
+
+Same scenario, three tiers, same driver methods:
+
+```ts
+// Presenter (packages/web/features/users/create-user/*.presenter.test.ts)
+const driver = rtlUsersDriver(
+  render(<CreateUser />, { wrapper: presenterHarness.wrapper }),
+  { getToasts: presenterHarness.getToasts },
+);
+await driver.createUser(validPayload);
+await driver.expectToast("success", "User created!");
+
+// Integration (packages/web/test/integration/create-user.test.tsx)
+const backend = await startInProcessBackend({ signedInAs: { userId: adminId } });
+const harness = makeIntegrationHarness({ transport: backend.fetch });
+const driver = rtlUsersDriver(
+  render(<UsersPage />, { wrapper: harness.wrapper }),
+  { getToasts: harness.getToasts },
+);
+await driver.goto();
+await driver.createUser(validPayload);
+await driver.expectUserInList(validPayload.email);
+expect(backend.db.wallets.size).toBe(1); // wallet auto-created via real event handler
+
+// Acceptance (packages/acceptance/specs/add-user.spec.ts)
+const driver = playwrightUsersDriver(page);
+await driver.goto();
+await driver.createUser(validPayload);
+await driver.expectUserInList(validPayload.email);
+```
+
+## Tier-ceiling acknowledgement
+
+Not every integration scenario is reproducible at the acceptance
+tier. If the setup requires "Stripe has previously declined this
+user 3 times in the last 30 days" or "the session is exactly 30 days
+old," the scenario stays at the integration tier. Don't build
+elaborate test-only production infrastructure to force promotion.

--- a/packages/test-drivers/src/adapters/playwright/users-page-driver.ts
+++ b/packages/test-drivers/src/adapters/playwright/users-page-driver.ts
@@ -1,0 +1,68 @@
+import { expect, type Page } from "@playwright/test";
+import type {
+  CreateUserField,
+  CreateUserInput,
+  ToastKind,
+  UsersPageDriver,
+} from "../../contracts/users-page-driver.js";
+
+// Field locators in one place so the contract methods stay
+// business-intent. Switch keeps each case exhaustive — adding a
+// CreateUserField member here would surface as a missing case.
+const fieldLocator = (page: Page, field: CreateUserField) => {
+  switch (field) {
+    case "email":
+      return page.getByTestId("create-user-email");
+    case "country":
+      return page.getByTestId("create-user-country");
+    case "street":
+      return page.getByTestId("create-user-street");
+    case "postalCode":
+      return page.getByTestId("create-user-postal-code");
+  }
+};
+
+export const playwrightUsersDriver = (page: Page): UsersPageDriver => {
+  const submit = page.getByTestId("create-user-submit");
+  const list = page.getByTestId("user-list");
+
+  return {
+    goto: async () => {
+      await page.goto("/users");
+      await expect(fieldLocator(page, "email")).toBeVisible();
+    },
+
+    createUser: async (input: CreateUserInput) => {
+      await fieldLocator(page, "email").fill(input.email);
+      await fieldLocator(page, "country").fill(input.country);
+      await fieldLocator(page, "street").fill(input.street);
+      await fieldLocator(page, "postalCode").fill(input.postalCode);
+      await submit.click();
+    },
+
+    expectUserInList: async (email: string) => {
+      await expect(
+        list.locator(`[data-testid="user-list-item"][data-user-email="${email}"]`),
+      ).toBeVisible();
+    },
+
+    expectFieldError: async (field: CreateUserField) => {
+      // Each input is wrapped in a Form.Control; the sibling
+      // Form.Error renders a span with the error message. The
+      // exact text varies per Schema rule, so we assert presence
+      // by walking up from the field's label.
+      const control = page.locator(`label[for="${field}"]`).locator("..");
+      await expect(control.locator("span.text-red-500")).toBeVisible();
+    },
+
+    expectToast: async (kind: ToastKind, message: string) => {
+      // sonner renders toasts as <li role="status"> elements under
+      // a region. Assert by text + role; sonner doesn't carry a
+      // stable kind attribute we can pivot on at this tier, so the
+      // `kind` parameter is documentation-only here.
+      const toast = page.getByRole("status").filter({ hasText: message });
+      await expect(toast).toBeVisible();
+      void kind;
+    },
+  };
+};

--- a/packages/test-drivers/src/adapters/rtl/users-page-driver.ts
+++ b/packages/test-drivers/src/adapters/rtl/users-page-driver.ts
@@ -1,0 +1,96 @@
+import { type RenderResult, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import type {
+  CreateUserField,
+  CreateUserInput,
+  ToastKind,
+  UsersPageDriver,
+} from "../../contracts/users-page-driver.js";
+
+const testIdByField: Record<CreateUserField, string> = {
+  email: "create-user-email",
+  country: "create-user-country",
+  street: "create-user-street",
+  postalCode: "create-user-postal-code",
+};
+
+type ToastQuery = {
+  readonly getToasts: () => Promise<
+    ReadonlyArray<{ readonly kind: ToastKind; readonly message: string }>
+  >;
+};
+
+export type RtlUsersDriverOptions = ToastQuery;
+
+// `render` here is the value returned from `@testing-library/react`'s
+// `render(...)`. Caller supplies it so this adapter doesn't pin a
+// specific rendering wrapper; the integration harness and presenter
+// harness mount their own providers.
+export const rtlUsersDriver = (
+  rendered: RenderResult,
+  opts: RtlUsersDriverOptions,
+): UsersPageDriver => {
+  const user = userEvent.setup();
+  const scope = within(rendered.container);
+
+  const fieldInput = (field: CreateUserField) => scope.getByTestId(testIdByField[field]);
+
+  return {
+    goto: async () => {
+      // RTL doesn't navigate; the caller already mounted the page.
+      // Assert that the form is ready so subsequent interactions
+      // have something to drive.
+      await waitFor(() => {
+        scope.getByTestId("create-user-email");
+      });
+    },
+
+    createUser: async (input: CreateUserInput) => {
+      await user.clear(fieldInput("email"));
+      await user.type(fieldInput("email"), input.email);
+      await user.clear(fieldInput("country"));
+      await user.type(fieldInput("country"), input.country);
+      await user.clear(fieldInput("street"));
+      await user.type(fieldInput("street"), input.street);
+      await user.clear(fieldInput("postalCode"));
+      await user.type(fieldInput("postalCode"), input.postalCode);
+      await user.click(scope.getByTestId("create-user-submit"));
+    },
+
+    expectUserInList: async (email: string) => {
+      await waitFor(() => {
+        const list = scope.getByTestId("user-list");
+        const match = list.querySelector(`[data-user-email="${email}"]`);
+        if (match === null) {
+          throw new Error(`user-list does not contain user with email ${email}`);
+        }
+      });
+    },
+
+    expectFieldError: async (field: CreateUserField) => {
+      await waitFor(() => {
+        // The form's `Form.Error` span renders adjacent to each
+        // input. Locate it by walking up from the field's label.
+        const input = fieldInput(field);
+        const parent = input.closest("div");
+        if (parent === null) throw new Error(`no enclosing control for ${field}`);
+        const errorSpan = parent.querySelector("span.text-red-500");
+        if (errorSpan?.textContent === null || errorSpan?.textContent === undefined) {
+          throw new Error(`no error for ${field}`);
+        }
+      });
+    },
+
+    expectToast: async (kind: ToastKind, message: string) => {
+      await waitFor(async () => {
+        const toasts = await opts.getToasts();
+        const found = toasts.some((t) => t.kind === kind && t.message === message);
+        if (!found) {
+          throw new Error(
+            `expected ${kind} toast with message "${message}", got ${JSON.stringify(toasts)}`,
+          );
+        }
+      });
+    },
+  };
+};

--- a/packages/test-drivers/src/contracts/users-page-driver.ts
+++ b/packages/test-drivers/src/contracts/users-page-driver.ts
@@ -1,0 +1,50 @@
+// Tier-agnostic UsersPage driver contract. The driver speaks
+// business intent (createUser, expectUserInList) at user-perceivable
+// granularity (visible text, ARIA roles, presence/absence) — never
+// DOM internals or CSS classes. The same set of methods is
+// implemented at every tier:
+//
+//   - presenter (in-memory ApiClient stub): exercised from
+//     presenter tests via the rtl adapter
+//   - integration (in-process backend): exercised from
+//     @org/web's integration tests via the rtl adapter
+//   - acceptance (Playwright + live server): exercised from
+//     @org/acceptance via the playwright adapter
+//
+// The spec body is identical at the integration and acceptance tiers;
+// only the setup phase and the driver factory differ. See the
+// worked example in @org/web's createUser tests.
+
+export type CreateUserInput = {
+  readonly email: string;
+  readonly country: string;
+  readonly street: string;
+  readonly postalCode: string;
+};
+
+export type CreateUserField = keyof CreateUserInput;
+
+export type ToastKind = "success" | "error";
+
+export interface UsersPageDriver {
+  // Visit the users page. Acceptance: navigate. Integration:
+  // render the page component. Presenter: render the create-user
+  // form only (no page chrome).
+  readonly goto: () => Promise<void>;
+
+  // Fill the form and submit. The driver wraps the field-level
+  // interactions so tests don't enumerate every input.
+  readonly createUser: (input: CreateUserInput) => Promise<void>;
+
+  // Assert a user appears in the list, keyed by email.
+  readonly expectUserInList: (email: string) => Promise<void>;
+
+  // Assert a per-field validation error is visible.
+  readonly expectFieldError: (field: CreateUserField) => Promise<void>;
+
+  // Assert a toast of the given kind with the given message is
+  // visible. Acceptance: sonner's DOM. Integration: the
+  // RecordingToast in the presenter harness, or the page-level
+  // toaster mounted in the integration harness.
+  readonly expectToast: (kind: ToastKind, message: string) => Promise<void>;
+}

--- a/packages/test-drivers/tsconfig.json
+++ b/packages/test-drivers/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "noEmit": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/web/lib/tanstack-query/make-form-options.test.ts
+++ b/packages/web/lib/tanstack-query/make-form-options.test.ts
@@ -79,9 +79,9 @@ describe("makeFormOptions", () => {
       defaultValues: { email: "" },
       validator: "onSubmit",
     });
-    expect(opts.validators?.onSubmit).toBeDefined();
-    expect(opts.validators?.onChange).toBeUndefined();
-    expect(opts.validators?.onBlur).toBeUndefined();
+    expect(opts?.validators?.onSubmit).toBeDefined();
+    expect(opts?.validators?.onChange).toBeUndefined();
+    expect(opts?.validators?.onBlur).toBeUndefined();
   });
 
   it("wires validators.onChange when validator: 'onChange'", () => {
@@ -90,8 +90,8 @@ describe("makeFormOptions", () => {
       defaultValues: { email: "" },
       validator: "onChange",
     });
-    expect(opts.validators?.onChange).toBeDefined();
-    expect(opts.validators?.onSubmit).toBeUndefined();
+    expect(opts?.validators?.onChange).toBeDefined();
+    expect(opts?.validators?.onSubmit).toBeUndefined();
   });
 
   it("wires validators.onBlur when validator: 'onBlur'", () => {
@@ -100,8 +100,8 @@ describe("makeFormOptions", () => {
       defaultValues: { email: "" },
       validator: "onBlur",
     });
-    expect(opts.validators?.onBlur).toBeDefined();
-    expect(opts.validators?.onSubmit).toBeUndefined();
+    expect(opts?.validators?.onBlur).toBeDefined();
+    expect(opts?.validators?.onSubmit).toBeUndefined();
   });
 
   it("returns defaultValues unchanged", () => {
@@ -111,6 +111,6 @@ describe("makeFormOptions", () => {
       defaultValues: defaults,
       validator: "onSubmit",
     });
-    expect(opts.defaultValues).toEqual(defaults);
+    expect(opts?.defaultValues).toEqual(defaults);
   });
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,9 +33,12 @@
     "sonner": "^2.0.7"
   },
   "devDependencies": {
+    "@org/test-backend": "workspace:^",
+    "@org/test-drivers": "workspace:^",
     "@tailwindcss/postcss": "4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/packages/web/test/integration-harness.tsx
+++ b/packages/web/test/integration-harness.tsx
@@ -1,0 +1,83 @@
+// Integration harness for FE tests that drive the real backend
+// handlers in-process via `@org/test-backend`. Mounts components
+// against a runtime whose `ApiClient` is wired to the in-process
+// backend's `fetch` function — same request/response objects the
+// browser would see, no network, no port, no codegen.
+//
+// Pair with `rtlUsersDriver(rendered, { getToasts })` to write
+// integration specs that mirror the acceptance specs' phrasing
+// (Phase 9 worked example).
+
+import { ApiClient } from "@/services/api-client.shared";
+import { QueryClient } from "@/services/common/query-client";
+import { RuntimeContext } from "@/services/runtime.client";
+import { RecordedToasts, RecordingToast, type ToastCall } from "@/test/recording-toast";
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { DomainApi } from "@org/contracts/DomainApi";
+import { QueryClientProvider, QueryClient as TanstackQueryClient } from "@tanstack/react-query";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import * as React from "react";
+
+export type IntegrationHarness = {
+  readonly wrapper: React.FC<{ children: React.ReactNode }>;
+  readonly queryClient: TanstackQueryClient;
+  readonly getToasts: () => Promise<ReadonlyArray<ToastCall>>;
+  readonly dispose: () => Promise<void>;
+};
+
+// Build an integration harness wired to the in-process backend.
+// `transport` is `backend.fetch` from `startInProcessBackend()`.
+export const makeIntegrationHarness = (opts: {
+  readonly transport: typeof fetch;
+}): IntegrationHarness => {
+  const queryClient = new TanstackQueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+  // The HttpApiClient wired to `opts.transport` — Effect builds a
+  // typed client (`client.user.find`, `client.todos.create`, …)
+  // whose calls go through fetch with the in-process backend as
+  // the transport. The base URL is arbitrary; the in-process
+  // handler ignores it and routes by path.
+  const HttpClientLive = FetchHttpClient.layer.pipe(
+    Layer.provide(Layer.succeed(FetchHttpClient.Fetch, opts.transport)),
+  );
+
+  const ApiClientLive = Layer.effect(
+    ApiClient,
+    Effect.gen(function* () {
+      const client = yield* HttpApiClient.make(DomainApi, {
+        baseUrl: "http://in-process.test",
+      });
+      return ApiClient.of({ client });
+    }),
+  ).pipe(Layer.provide(HttpClientLive));
+
+  const layer = Layer.mergeAll(ApiClientLive, QueryClient.make(queryClient), RecordingToast);
+  const built = ManagedRuntime.make(layer);
+  const runtime = built as unknown as React.ContextType<typeof RuntimeContext>;
+  const recordingRuntime = built as unknown as ManagedRuntime.ManagedRuntime<RecordedToasts, never>;
+
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <RuntimeContext.Provider value={runtime}>
+        <React.Suspense fallback={<span data-testid="integration-suspense-fallback" />}>
+          {children}
+        </React.Suspense>
+      </RuntimeContext.Provider>
+    </QueryClientProvider>
+  );
+
+  return {
+    wrapper,
+    queryClient,
+    getToasts: () => recordingRuntime.runPromise(Effect.flatMap(RecordedToasts, (rec) => rec.all)),
+    dispose: () => built.dispose(),
+  };
+};

--- a/packages/web/test/integration/create-user.integration.test.tsx
+++ b/packages/web/test/integration/create-user.integration.test.tsx
@@ -1,0 +1,86 @@
+// Worked example from Phase 9 of the remediation plan: createUser
+// at the integration tier. Same scenario as the presenter test and
+// the acceptance spec, same driver methods — only the setup phase
+// changes.
+//
+// What this exercises:
+//   - The real CreateUser presenter (TanStack Form orchestration)
+//   - The real `useCreateUserMutation` (data-access + useEffectMutation)
+//   - The real backend handlers (createUser command, UserCreated
+//     event, wallet event adapter, wallet handler, wallet repo
+//     insert) — all running in-process over the FakeDatabase.
+//
+// What this does NOT exercise:
+//   - Next.js routing, hydration, or RSC boundaries (the page
+//     wrapper is bypassed; we mount the feature components directly)
+//   - The real OIDC dance (backend.auth.signInAs short-circuits it)
+
+import { CreateUser } from "@/features/users/create-user/create-user";
+import { UserList } from "@/features/users/user-list";
+import { makeIntegrationHarness } from "@/test/integration-harness";
+import { UserId } from "@org/contracts/EntityIds";
+import { startInProcessBackend, type InProcessBackend } from "@org/test-backend";
+import { rtlUsersDriver } from "@org/test-drivers/adapters/rtl/users-page-driver";
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const adminUserId = UserId.make("00000000-0000-0000-0000-000000000001");
+
+let backend: InProcessBackend;
+let harness: ReturnType<typeof makeIntegrationHarness>;
+
+beforeEach(async () => {
+  backend = await startInProcessBackend({
+    signedInAs: { userId: adminUserId },
+  });
+  harness = makeIntegrationHarness({ transport: backend.fetch });
+});
+
+afterEach(async () => {
+  await harness.dispose();
+  await backend.dispose();
+});
+
+const validPayload = {
+  email: "alice@example.com",
+  country: "USA",
+  street: "123 Main St",
+  postalCode: "12345",
+};
+
+describe("createUser — integration tier (worked example)", () => {
+  it("creates a user via the real form + real backend; the wallet event handler auto-creates a wallet", async () => {
+    const rendered = render(
+      <React.Fragment>
+        <CreateUser />
+        <UserList />
+      </React.Fragment>,
+      { wrapper: harness.wrapper },
+    );
+    const driver = rtlUsersDriver(rendered, { getToasts: harness.getToasts });
+
+    await driver.goto();
+    await driver.createUser(validPayload);
+
+    // Success toast confirms the mutation completed end-to-end
+    // (FE form → useEffectMutation → /api/users → createUser handler
+    // → fake repo → success → toast).
+    await driver.expectToast("success", "User created!");
+
+    // Verify the user landed in the FakeDatabase — same Map the
+    // backend handler wrote to.
+    const users = Array.from(backend.db.users.values());
+    expect(users.length).toBe(1);
+    expect(users[0]?.email).toBe(validPayload.email);
+
+    // Critical cross-module assertion: the real wallet event
+    // adapter ran, translated UserCreated → UserCreatedTrigger,
+    // dispatched to the wallet handler, which inserted a wallet
+    // via the wallet repository. Cross-module composition under
+    // test, end-to-end.
+    expect(backend.db.wallets.size).toBe(1);
+    const wallet = Array.from(backend.db.wallets.values())[0];
+    expect(wallet.userId).toBe(users[0]?.id);
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -20,8 +20,29 @@ export default defineConfig({
   // module shape the app does.
   resolve: {
     alias: [
+      // Server's `@/` path map. The in-process backend (consumed via
+      // `@org/test-backend` in integration tests) imports server
+      // source like `@/api.js`, `@/modules/...`. The web's `@/` below
+      // is a different package — disambiguate by anchoring the
+      // server-side prefix to top-level dirs that exist only in the
+      // server tree (api/common/modules/platform/test-utils).
+      {
+        find: /^@\/(api(?:\.[jt]s)?|(?:common|modules|platform|test-utils)(?:\/.*)?)$/,
+        replacement: path.join(__dirname, "../server/src/$1"),
+      },
       { find: /^@\/(.*)$/, replacement: path.join(__dirname, "./$1") },
       { find: /^@org\/components\/(.*)$/, replacement: path.join(__dirname, "../components/$1") },
+      // The in-process backend (transitively, via fake repositories
+      // and query handlers) imports `@org/database`. Alias to the
+      // database package's source entry point.
+      {
+        find: /^@org\/database$/,
+        replacement: path.join(__dirname, "../database/src/index.ts"),
+      },
+      {
+        find: /^@org\/database\/(.*)$/,
+        replacement: path.join(__dirname, "../database/src/$1.ts"),
+      },
       // Match the tsconfig paths and the runtime export shape: contracts
       // resolves via the built ESM. Keep the build step in the setup
       // composite action so CI doesn't have to remember per-job.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@org/contracts':
         specifier: workspace:^
         version: link:../contracts/dist
+      '@org/test-drivers':
+        specifier: workspace:^
+        version: link:../test-drivers
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.59.1
@@ -434,6 +437,30 @@ importers:
         specifier: ^5.6.3
         version: 5.7.3
 
+  packages/test-drivers:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.7.3
+
   packages/web:
     dependencies:
       '@effect/opentelemetry':
@@ -491,6 +518,12 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@org/test-backend':
+        specifier: workspace:^
+        version: link:../test-backend
+      '@org/test-drivers':
+        specifier: workspace:^
+        version: link:../test-drivers
       '@tailwindcss/postcss':
         specifier: 4.2.4
         version: 4.2.4
@@ -500,6 +533,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: ^20
         version: 20.19.40

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,6 +415,25 @@ importers:
         specifier: ^4.19.2
         version: 4.19.2
 
+  packages/test-backend:
+    dependencies:
+      '@org/contracts':
+        specifier: workspace:^
+        version: link:../contracts/dist
+      '@org/server':
+        specifier: workspace:^
+        version: link:../server
+      effect:
+        specifier: 3.21.2
+        version: 3.21.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.7.3
+
   packages/web:
     dependencies:
       '@effect/opentelemetry':


### PR DESCRIPTION
## Summary

Stacked on top of #51. Adds the integration testing tier from the remediation plan: a shared FakeDatabase, an in-process backend harness, and a tier-agnostic page driver contract with the createUser scenario wired end-to-end across all three tiers.

## Phases in this PR

- **Phase 7** — `FakeDatabase` + cross-repository contract suite. Shared in-memory model enforces UNIQUE / FK / CASCADE; each repo fake (`*RepositoryFakeShared`) is a thin Layer over it; `FakeRepositoriesLive` composes them. The contract suite at `packages/server/src/test-utils/repository-behavior/` runs against fake (always) and live (gated on `DATABASE_URL_TEST`) so the fake's claims can't drift from the schema.
- **Phase 8** — `startInProcessBackend()` builds the real HTTP handlers from `@/api.js` over the FakeDatabase + Fake repos and exposes a `fetch`-shaped function via `HttpApiBuilder.toWebHandler`. New `@org/test-backend` workspace package as the public surface (server's `package.json` exports `./test-utils/*`). `FakeAuthMiddleware` bypasses the OIDC dance via `backend.auth.signInAs(...)`. Smoke test round-trips all four CRUD verbs.
- **Phase 9** — `@org/test-drivers` workspace package: `UsersPageDriver` contract + Playwright adapter (lifted from `acceptance/drivers/pages/users-page.ts`) + RTL adapter. Worked example at `packages/web/test/integration/create-user.integration.test.tsx`: drives the real CreateUser form against the in-process backend, verifies the wallet was auto-created by the real `UserCreated` event handler. The acceptance `add-user.spec.ts` is refactored to use the same driver — same spec body across tiers.

## Base + merge order

- Base branch is `feat/frontend-testing-remediation` (PR #51). Merge that first; once it lands on main, GitHub will retarget this PR to main automatically.
- The diff here is exactly the 3 commits beyond PR #51's tip; nothing from PR #51 shows up in this diff.

## Test plan

- [x] `pnpm check:all` green: 208 tests without `DATABASE_URL_TEST`, +8 with it (4 from the cross-repo contract suite running against live Postgres, plus the live half of integration-test mirroring)
- [x] In-process backend smoke test exercises POST/GET/PUT/DELETE round-trips
- [x] Worked example integration test passes: real form → real handlers → real wallet event subscriber

🤖 Generated with [Claude Code](https://claude.com/claude-code)