### PR TITLE
chore(lint): enforce import sort via simple-import-sort

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,5 @@
 {
-  "plugins": [
-    "prettier-plugin-organize-imports",
-    "prettier-plugin-tailwindcss"
-  ],
+  "plugins": ["prettier-plugin-tailwindcss"],
   "endOfLine": "auto",
   "semi": true,
   "singleQuote": false,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -162,7 +162,8 @@ export default [
       "import/no-duplicates": "error",
       "import/no-unresolved": "off",
       "import/order": "off",
-      "simple-import-sort/imports": "off",
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
       "sort-destructure-keys/sort-destructure-keys": "error",
 
       "@typescript-eslint/array-type": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
     "prettier": "3.8.3",
-    "prettier-plugin-organize-imports": "4.3.0",
     "prettier-plugin-tailwindcss": "0.8.0",
     "read-package-up": "^12.0.0",
     "tsx": "^4.19.2",

--- a/packages/acceptance/setup/auth.setup.ts
+++ b/packages/acceptance/setup/auth.setup.ts
@@ -1,5 +1,6 @@
-import { ZitadelLoginPage } from "@/drivers/pages/zitadel-login-page";
 import { test as setup } from "@playwright/test";
+
+import { ZitadelLoginPage } from "@/drivers/pages/zitadel-login-page";
 
 // Auth setup project. Runs once per Playwright invocation (before the
 // `chromium` test project) and stamps the resulting session cookie into

--- a/packages/acceptance/specs/add-todo.spec.ts
+++ b/packages/acceptance/specs/add-todo.spec.ts
@@ -1,6 +1,7 @@
+import { test } from "@playwright/test";
+
 import { IndexPage } from "@/drivers/pages/index-page";
 import { truncate } from "@/test-utils/database";
-import { test } from "@playwright/test";
 
 const DATABASE_URL_TEST =
   process.env.DATABASE_URL_TEST ??

--- a/packages/acceptance/specs/add-user.spec.ts
+++ b/packages/acceptance/specs/add-user.spec.ts
@@ -1,6 +1,7 @@
-import { truncate } from "@/test-utils/database";
 import { playwrightUsersDriver } from "@org/test-drivers/adapters/playwright/users-page-driver";
 import { test } from "@playwright/test";
+
+import { truncate } from "@/test-utils/database";
 
 const DATABASE_URL_TEST =
   process.env.DATABASE_URL_TEST ??

--- a/packages/acceptance/specs/login.spec.ts
+++ b/packages/acceptance/specs/login.spec.ts
@@ -1,5 +1,6 @@
-import { ZitadelLoginPage } from "@/drivers/pages/zitadel-login-page";
 import { expect, test } from "@playwright/test";
+
+import { ZitadelLoginPage } from "@/drivers/pages/zitadel-login-page";
 
 // Login is a critical user path; it gets exercised on every run, not just
 // in setup. Runs in the dedicated `login` project (no storageState) so the

--- a/packages/acceptance/test-utils/admin-seed.ts
+++ b/packages/acceptance/test-utils/admin-seed.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+
 import pg from "pg";
 
 // Mirrors the relevant slice of `infra/zitadel/seed.mjs` against the TEST

--- a/packages/acceptance/test-utils/database.ts
+++ b/packages/acceptance/test-utils/database.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+
 import pg from "pg";
 
 // Test-database utilities for the acceptance workspace. Mirrors the server's

--- a/packages/components/.storybook/preview.ts
+++ b/packages/components/.storybook/preview.ts
@@ -1,7 +1,7 @@
+import "../styles/globals.css";
+
 import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react-vite";
-
-import "../styles/globals.css";
 
 const preview: Preview = {
   parameters: {

--- a/packages/components/primitives/badge.stories.tsx
+++ b/packages/components/primitives/badge.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Badge } from "./badge";
 
 const meta = {

--- a/packages/components/primitives/badge.tsx
+++ b/packages/components/primitives/badge.tsx
@@ -1,6 +1,7 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const badgeVariants = cva(

--- a/packages/components/primitives/button.stories.tsx
+++ b/packages/components/primitives/button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Button } from "./button";
 
 const meta = {

--- a/packages/components/primitives/button.tsx
+++ b/packages/components/primitives/button.tsx
@@ -2,6 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Loader2Icon } from "lucide-react";
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const buttonVariants = cva(

--- a/packages/components/primitives/card.stories.tsx
+++ b/packages/components/primitives/card.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Button } from "./button";
 import { Card } from "./card";
 

--- a/packages/components/primitives/checkbox.stories.tsx
+++ b/packages/components/primitives/checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
+
 import { Checkbox } from "./checkbox";
 import { Label } from "./label";
 

--- a/packages/components/primitives/checkbox.tsx
+++ b/packages/components/primitives/checkbox.tsx
@@ -1,6 +1,7 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const Checkbox = React.forwardRef<

--- a/packages/components/primitives/dialog.stories.tsx
+++ b/packages/components/primitives/dialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
+
 import { Button } from "./button";
 import { Dialog } from "./dialog";
 

--- a/packages/components/primitives/dialog.tsx
+++ b/packages/components/primitives/dialog.tsx
@@ -1,6 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const DialogRoot = ({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) => {

--- a/packages/components/primitives/form.stories.tsx
+++ b/packages/components/primitives/form.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import * as React from "react";
 import { expect, userEvent, within } from "storybook/test";
+
 import { Button } from "./button";
 import { Form } from "./form";
 

--- a/packages/components/primitives/form.tsx
+++ b/packages/components/primitives/form.tsx
@@ -1,5 +1,6 @@
 import * as String from "effect/String";
 import React from "react";
+
 import { cn } from "../lib/utils/cn";
 import { Input } from "./input";
 import { Label } from "./label";

--- a/packages/components/primitives/icon/icon.stories.tsx
+++ b/packages/components/primitives/icon/icon.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import type { IconProps } from "./icon";
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon, TrashIcon } from "./icons";
 

--- a/packages/components/primitives/icon/icon.tsx
+++ b/packages/components/primitives/icon/icon.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import * as React from "react";
+
 import { cn } from "../../lib/utils/cn";
 
 export type IconSize = "sm" | "md" | "lg";

--- a/packages/components/primitives/icon/icons.ts
+++ b/packages/components/primitives/icon/icons.ts
@@ -4,6 +4,7 @@ import {
   PlusIcon as LucidePlusIcon,
   Trash2Icon as LucideTrash2Icon,
 } from "lucide-react";
+
 import { createIcon } from "./icon";
 
 export const PlusIcon = createIcon(LucidePlusIcon);

--- a/packages/components/primitives/input.stories.tsx
+++ b/packages/components/primitives/input.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
+
 import { Input } from "./input";
 
 const meta: Meta<typeof Input> = {

--- a/packages/components/primitives/input.tsx
+++ b/packages/components/primitives/input.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const Input = ({ className, type, ...props }: React.ComponentProps<"input">) => {

--- a/packages/components/primitives/label.stories.tsx
+++ b/packages/components/primitives/label.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Input } from "./input";
 import { Label } from "./label";
 

--- a/packages/components/primitives/label.tsx
+++ b/packages/components/primitives/label.tsx
@@ -1,5 +1,6 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const Label = ({

--- a/packages/components/primitives/select.stories.tsx
+++ b/packages/components/primitives/select.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
+
 import { Select } from "./select";
 
 const meta = {

--- a/packages/components/primitives/select.tsx
+++ b/packages/components/primitives/select.tsx
@@ -1,6 +1,7 @@
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import * as React from "react";
+
 import { cn } from "../lib/utils/cn";
 
 const SelectRoot = ({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) => {

--- a/packages/components/primitives/skeleton.stories.tsx
+++ b/packages/components/primitives/skeleton.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Skeleton } from "./skeleton";
 
 const meta = {

--- a/packages/components/primitives/toaster.stories.tsx
+++ b/packages/components/primitives/toaster.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { toast } from "sonner";
+
 import { Button } from "./button";
 import { Toaster } from "./toaster";
 

--- a/packages/components/primitives/toaster.tsx
+++ b/packages/components/primitives/toaster.tsx
@@ -1,4 +1,5 @@
 import { Toaster as Sonner } from "sonner";
+
 import { useTheme } from "../providers/theme-provider";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;

--- a/packages/contracts/src/DomainApi.ts
+++ b/packages/contracts/src/DomainApi.ts
@@ -1,4 +1,5 @@
 import * as HttpApi from "@effect/platform/HttpApi";
+
 import * as AuthContract from "./api/AuthContract.js";
 import * as TodosContract from "./api/TodosContract.js";
 import * as UserContract from "./api/UserContract.js";

--- a/packages/contracts/src/ManualCache.ts
+++ b/packages/contracts/src/ManualCache.ts
@@ -4,6 +4,7 @@ import type * as Effect from "effect/Effect";
 import type * as Option from "effect/Option";
 import type * as Scope from "effect/Scope";
 import type * as Types from "effect/Types";
+
 import * as internal from "./internal/manual-cache.js";
 
 /**

--- a/packages/contracts/src/Policy.ts
+++ b/packages/contracts/src/Policy.ts
@@ -3,6 +3,7 @@ import { type NonEmptyReadonlyArray } from "effect/Array";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+
 import * as CustomHttpApiError from "./CustomHttpApiError.js";
 import { type UserId } from "./EntityIds.js";
 import * as internal from "./internal/policy.js";

--- a/packages/contracts/src/api/AuthContract.ts
+++ b/packages/contracts/src/api/AuthContract.ts
@@ -1,6 +1,7 @@
 import * as HttpApiEndpoint from "@effect/platform/HttpApiEndpoint";
 import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
 import * as Schema from "effect/Schema";
+
 import * as CustomHttpApiError from "../CustomHttpApiError.js";
 import { UserId } from "../EntityIds.js";
 import { Permission, UserAuthMiddleware } from "../Policy.js";

--- a/packages/contracts/src/api/TodosContract.ts
+++ b/packages/contracts/src/api/TodosContract.ts
@@ -2,6 +2,7 @@ import * as HttpApiEndpoint from "@effect/platform/HttpApiEndpoint";
 import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
 import * as HttpApiSchema from "@effect/platform/HttpApiSchema";
 import * as Schema from "effect/Schema";
+
 import { TodoId } from "../EntityIds.js";
 import { UserAuthMiddleware } from "../Policy.js";
 

--- a/packages/contracts/src/api/UserContract.ts
+++ b/packages/contracts/src/api/UserContract.ts
@@ -2,6 +2,7 @@ import * as HttpApiEndpoint from "@effect/platform/HttpApiEndpoint";
 import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
 import * as HttpApiSchema from "@effect/platform/HttpApiSchema";
 import * as Schema from "effect/Schema";
+
 import { UserId } from "../EntityIds.js";
 import { UserAuthMiddleware } from "../Policy.js";
 

--- a/packages/contracts/test/ManualCache.test.ts
+++ b/packages/contracts/test/ManualCache.test.ts
@@ -1,7 +1,9 @@
+import { strictEqual } from "node:assert";
+
 import { describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as TestClock from "effect/TestClock";
-import { strictEqual } from "node:assert";
+
 import * as ManualCache from "../src/ManualCache.js";
 
 describe("ManualCache", () => {

--- a/packages/contracts/test/internal/policy.test.ts
+++ b/packages/contracts/test/internal/policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
+
 import * as internal from "../../src/internal/policy.js";
 
 describe("makePermissions", () => {

--- a/packages/contracts/test/policy.test.ts
+++ b/packages/contracts/test/policy.test.ts
@@ -3,6 +3,7 @@ import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
+
 import * as CustomHttpApiError from "../src/CustomHttpApiError.js";
 import { UserId } from "../src/EntityIds.js";
 import * as Policy from "../src/Policy.js";

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,4 +1,4 @@
-export { sql } from "slonik";
 export * as Database from "./Database.js";
 export { orFail } from "./or-fail.js";
 export * as RowSchemas from "./row-schemas/index.js";
+export { sql } from "slonik";

--- a/packages/database/src/scripts/reset-database.ts
+++ b/packages/database/src/scripts/reset-database.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import { sql } from "slonik";
+
 import * as Database from "../Database.js";
 
 dotenv({

--- a/packages/database/test/or-fail.test.ts
+++ b/packages/database/test/or-fail.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
 import { orFail } from "../src/or-fail.js";
 
 class NotFound {

--- a/packages/jobs/src/jobs/purge-expired-sessions.integration.test.ts
+++ b/packages/jobs/src/jobs/purge-expired-sessions.integration.test.ts
@@ -4,6 +4,7 @@ import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
+
 import { hasTestDatabase, TestDatabaseLive, truncate } from "../test-utils/test-database.js";
 import { purgeExpiredSessions } from "./purge-expired-sessions.js";
 

--- a/packages/jobs/src/main.ts
+++ b/packages/jobs/src/main.ts
@@ -5,6 +5,7 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
+
 import { purgeExpiredSessions } from "./jobs/purge-expired-sessions.js";
 
 dotenv.config({ path: "../../.env" });

--- a/packages/jobs/src/test-utils/test-database.ts
+++ b/packages/jobs/src/test-utils/test-database.ts
@@ -1,10 +1,11 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { Database, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import * as pg from "pg";
 
 // Mirrors packages/server/src/test-utils/test-database.ts. Duplicated rather

--- a/packages/server/src/common/token-cipher.test.ts
+++ b/packages/server/src/common/token-cipher.test.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
+
 import * as TokenCipher from "./token-cipher.js";
 
 const TEST_KEY = Redacted.make("test-key-32-chars-exactly-12345678");

--- a/packages/server/src/common/token-cipher.ts
+++ b/packages/server/src/common/token-cipher.ts
@@ -1,10 +1,11 @@
+import * as crypto from "node:crypto";
+
 import * as Effect from "effect/Effect";
 import { flow } from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as ParseResult from "effect/ParseResult";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
-import * as crypto from "node:crypto";
 
 export const EncryptedToken = Schema.String.pipe(Schema.brand("encryptedToken"));
 export type EncryptedToken = typeof EncryptedToken.Type;

--- a/packages/server/src/modules/auth/auth-module.ts
+++ b/packages/server/src/modules/auth/auth-module.ts
@@ -1,4 +1,5 @@
 import * as Layer from "effect/Layer";
+
 import { AuthIdentityRepositoryLive } from "./infrastructure/auth-identity-repository-live.js";
 import { OidcClient } from "./infrastructure/oidc-client.js";
 import { AuthLive } from "./interface/http/auth-live.js";

--- a/packages/server/src/modules/auth/auth-shared-deps.ts
+++ b/packages/server/src/modules/auth/auth-shared-deps.ts
@@ -1,5 +1,7 @@
-import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 import * as Layer from "effect/Layer";
+
+import { CookieCodec } from "@/platform/auth/cookie-codec.js";
+
 import { SessionRepositoryLive } from "./infrastructure/session-repository-live.js";
 
 // The two auth-infra services that genuinely cross the module

--- a/packages/server/src/modules/auth/commands/auth-command-handlers.ts
+++ b/packages/server/src/modules/auth/commands/auth-command-handlers.ts
@@ -1,7 +1,7 @@
-import { signInCommandSpanAttributes } from "@/modules/auth/commands/sign-in-command.js";
 import { signIn } from "@/modules/auth/commands/sign-in.js";
-import { touchSessionCommandSpanAttributes } from "@/modules/auth/commands/touch-session-command.js";
+import { signInCommandSpanAttributes } from "@/modules/auth/commands/sign-in-command.js";
 import { touchSession } from "@/modules/auth/commands/touch-session.js";
+import { touchSessionCommandSpanAttributes } from "@/modules/auth/commands/touch-session-command.js";
 import { commandHandlers } from "@/platform/ddd/command-bus.js";
 
 export const authCommandHandlers = commandHandlers({

--- a/packages/server/src/modules/auth/commands/sign-in-command.ts
+++ b/packages/server/src/modules/auth/commands/sign-in-command.ts
@@ -1,11 +1,12 @@
+import type * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type AuthIdentityRepository } from "@/modules/auth/domain/auth-identity-repository.js";
 import { type SessionId } from "@/modules/auth/domain/session-id.js";
 import { type SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { type UserId } from "@/platform/ids/user-id.js";
-import type * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 // Inputs come from the OIDC callback: a verified Zitadel `subject` + the
 // caller's chosen TTLs. `email` is informational (kept for future JIT

--- a/packages/server/src/modules/auth/commands/sign-in.test.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.test.ts
@@ -5,8 +5,8 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 
-import { SignInCommand } from "@/modules/auth/commands/sign-in-command.js";
 import { signIn } from "@/modules/auth/commands/sign-in.js";
+import { SignInCommand } from "@/modules/auth/commands/sign-in-command.js";
 import { type AuthIdentity } from "@/modules/auth/domain/auth-identity-repository.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import { makeAuthIdentityRepositoryFake } from "@/modules/auth/infrastructure/auth-identity-repository-fake.js";

--- a/packages/server/src/modules/auth/commands/sign-in.test.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.test.ts
@@ -1,3 +1,10 @@
+import { describe, it } from "@effect/vitest";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
 import { SignInCommand } from "@/modules/auth/commands/sign-in-command.js";
 import { signIn } from "@/modules/auth/commands/sign-in.js";
 import { type AuthIdentity } from "@/modules/auth/domain/auth-identity-repository.js";
@@ -5,12 +12,6 @@ import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import { makeAuthIdentityRepositoryFake } from "@/modules/auth/infrastructure/auth-identity-repository-fake.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/session-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { describe, it } from "@effect/vitest";
-import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
-import { deepStrictEqual } from "assert";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Layer from "effect/Layer";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const subject = "zitadel-sub-1";

--- a/packages/server/src/modules/auth/commands/sign-in.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.ts
@@ -4,9 +4,9 @@ import * as Effect from "effect/Effect";
 
 import { type SignInCommand, type SignInOutput } from "@/modules/auth/commands/sign-in-command.js";
 import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity-repository.js";
+import * as Session from "@/modules/auth/domain/session.aggregate.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
-import * as Session from "@/modules/auth/domain/session.aggregate.js";
 
 // Slice-scope SignIn:
 //   - looks up auth_identities by Zitadel subject

--- a/packages/server/src/modules/auth/commands/sign-in.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.ts
@@ -1,11 +1,12 @@
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import { type SignInCommand, type SignInOutput } from "@/modules/auth/commands/sign-in-command.js";
 import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity-repository.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import * as Session from "@/modules/auth/domain/session.aggregate.js";
-import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 // Slice-scope SignIn:
 //   - looks up auth_identities by Zitadel subject

--- a/packages/server/src/modules/auth/commands/touch-session-command.ts
+++ b/packages/server/src/modules/auth/commands/touch-session-command.ts
@@ -1,8 +1,9 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { type SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 // Sliding-TTL refresh, dispatched by the auth middleware after a successful
 // `FindSessionQuery`. The handler does its own throttle + revocation guard,

--- a/packages/server/src/modules/auth/commands/touch-session.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.test.ts
@@ -1,3 +1,8 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import { TouchSessionCommand } from "@/modules/auth/commands/touch-session-command.js";
 import { touchSession } from "@/modules/auth/commands/touch-session.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
@@ -5,10 +10,6 @@ import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import * as Session from "@/modules/auth/domain/session.aggregate.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/session-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 const sessionId = SessionId.make("33333333-3333-3333-3333-333333333333");
 const userId = UserId.make("44444444-4444-4444-4444-444444444444");

--- a/packages/server/src/modules/auth/commands/touch-session.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.test.ts
@@ -3,11 +3,11 @@ import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
-import { TouchSessionCommand } from "@/modules/auth/commands/touch-session-command.js";
 import { touchSession } from "@/modules/auth/commands/touch-session.js";
+import { TouchSessionCommand } from "@/modules/auth/commands/touch-session-command.js";
+import * as Session from "@/modules/auth/domain/session.aggregate.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
-import * as Session from "@/modules/auth/domain/session.aggregate.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/session-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 

--- a/packages/server/src/modules/auth/commands/touch-session.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.ts
@@ -6,8 +6,8 @@ import {
   type TouchSessionCommand,
   type TouchSessionOutput,
 } from "@/modules/auth/commands/touch-session-command.js";
-import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import * as Session from "@/modules/auth/domain/session.aggregate.js";
+import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 
 // Sliding-TTL refresh.
 //

--- a/packages/server/src/modules/auth/commands/touch-session.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.ts
@@ -1,12 +1,13 @@
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+
 import {
   type TouchSessionCommand,
   type TouchSessionOutput,
 } from "@/modules/auth/commands/touch-session-command.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import * as Session from "@/modules/auth/domain/session.aggregate.js";
-import * as DateTime from "effect/DateTime";
-import * as Duration from "effect/Duration";
-import * as Effect from "effect/Effect";
 
 // Sliding-TTL refresh.
 //

--- a/packages/server/src/modules/auth/domain/auth-identity-repository.ts
+++ b/packages/server/src/modules/auth/domain/auth-identity-repository.ts
@@ -1,6 +1,8 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { type AuthIdentityNotFound } from "./session-errors.js";
 
 export type AuthIdentity = {

--- a/packages/server/src/modules/auth/domain/session-errors.ts
+++ b/packages/server/src/modules/auth/domain/session-errors.ts
@@ -1,4 +1,5 @@
 import * as Schema from "effect/Schema";
+
 import { SessionId } from "./session-id.js";
 
 export class SessionNotFound extends Schema.TaggedError<SessionNotFound>("SessionNotFound")(

--- a/packages/server/src/modules/auth/domain/session-repository.ts
+++ b/packages/server/src/modules/auth/domain/session-repository.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
+
 import { type SessionNotFound, type SessionRevoked } from "./session-errors.js";
 import { type SessionId } from "./session-id.js";
 import { type Session } from "./session.aggregate.js";

--- a/packages/server/src/modules/auth/domain/session-repository.ts
+++ b/packages/server/src/modules/auth/domain/session-repository.ts
@@ -1,9 +1,9 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 
+import { type Session } from "./session.aggregate.js";
 import { type SessionNotFound, type SessionRevoked } from "./session-errors.js";
 import { type SessionId } from "./session-id.js";
-import { type Session } from "./session.aggregate.js";
 
 export type SessionRepositoryShape = {
   readonly insert: (session: Session) => Effect.Effect<void>;

--- a/packages/server/src/modules/auth/domain/session.aggregate.test.ts
+++ b/packages/server/src/modules/auth/domain/session.aggregate.test.ts
@@ -1,7 +1,9 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { SessionId } from "./session-id.js";
 import * as Session from "./session.aggregate.js";
 

--- a/packages/server/src/modules/auth/domain/session.aggregate.test.ts
+++ b/packages/server/src/modules/auth/domain/session.aggregate.test.ts
@@ -4,8 +4,8 @@ import * as DateTime from "effect/DateTime";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { SessionId } from "./session-id.js";
 import * as Session from "./session.aggregate.js";
+import { SessionId } from "./session-id.js";
 
 const sessionId = SessionId.make("11111111-1111-1111-1111-111111111111");
 const userId = UserId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/auth/domain/session.aggregate.ts
+++ b/packages/server/src/modules/auth/domain/session.aggregate.ts
@@ -1,6 +1,8 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import * as DateTime from "effect/DateTime";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { SessionId } from "./session-id.js";
 
 export class Session extends Schema.Class<Session>("Session")({

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -1,10 +1,9 @@
+export { AuthModuleLive } from "./auth-module.js";
 export { authCommandHandlers } from "./commands/auth-command-handlers.js";
 export { SignInCommand } from "./commands/sign-in-command.js";
 export { TouchSessionCommand } from "./commands/touch-session-command.js";
 export { authQueryHandlers } from "./queries/auth-query-handlers.js";
 export { FindSessionQuery } from "./queries/find-session-query.js";
-
-export { AuthModuleLive } from "./auth-module.js";
 // AuthSharedDepsLive narrowly exposes the auth-infra services that
 // must be shared by reference with the platform middleware
 // (CookieCodec + SessionRepository). Other auth-infra services stay

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -9,6 +9,7 @@ export { FindSessionQuery } from "./queries/find-session-query.js";
 // (CookieCodec + SessionRepository). Other auth-infra services stay
 // internal to AuthModuleLive — see auth-shared-deps.ts.
 export { AuthSharedDepsLive } from "./auth-shared-deps.js";
+export { Session } from "./domain/session.aggregate.js";
 export {
   AuthIdentityNotFound,
   SessionExpired,
@@ -17,4 +18,3 @@ export {
 } from "./domain/session-errors.js";
 export { SessionId } from "./domain/session-id.js";
 export { SessionRepository } from "./domain/session-repository.js";
-export { Session } from "./domain/session.aggregate.js";

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-mapper.ts
@@ -1,5 +1,7 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { type RowSchemas } from "@org/database/index";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { type AuthIdentity } from "../domain/auth-identity-repository.js";
 
 export const toDomain = (row: RowSchemas.AuthIdentityRow): AuthIdentity => ({

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.test.ts
@@ -1,8 +1,10 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { AuthIdentityRepository } from "../domain/auth-identity-repository.js";
 import { AuthIdentityNotFound } from "../domain/session-errors.js";
 import { makeAuthIdentityRepositoryFake } from "./auth-identity-repository-fake.js";

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.ts
@@ -3,6 +3,7 @@ import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+
 import { type AuthIdentity, AuthIdentityRepository } from "../domain/auth-identity-repository.js";
 import { AuthIdentityNotFound } from "../domain/session-errors.js";
 

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.integration.test.ts
@@ -1,8 +1,3 @@
-import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity-repository.js";
-import { AuthIdentityNotFound } from "@/modules/auth/domain/session-errors.js";
-import { AuthIdentityRepositoryLive } from "@/modules/auth/infrastructure/auth-identity-repository-live.js";
-import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
@@ -10,6 +5,12 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
+
+import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity-repository.js";
+import { AuthIdentityNotFound } from "@/modules/auth/domain/session-errors.js";
+import { AuthIdentityRepositoryLive } from "@/modules/auth/infrastructure/auth-identity-repository-live.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const subject = "zitadel-sub-integration";

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.ts
@@ -1,6 +1,7 @@
 import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
 import { AuthIdentityRepository } from "../domain/auth-identity-repository.js";
 import { AuthIdentityNotFound } from "../domain/session-errors.js";
 import * as AuthIdentityMapper from "./auth-identity-mapper.js";

--- a/packages/server/src/modules/auth/infrastructure/oidc-client.ts
+++ b/packages/server/src/modules/auth/infrastructure/oidc-client.ts
@@ -1,8 +1,9 @@
-import { EnvVars } from "@/common/env-vars.js";
 import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as openid from "openid-client";
+
+import { EnvVars } from "@/common/env-vars.js";
 
 // Wraps openid-client. The only file in the repo that imports `openid-client`.
 // Used exclusively by the auth login + callback paths — once we have a

--- a/packages/server/src/modules/auth/infrastructure/session-mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-mapper.ts
@@ -3,8 +3,8 @@ import * as DateTime from "effect/DateTime";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { SessionId } from "../domain/session-id.js";
 import { Session } from "../domain/session.aggregate.js";
+import { SessionId } from "../domain/session-id.js";
 
 export const toDomain = (row: RowSchemas.SessionRow): Session =>
   Session.make({

--- a/packages/server/src/modules/auth/infrastructure/session-mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-mapper.ts
@@ -1,6 +1,8 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { type RowSchemas } from "@org/database/index";
 import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { SessionId } from "../domain/session-id.js";
 import { Session } from "../domain/session.aggregate.js";
 

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.test.ts
@@ -1,9 +1,11 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { SessionNotFound } from "../domain/session-errors.js";
 import { SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.test.ts
@@ -6,10 +6,10 @@ import * as Exit from "effect/Exit";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
+import * as Session from "../domain/session.aggregate.js";
 import { SessionNotFound } from "../domain/session-errors.js";
 import { SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";
-import * as Session from "../domain/session.aggregate.js";
 import { SessionRepositoryFake } from "./session-repository-fake.js";
 
 const idA = SessionId.make("11111111-1111-1111-1111-111111111111");

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
@@ -5,10 +5,10 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
+import { Session } from "../domain/session.aggregate.js";
 import { SessionNotFound } from "../domain/session-errors.js";
 import { type SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";
-import { Session } from "../domain/session.aggregate.js";
 
 export const SessionRepositoryFake = Layer.effect(
   SessionRepository,

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
@@ -4,6 +4,7 @@ import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+
 import { SessionNotFound } from "../domain/session-errors.js";
 import { type SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";

--- a/packages/server/src/modules/auth/infrastructure/session-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-live.integration.test.ts
@@ -7,10 +7,10 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
 
+import * as Session from "@/modules/auth/domain/session.aggregate.js";
 import { SessionNotFound } from "@/modules/auth/domain/session-errors.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
-import * as Session from "@/modules/auth/domain/session.aggregate.js";
 import { SessionRepositoryLive } from "@/modules/auth/infrastructure/session-repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";

--- a/packages/server/src/modules/auth/infrastructure/session-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-live.integration.test.ts
@@ -1,10 +1,3 @@
-import { SessionNotFound } from "@/modules/auth/domain/session-errors.js";
-import { SessionId } from "@/modules/auth/domain/session-id.js";
-import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
-import * as Session from "@/modules/auth/domain/session.aggregate.js";
-import { SessionRepositoryLive } from "@/modules/auth/infrastructure/session-repository-live.js";
-import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
@@ -13,6 +6,14 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
+
+import { SessionNotFound } from "@/modules/auth/domain/session-errors.js";
+import { SessionId } from "@/modules/auth/domain/session-id.js";
+import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
+import * as Session from "@/modules/auth/domain/session.aggregate.js";
+import { SessionRepositoryLive } from "@/modules/auth/infrastructure/session-repository-live.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const sessionId = SessionId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/auth/infrastructure/session-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-live.ts
@@ -2,10 +2,10 @@ import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
+import { type Session } from "../domain/session.aggregate.js";
 import { SessionNotFound } from "../domain/session-errors.js";
 import { type SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";
-import { type Session } from "../domain/session.aggregate.js";
 import * as SessionMapper from "./session-mapper.js";
 
 export const SessionRepositoryLive = Layer.effect(

--- a/packages/server/src/modules/auth/infrastructure/session-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-live.ts
@@ -1,6 +1,7 @@
 import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
 import { SessionNotFound } from "../domain/session-errors.js";
 import { type SessionId } from "../domain/session-id.js";
 import { SessionRepository } from "../domain/session-repository.js";

--- a/packages/server/src/modules/auth/interface/http/auth-live.ts
+++ b/packages/server/src/modules/auth/interface/http/auth-live.ts
@@ -1,6 +1,8 @@
-import { Api } from "@/api.js";
 import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
 import * as Layer from "effect/Layer";
+
+import { Api } from "@/api.js";
+
 import { callbackEndpoint } from "./callback.endpoint.js";
 import { loginEndpoint } from "./login.endpoint.js";
 import { logoutEndpoint } from "./logout.endpoint.js";

--- a/packages/server/src/modules/auth/interface/http/callback.endpoint.test.ts
+++ b/packages/server/src/modules/auth/interface/http/callback.endpoint.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { callbackEndpoint } from "./callback.endpoint.js";
 
 // The callback endpoint reads the OIDC PKCE cookie, exchanges the code with

--- a/packages/server/src/modules/auth/interface/http/callback.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/callback.endpoint.ts
@@ -1,13 +1,14 @@
-import { EnvVars } from "@/common/env-vars.js";
-import { SignInCommand } from "@/modules/auth/commands/sign-in-command.js";
-import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
-import { CookieCodec } from "@/platform/auth/cookie-codec.js";
-import { CommandBus } from "@/platform/ddd/command-bus.js";
 import * as HttpServerRequest from "@effect/platform/HttpServerRequest";
 import * as HttpServerResponse from "@effect/platform/HttpServerResponse";
 import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
 import * as cookie from "cookie";
 import * as Effect from "effect/Effect";
+
+import { EnvVars } from "@/common/env-vars.js";
+import { SignInCommand } from "@/modules/auth/commands/sign-in-command.js";
+import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
+import { CookieCodec } from "@/platform/auth/cookie-codec.js";
+import { CommandBus } from "@/platform/ddd/command-bus.js";
 
 const PKCE_COOKIE_NAME = "oidc_pkce";
 

--- a/packages/server/src/modules/auth/interface/http/login.endpoint.test.ts
+++ b/packages/server/src/modules/auth/interface/http/login.endpoint.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { loginEndpoint } from "./login.endpoint.js";
 
 // The login endpoint redirects (302) to Zitadel's authorization endpoint and

--- a/packages/server/src/modules/auth/interface/http/login.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/login.endpoint.ts
@@ -1,7 +1,8 @@
-import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
-import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 import * as HttpServerResponse from "@effect/platform/HttpServerResponse";
 import * as Effect from "effect/Effect";
+
+import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
+import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 
 const PKCE_COOKIE_NAME = "oidc_pkce";
 

--- a/packages/server/src/modules/auth/interface/http/logout.endpoint.test.ts
+++ b/packages/server/src/modules/auth/interface/http/logout.endpoint.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { logoutEndpoint } from "./logout.endpoint.js";
 
 // The logout endpoint reads the session cookie inline, revokes the row,

--- a/packages/server/src/modules/auth/interface/http/logout.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/logout.endpoint.ts
@@ -1,12 +1,13 @@
+import * as HttpServerRequest from "@effect/platform/HttpServerRequest";
+import * as HttpServerResponse from "@effect/platform/HttpServerResponse";
+import * as cookie from "cookie";
+import * as Effect from "effect/Effect";
+
 import { EnvVars } from "@/common/env-vars.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import { OidcClient } from "@/modules/auth/infrastructure/oidc-client.js";
 import { CookieCodec } from "@/platform/auth/cookie-codec.js";
-import * as HttpServerRequest from "@effect/platform/HttpServerRequest";
-import * as HttpServerResponse from "@effect/platform/HttpServerResponse";
-import * as cookie from "cookie";
-import * as Effect from "effect/Effect";
 
 // Sign out — single round-trip:
 //   1. Reads our session cookie inline (no middleware; logout must work even

--- a/packages/server/src/modules/auth/interface/http/me.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/me.endpoint.integration.test.ts
@@ -1,10 +1,11 @@
-import { Api } from "@/api.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 // `TestServerLive` provides `UserAuthMiddlewareFake`, which always succeeds
 // with a deterministic admin CurrentUser. So `/auth/me` should always return

--- a/packages/server/src/modules/auth/interface/http/me.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/me.endpoint.ts
@@ -1,7 +1,8 @@
-import { type EndpointRequest } from "@/platform/http-endpoint.js";
 import { AuthContract } from "@org/contracts/api/Contracts";
 import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
+
+import { type EndpointRequest } from "@/platform/http-endpoint.js";
 
 export const meEndpoint = (_request: EndpointRequest<typeof AuthContract.PrivateGroup, "me">) =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/auth/queries/auth-query-handlers.ts
+++ b/packages/server/src/modules/auth/queries/auth-query-handlers.ts
@@ -1,5 +1,5 @@
-import { findSessionQuerySpanAttributes } from "@/modules/auth/queries/find-session-query.js";
 import { findSession } from "@/modules/auth/queries/find-session.js";
+import { findSessionQuerySpanAttributes } from "@/modules/auth/queries/find-session-query.js";
 import { queryHandlers } from "@/platform/ddd/query-bus.js";
 
 export const authQueryHandlers = queryHandlers({

--- a/packages/server/src/modules/auth/queries/find-session-query.ts
+++ b/packages/server/src/modules/auth/queries/find-session-query.ts
@@ -1,6 +1,7 @@
 import type * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
+import { type Session } from "@/modules/auth/domain/session.aggregate.js";
 import {
   type SessionExpired,
   type SessionNotFound,
@@ -8,7 +9,6 @@ import {
 } from "@/modules/auth/domain/session-errors.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { type SessionRepository } from "@/modules/auth/domain/session-repository.js";
-import { type Session } from "@/modules/auth/domain/session.aggregate.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 
 export const FindSessionQuery = Schema.TaggedStruct("FindSessionQuery", {

--- a/packages/server/src/modules/auth/queries/find-session-query.ts
+++ b/packages/server/src/modules/auth/queries/find-session-query.ts
@@ -1,3 +1,6 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import {
   type SessionExpired,
   type SessionNotFound,
@@ -7,8 +10,6 @@ import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { type SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import { type Session } from "@/modules/auth/domain/session.aggregate.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const FindSessionQuery = Schema.TaggedStruct("FindSessionQuery", {
   sessionId: SessionId,

--- a/packages/server/src/modules/auth/queries/find-session.test.ts
+++ b/packages/server/src/modules/auth/queries/find-session.test.ts
@@ -1,3 +1,9 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
 import {
   SessionExpired,
   SessionNotFound,
@@ -10,11 +16,6 @@ import { SessionRepositoryFake } from "@/modules/auth/infrastructure/session-rep
 import { FindSessionQuery } from "@/modules/auth/queries/find-session-query.js";
 import { findSession } from "@/modules/auth/queries/find-session.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 
 const sessionId = SessionId.make("22222222-2222-2222-2222-222222222222");
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");

--- a/packages/server/src/modules/auth/queries/find-session.test.ts
+++ b/packages/server/src/modules/auth/queries/find-session.test.ts
@@ -4,6 +4,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
+import { Session } from "@/modules/auth/domain/session.aggregate.js";
 import {
   SessionExpired,
   SessionNotFound,
@@ -11,10 +12,9 @@ import {
 } from "@/modules/auth/domain/session-errors.js";
 import { SessionId } from "@/modules/auth/domain/session-id.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
-import { Session } from "@/modules/auth/domain/session.aggregate.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/session-repository-fake.js";
-import { FindSessionQuery } from "@/modules/auth/queries/find-session-query.js";
 import { findSession } from "@/modules/auth/queries/find-session.js";
+import { FindSessionQuery } from "@/modules/auth/queries/find-session-query.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 const sessionId = SessionId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/auth/queries/find-session.ts
+++ b/packages/server/src/modules/auth/queries/find-session.ts
@@ -1,11 +1,12 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import { SessionExpired, SessionRevoked } from "@/modules/auth/domain/session-errors.js";
 import { SessionRepository } from "@/modules/auth/domain/session-repository.js";
 import {
   type FindSessionOutput,
   type FindSessionQuery,
 } from "@/modules/auth/queries/find-session-query.js";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 // Looks up a session and validates its lifecycle (revoked / expired). Used
 // by the auth middleware via `QueryBus.execute(FindSessionQuery.make({...}))`

--- a/packages/server/src/modules/todos/commands/create-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/create-todo-command.ts
@@ -1,9 +1,10 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import { type Todo } from "@/modules/todos/domain/todo.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const CreateTodoCommand = Schema.TaggedStruct("CreateTodoCommand", {
   title: Schema.String,

--- a/packages/server/src/modules/todos/commands/create-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/create-todo-command.ts
@@ -1,8 +1,8 @@
 import type * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
-import { type TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import { type Todo } from "@/modules/todos/domain/todo.js";
+import { type TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
 

--- a/packages/server/src/modules/todos/commands/create-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.test.ts
@@ -1,9 +1,11 @@
-import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
+
+import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
+import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { CreateTodoCommand } from "./create-todo-command.js";
 import { createTodo } from "./create-todo.js";
 

--- a/packages/server/src/modules/todos/commands/create-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.test.ts
@@ -6,8 +6,8 @@ import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { CreateTodoCommand } from "./create-todo-command.js";
 import { createTodo } from "./create-todo.js";
+import { CreateTodoCommand } from "./create-todo-command.js";
 
 const aliceUserId = UserId.make("11111111-1111-1111-1111-111111111111");
 

--- a/packages/server/src/modules/todos/commands/create-todo.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.ts
@@ -5,9 +5,9 @@ import {
   type CreateTodoCommand,
   type CreateTodoOutput,
 } from "@/modules/todos/commands/create-todo-command.js";
+import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Todo from "@/modules/todos/domain/todo.js";
 
 export const createTodo = (cmd: CreateTodoCommand): CreateTodoOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/commands/create-todo.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.ts
@@ -1,3 +1,6 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import {
   type CreateTodoCommand,
   type CreateTodoOutput,
@@ -5,8 +8,6 @@ import {
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import * as Todo from "@/modules/todos/domain/todo.js";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 export const createTodo = (cmd: CreateTodoCommand): CreateTodoOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/commands/delete-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo-command.ts
@@ -1,10 +1,11 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const DeleteTodoCommand = Schema.TaggedStruct("DeleteTodoCommand", {
   todoId: TodoId,

--- a/packages/server/src/modules/todos/commands/delete-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.test.ts
@@ -1,14 +1,16 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
+
 import { DeleteTodoCommand } from "./delete-todo-command.js";
 import { deleteTodo } from "./delete-todo.js";
 

--- a/packages/server/src/modules/todos/commands/delete-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.test.ts
@@ -4,15 +4,15 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
+import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { DeleteTodoCommand } from "./delete-todo-command.js";
 import { deleteTodo } from "./delete-todo.js";
+import { DeleteTodoCommand } from "./delete-todo-command.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const aliceUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");

--- a/packages/server/src/modules/todos/commands/delete-todo.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.ts
@@ -1,9 +1,10 @@
+import * as Effect from "effect/Effect";
+
 import {
   type DeleteTodoCommand,
   type DeleteTodoOutput,
 } from "@/modules/todos/commands/delete-todo-command.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Effect from "effect/Effect";
 
 export const deleteTodo = (cmd: DeleteTodoCommand): DeleteTodoOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/commands/todo-command-handlers.ts
+++ b/packages/server/src/modules/todos/commands/todo-command-handlers.ts
@@ -1,9 +1,9 @@
-import { createTodoCommandSpanAttributes } from "@/modules/todos/commands/create-todo-command.js";
 import { createTodo } from "@/modules/todos/commands/create-todo.js";
-import { deleteTodoCommandSpanAttributes } from "@/modules/todos/commands/delete-todo-command.js";
+import { createTodoCommandSpanAttributes } from "@/modules/todos/commands/create-todo-command.js";
 import { deleteTodo } from "@/modules/todos/commands/delete-todo.js";
-import { updateTodoCommandSpanAttributes } from "@/modules/todos/commands/update-todo-command.js";
+import { deleteTodoCommandSpanAttributes } from "@/modules/todos/commands/delete-todo-command.js";
 import { updateTodo } from "@/modules/todos/commands/update-todo.js";
+import { updateTodoCommandSpanAttributes } from "@/modules/todos/commands/update-todo-command.js";
 import { commandHandlers } from "@/platform/ddd/command-bus.js";
 
 export const todoCommandHandlers = commandHandlers({

--- a/packages/server/src/modules/todos/commands/update-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/update-todo-command.ts
@@ -1,11 +1,12 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import { type Todo } from "@/modules/todos/domain/todo.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const UpdateTodoCommand = Schema.TaggedStruct("UpdateTodoCommand", {
   todoId: TodoId,

--- a/packages/server/src/modules/todos/commands/update-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/update-todo-command.ts
@@ -1,10 +1,10 @@
 import type * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
+import { type Todo } from "@/modules/todos/domain/todo.js";
 import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import { type Todo } from "@/modules/todos/domain/todo.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
 

--- a/packages/server/src/modules/todos/commands/update-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.test.ts
@@ -4,15 +4,15 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
+import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { UpdateTodoCommand } from "./update-todo-command.js";
 import { updateTodo } from "./update-todo.js";
+import { UpdateTodoCommand } from "./update-todo-command.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const aliceUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");

--- a/packages/server/src/modules/todos/commands/update-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.test.ts
@@ -1,14 +1,16 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
+
 import { UpdateTodoCommand } from "./update-todo-command.js";
 import { updateTodo } from "./update-todo.js";
 

--- a/packages/server/src/modules/todos/commands/update-todo.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.ts
@@ -1,11 +1,12 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import {
   type UpdateTodoCommand,
   type UpdateTodoOutput,
 } from "@/modules/todos/commands/update-todo-command.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import * as Todo from "@/modules/todos/domain/todo.js";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 export const updateTodo = (cmd: UpdateTodoCommand): UpdateTodoOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/commands/update-todo.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.ts
@@ -5,8 +5,8 @@ import {
   type UpdateTodoCommand,
   type UpdateTodoOutput,
 } from "@/modules/todos/commands/update-todo-command.js";
-import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import * as Todo from "@/modules/todos/domain/todo.js";
+import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 
 export const updateTodo = (cmd: UpdateTodoCommand): UpdateTodoOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/domain/todo-errors.ts
+++ b/packages/server/src/modules/todos/domain/todo-errors.ts
@@ -1,4 +1,5 @@
 import * as Schema from "effect/Schema";
+
 import { TodoId } from "./todo-id.js";
 
 export class TodoNotFound extends Schema.TaggedError<TodoNotFound>("TodoNotFound")("TodoNotFound", {

--- a/packages/server/src/modules/todos/domain/todo-repository.ts
+++ b/packages/server/src/modules/todos/domain/todo-repository.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
+
 import { type TodoNotFound } from "./todo-errors.js";
 import { type TodoId } from "./todo-id.js";
 import { type Todo } from "./todo.js";

--- a/packages/server/src/modules/todos/domain/todo-repository.ts
+++ b/packages/server/src/modules/todos/domain/todo-repository.ts
@@ -1,9 +1,9 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 
+import { type Todo } from "./todo.js";
 import { type TodoNotFound } from "./todo-errors.js";
 import { type TodoId } from "./todo-id.js";
-import { type Todo } from "./todo.js";
 
 export type TodosRepositoryShape = {
   readonly insert: (todo: Todo) => Effect.Effect<void>;

--- a/packages/server/src/modules/todos/domain/todo.ts
+++ b/packages/server/src/modules/todos/domain/todo.ts
@@ -1,5 +1,6 @@
 import type * as DateTime from "effect/DateTime";
 import * as Schema from "effect/Schema";
+
 import { TodoId } from "./todo-id.js";
 
 export class Todo extends Schema.Class<Todo>("Todo")({

--- a/packages/server/src/modules/todos/infrastructure/todo-mapper.ts
+++ b/packages/server/src/modules/todos/infrastructure/todo-mapper.ts
@@ -1,5 +1,6 @@
 import { type RowSchemas } from "@org/database/index";
 import * as DateTime from "effect/DateTime";
+
 import { TodoId } from "../domain/todo-id.js";
 import { Todo } from "../domain/todo.js";
 

--- a/packages/server/src/modules/todos/infrastructure/todo-mapper.ts
+++ b/packages/server/src/modules/todos/infrastructure/todo-mapper.ts
@@ -1,8 +1,8 @@
 import { type RowSchemas } from "@org/database/index";
 import * as DateTime from "effect/DateTime";
 
-import { TodoId } from "../domain/todo-id.js";
 import { Todo } from "../domain/todo.js";
+import { TodoId } from "../domain/todo-id.js";
 
 type Row = RowSchemas.TodoRow;
 

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
@@ -6,9 +6,9 @@ import * as Exit from "effect/Exit";
 
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 
+import * as Todo from "../domain/todo.js";
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { TodosRepository } from "../domain/todo-repository.js";
-import * as Todo from "../domain/todo.js";
 import { TodosRepositoryFake } from "./todos-repository-fake.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
@@ -1,9 +1,11 @@
-import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { TodosRepository } from "../domain/todo-repository.js";
 import * as Todo from "../domain/todo.js";

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
@@ -3,6 +3,7 @@ import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { type TodoId } from "../domain/todo-id.js";
 import { TodosRepository } from "../domain/todo-repository.js";

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
@@ -4,10 +4,10 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
+import { type Todo } from "../domain/todo.js";
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { type TodoId } from "../domain/todo-id.js";
 import { TodosRepository } from "../domain/todo-repository.js";
-import { type Todo } from "../domain/todo.js";
 
 export const TodosRepositoryFake = Layer.effect(
   TodosRepository,

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
@@ -1,9 +1,3 @@
-import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
-import { TodoId } from "@/modules/todos/domain/todo-id.js";
-import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Todo from "@/modules/todos/domain/todo.js";
-import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { describe, it } from "@effect/vitest";
 import { Database } from "@org/database/index";
 import { deepStrictEqual } from "assert";
@@ -12,6 +6,13 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
+
+import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
+import * as Todo from "@/modules/todos/domain/todo.js";
+import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
@@ -7,10 +7,10 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
 
+import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
@@ -2,10 +2,10 @@ import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
+import { type Todo } from "../domain/todo.js";
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { type TodoId } from "../domain/todo-id.js";
 import { TodosRepository } from "../domain/todo-repository.js";
-import { type Todo } from "../domain/todo.js";
 import * as TodoMapper from "./todo-mapper.js";
 
 export const TodosRepositoryLive = Layer.effect(

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
@@ -1,6 +1,7 @@
 import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { type TodoId } from "../domain/todo-id.js";
 import { TodosRepository } from "../domain/todo-repository.js";

--- a/packages/server/src/modules/todos/interface/http/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/create.endpoint.integration.test.ts
@@ -1,10 +1,11 @@
-import { Api } from "@/api.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 

--- a/packages/server/src/modules/todos/interface/http/create.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/create.endpoint.ts
@@ -1,9 +1,10 @@
-import { CreateTodoCommand } from "@/modules/todos/commands/create-todo-command.js";
-import { CommandBus } from "@/platform/ddd/command-bus.js";
-import { type EndpointRequest } from "@/platform/http-endpoint.js";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
+
+import { CreateTodoCommand } from "@/modules/todos/commands/create-todo-command.js";
+import { CommandBus } from "@/platform/ddd/command-bus.js";
+import { type EndpointRequest } from "@/platform/http-endpoint.js";
 
 export const createEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "create">) =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/interface/http/delete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/delete.endpoint.integration.test.ts
@@ -1,13 +1,14 @@
-import { Api } from "@/api.js";
-import { TodoId } from "@/modules/todos/domain/todo-id.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { Api } from "@/api.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 

--- a/packages/server/src/modules/todos/interface/http/delete.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/delete.endpoint.ts
@@ -1,9 +1,10 @@
-import { DeleteTodoCommand } from "@/modules/todos/commands/delete-todo-command.js";
-import { CommandBus } from "@/platform/ddd/command-bus.js";
-import { type EndpointRequest } from "@/platform/http-endpoint.js";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
+
+import { DeleteTodoCommand } from "@/modules/todos/commands/delete-todo-command.js";
+import { CommandBus } from "@/platform/ddd/command-bus.js";
+import { type EndpointRequest } from "@/platform/http-endpoint.js";
 
 export const deleteEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "delete">) =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/interface/http/get.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/get.endpoint.integration.test.ts
@@ -1,10 +1,11 @@
-import { Api } from "@/api.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 

--- a/packages/server/src/modules/todos/interface/http/get.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/get.endpoint.ts
@@ -1,12 +1,13 @@
+import { TodosContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
 import {
+  ListTodosQuery,
   type ListTodosResult,
   type ListTodosTodoView,
-  ListTodosQuery,
 } from "@/modules/todos/queries/list-todos-query.js";
 import { QueryBus } from "@/platform/ddd/query-bus.js";
 import { type EndpointRequest } from "@/platform/http-endpoint.js";
-import { TodosContract } from "@org/contracts/api/Contracts";
-import * as Effect from "effect/Effect";
 
 const toContract = (view: ListTodosTodoView): TodosContract.Todo =>
   new TodosContract.Todo({

--- a/packages/server/src/modules/todos/interface/http/todos-live.ts
+++ b/packages/server/src/modules/todos/interface/http/todos-live.ts
@@ -1,9 +1,10 @@
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+
 import { Api } from "@/api.js";
 import { createEndpoint } from "@/modules/todos/interface/http/create.endpoint.js";
 import { deleteEndpoint } from "@/modules/todos/interface/http/delete.endpoint.js";
 import { getEndpoint } from "@/modules/todos/interface/http/get.endpoint.js";
 import { updateEndpoint } from "@/modules/todos/interface/http/update.endpoint.js";
-import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
 
 export const TodosLive = HttpApiBuilder.group(Api, "todos", (handlers) =>
   handlers

--- a/packages/server/src/modules/todos/interface/http/update.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/update.endpoint.integration.test.ts
@@ -1,13 +1,14 @@
-import { Api } from "@/api.js";
-import { TodoId } from "@/modules/todos/domain/todo-id.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { Api } from "@/api.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 

--- a/packages/server/src/modules/todos/interface/http/update.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/update.endpoint.ts
@@ -1,9 +1,10 @@
-import { UpdateTodoCommand } from "@/modules/todos/commands/update-todo-command.js";
-import { CommandBus } from "@/platform/ddd/command-bus.js";
-import { type EndpointRequest } from "@/platform/http-endpoint.js";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
+
+import { UpdateTodoCommand } from "@/modules/todos/commands/update-todo-command.js";
+import { CommandBus } from "@/platform/ddd/command-bus.js";
+import { type EndpointRequest } from "@/platform/http-endpoint.js";
 
 export const updateEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "update">) =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/todos/queries/list-todos-query.ts
+++ b/packages/server/src/modules/todos/queries/list-todos-query.ts
@@ -1,8 +1,9 @@
-import { type TodoId } from "@/modules/todos/domain/todo-id.js";
-import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { type Database } from "@org/database/index";
 import type * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+
+import { type TodoId } from "@/modules/todos/domain/todo-id.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 
 export const ListTodosQuery = Schema.TaggedStruct("ListTodosQuery", {});
 export type ListTodosQuery = typeof ListTodosQuery.Type;

--- a/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
@@ -1,3 +1,10 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { beforeEach } from "vitest";
+
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
 import * as Todo from "@/modules/todos/domain/todo.js";
@@ -5,12 +12,6 @@ import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-reposi
 import { ListTodosQuery } from "@/modules/todos/queries/list-todos-query.js";
 import { listTodos } from "@/modules/todos/queries/list-todos.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import { beforeEach } from "vitest";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
@@ -5,12 +5,12 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
 
+import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo-repository.js";
-import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
-import { ListTodosQuery } from "@/modules/todos/queries/list-todos-query.js";
 import { listTodos } from "@/modules/todos/queries/list-todos.js";
+import { ListTodosQuery } from "@/modules/todos/queries/list-todos-query.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");

--- a/packages/server/src/modules/todos/queries/list-todos.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.ts
@@ -1,11 +1,12 @@
+import { Database, RowSchemas, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import {
   type ListTodosOutput,
   type ListTodosQuery,
   type ListTodosTodoView,
 } from "@/modules/todos/queries/list-todos-query.js";
-import { Database, RowSchemas, sql } from "@org/database/index";
-import * as Effect from "effect/Effect";
 
 const toView = (row: RowSchemas.TodoRow): ListTodosTodoView => ({
   id: TodoId.make(row.id),

--- a/packages/server/src/modules/todos/queries/todo-query-handlers.ts
+++ b/packages/server/src/modules/todos/queries/todo-query-handlers.ts
@@ -1,5 +1,5 @@
-import { listTodosQuerySpanAttributes } from "@/modules/todos/queries/list-todos-query.js";
 import { listTodos } from "@/modules/todos/queries/list-todos.js";
+import { listTodosQuerySpanAttributes } from "@/modules/todos/queries/list-todos-query.js";
 import { queryHandlers } from "@/platform/ddd/query-bus.js";
 
 export const todoQueryHandlers = queryHandlers({

--- a/packages/server/src/modules/todos/todos-module.ts
+++ b/packages/server/src/modules/todos/todos-module.ts
@@ -1,4 +1,5 @@
 import * as Layer from "effect/Layer";
+
 import { TodosRepositoryLive } from "./infrastructure/todos-repository-live.js";
 import { TodosLive } from "./interface/http/todos-live.js";
 

--- a/packages/server/src/modules/user/commands/change-user-role-command.ts
+++ b/packages/server/src/modules/user/commands/change-user-role-command.ts
@@ -1,11 +1,12 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type UserNotFound } from "@/modules/user/domain/user-errors.js";
 import { type UserRepository } from "@/modules/user/domain/user-repository.js";
 import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { type UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const PromotableRole = Schema.Literal("admin", "moderator");
 export type PromotableRole = typeof PromotableRole.Type;

--- a/packages/server/src/modules/user/commands/change-user-role.test.ts
+++ b/packages/server/src/modules/user/commands/change-user-role.test.ts
@@ -13,10 +13,10 @@ import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
 
-import { ChangeUserRoleCommand } from "./change-user-role-command.js";
 import { changeUserRole } from "./change-user-role.js";
-import { CreateUserCommand } from "./create-user-command.js";
+import { ChangeUserRoleCommand } from "./change-user-role-command.js";
 import { createUser } from "./create-user.js";
+import { CreateUserCommand } from "./create-user-command.js";
 
 const TestLayer = Layer.mergeAll(UserRepositoryFake, RecordingEventBus, IdentityUnitOfWork);
 

--- a/packages/server/src/modules/user/commands/change-user-role.test.ts
+++ b/packages/server/src/modules/user/commands/change-user-role.test.ts
@@ -1,3 +1,9 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
 import { UserNotFound } from "@/modules/user/domain/user-errors.js";
 import { type UserRoleChanged } from "@/modules/user/domain/user-events.js";
 import { UserRepository } from "@/modules/user/domain/user-repository.js";
@@ -6,11 +12,7 @@ import { UserRepositoryFake } from "@/modules/user/infrastructure/user-repositor
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Layer from "effect/Layer";
+
 import { ChangeUserRoleCommand } from "./change-user-role-command.js";
 import { changeUserRole } from "./change-user-role.js";
 import { CreateUserCommand } from "./create-user-command.js";

--- a/packages/server/src/modules/user/commands/change-user-role.ts
+++ b/packages/server/src/modules/user/commands/change-user-role.ts
@@ -1,3 +1,6 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import {
   type ChangeUserRoleCommand,
   type ChangeUserRoleOutput,
@@ -6,8 +9,6 @@ import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 export const changeUserRole = (cmd: ChangeUserRoleCommand): ChangeUserRoleOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/user/commands/change-user-role.ts
+++ b/packages/server/src/modules/user/commands/change-user-role.ts
@@ -5,8 +5,8 @@ import {
   type ChangeUserRoleCommand,
   type ChangeUserRoleOutput,
 } from "@/modules/user/commands/change-user-role-command.js";
-import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
+import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 

--- a/packages/server/src/modules/user/commands/create-user-command.ts
+++ b/packages/server/src/modules/user/commands/create-user-command.ts
@@ -1,11 +1,12 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type UserAlreadyExists } from "@/modules/user/domain/user-errors.js";
 import { type UserRepository } from "@/modules/user/domain/user-repository.js";
 import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { type UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import { type UserId } from "@/platform/ids/user-id.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const CreateUserCommand = Schema.TaggedStruct("CreateUserCommand", {
   email: Schema.String,

--- a/packages/server/src/modules/user/commands/create-user.test.ts
+++ b/packages/server/src/modules/user/commands/create-user.test.ts
@@ -11,8 +11,8 @@ import { UserRepositoryFake } from "@/modules/user/infrastructure/user-repositor
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
 
-import { CreateUserCommand } from "./create-user-command.js";
 import { createUser } from "./create-user.js";
+import { CreateUserCommand } from "./create-user-command.js";
 
 const TestLayer = Layer.mergeAll(UserRepositoryFake, RecordingEventBus, IdentityUnitOfWork);
 

--- a/packages/server/src/modules/user/commands/create-user.test.ts
+++ b/packages/server/src/modules/user/commands/create-user.test.ts
@@ -1,14 +1,16 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
 import { UserAlreadyExists } from "@/modules/user/domain/user-errors.js";
 import { type UserCreated } from "@/modules/user/domain/user-events.js";
 import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import { UserRepositoryFake } from "@/modules/user/infrastructure/user-repository-fake.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Layer from "effect/Layer";
+
 import { CreateUserCommand } from "./create-user-command.js";
 import { createUser } from "./create-user.js";
 

--- a/packages/server/src/modules/user/commands/create-user.ts
+++ b/packages/server/src/modules/user/commands/create-user.ts
@@ -5,8 +5,8 @@ import {
   type CreateUserCommand,
   type CreateUserOutput,
 } from "@/modules/user/commands/create-user-command.js";
-import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
+import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import { Address } from "@/modules/user/domain/value-objects/address.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";

--- a/packages/server/src/modules/user/commands/create-user.ts
+++ b/packages/server/src/modules/user/commands/create-user.ts
@@ -1,3 +1,6 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import {
   type CreateUserCommand,
   type CreateUserOutput,
@@ -8,8 +11,6 @@ import { Address } from "@/modules/user/domain/value-objects/address.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
 
 export const createUser = (cmd: CreateUserCommand): CreateUserOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/user/commands/delete-user-command.ts
+++ b/packages/server/src/modules/user/commands/delete-user-command.ts
@@ -1,11 +1,12 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type UserNotFound } from "@/modules/user/domain/user-errors.js";
 import { type UserRepository } from "@/modules/user/domain/user-repository.js";
 import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { type UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import type * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 export const DeleteUserCommand = Schema.TaggedStruct("DeleteUserCommand", {
   userId: UserId,

--- a/packages/server/src/modules/user/commands/delete-user.test.ts
+++ b/packages/server/src/modules/user/commands/delete-user.test.ts
@@ -13,10 +13,10 @@ import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
 
-import { CreateUserCommand } from "./create-user-command.js";
 import { createUser } from "./create-user.js";
-import { DeleteUserCommand } from "./delete-user-command.js";
+import { CreateUserCommand } from "./create-user-command.js";
 import { deleteUser } from "./delete-user.js";
+import { DeleteUserCommand } from "./delete-user-command.js";
 
 const TestLayer = Layer.mergeAll(UserRepositoryFake, RecordingEventBus, IdentityUnitOfWork);
 

--- a/packages/server/src/modules/user/commands/delete-user.test.ts
+++ b/packages/server/src/modules/user/commands/delete-user.test.ts
@@ -1,3 +1,9 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
 import { UserNotFound } from "@/modules/user/domain/user-errors.js";
 import { type UserDeleted } from "@/modules/user/domain/user-events.js";
 import { UserRepository } from "@/modules/user/domain/user-repository.js";
@@ -6,11 +12,7 @@ import { UserRepositoryFake } from "@/modules/user/infrastructure/user-repositor
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Layer from "effect/Layer";
+
 import { CreateUserCommand } from "./create-user-command.js";
 import { createUser } from "./create-user.js";
 import { DeleteUserCommand } from "./delete-user-command.js";

--- a/packages/server/src/modules/user/commands/delete-user.ts
+++ b/packages/server/src/modules/user/commands/delete-user.ts
@@ -4,8 +4,8 @@ import {
   type DeleteUserCommand,
   type DeleteUserOutput,
 } from "@/modules/user/commands/delete-user-command.js";
-import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
+import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 

--- a/packages/server/src/modules/user/commands/delete-user.ts
+++ b/packages/server/src/modules/user/commands/delete-user.ts
@@ -1,3 +1,5 @@
+import * as Effect from "effect/Effect";
+
 import {
   type DeleteUserCommand,
   type DeleteUserOutput,
@@ -6,7 +8,6 @@ import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
-import * as Effect from "effect/Effect";
 
 export const deleteUser = (cmd: DeleteUserCommand): DeleteUserOutput =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/user/commands/user-command-handlers.ts
+++ b/packages/server/src/modules/user/commands/user-command-handlers.ts
@@ -1,9 +1,9 @@
-import { changeUserRoleCommandSpanAttributes } from "@/modules/user/commands/change-user-role-command.js";
 import { changeUserRole } from "@/modules/user/commands/change-user-role.js";
-import { createUserCommandSpanAttributes } from "@/modules/user/commands/create-user-command.js";
+import { changeUserRoleCommandSpanAttributes } from "@/modules/user/commands/change-user-role-command.js";
 import { createUser } from "@/modules/user/commands/create-user.js";
-import { deleteUserCommandSpanAttributes } from "@/modules/user/commands/delete-user-command.js";
+import { createUserCommandSpanAttributes } from "@/modules/user/commands/create-user-command.js";
 import { deleteUser } from "@/modules/user/commands/delete-user.js";
+import { deleteUserCommandSpanAttributes } from "@/modules/user/commands/delete-user-command.js";
 import { commandHandlers } from "@/platform/ddd/command-bus.js";
 
 export const userCommandHandlers = commandHandlers({

--- a/packages/server/src/modules/user/domain/user-errors.ts
+++ b/packages/server/src/modules/user/domain/user-errors.ts
@@ -1,5 +1,6 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
 
 export class UserAlreadyExists extends Schema.TaggedError<UserAlreadyExists>("UserAlreadyExists")(
   "UserAlreadyExists",

--- a/packages/server/src/modules/user/domain/user-events.ts
+++ b/packages/server/src/modules/user/domain/user-events.ts
@@ -1,7 +1,9 @@
+import * as Schema from "effect/Schema";
+
 import { DomainEvent } from "@/platform/ddd/domain-event.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import * as Schema from "effect/Schema";
+
 import { UserRole } from "./user-role.js";
 import { Address } from "./value-objects/address.js";
 

--- a/packages/server/src/modules/user/domain/user-repository.ts
+++ b/packages/server/src/modules/user/domain/user-repository.ts
@@ -1,7 +1,9 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as Option from "effect/Option";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { type UserAlreadyExists, type UserNotFound } from "./user-errors.js";
 import { type User } from "./user.aggregate.js";
 

--- a/packages/server/src/modules/user/domain/user-repository.ts
+++ b/packages/server/src/modules/user/domain/user-repository.ts
@@ -4,8 +4,8 @@ import type * as Option from "effect/Option";
 
 import { type UserId } from "@/platform/ids/user-id.js";
 
-import { type UserAlreadyExists, type UserNotFound } from "./user-errors.js";
 import { type User } from "./user.aggregate.js";
+import { type UserAlreadyExists, type UserNotFound } from "./user-errors.js";
 
 export type UserRepositoryShape = {
   readonly insert: (user: User) => Effect.Effect<void, UserAlreadyExists>;

--- a/packages/server/src/modules/user/domain/user.aggregate.test.ts
+++ b/packages/server/src/modules/user/domain/user.aggregate.test.ts
@@ -1,9 +1,11 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Either from "effect/Either";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { type UserEvent } from "./user-events.js";
 import * as User from "./user.aggregate.js";
 import { Address } from "./value-objects/address.js";

--- a/packages/server/src/modules/user/domain/user.aggregate.test.ts
+++ b/packages/server/src/modules/user/domain/user.aggregate.test.ts
@@ -6,8 +6,8 @@ import * as Schema from "effect/Schema";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { type UserEvent } from "./user-events.js";
 import * as User from "./user.aggregate.js";
+import { type UserEvent } from "./user-events.js";
 import { Address } from "./value-objects/address.js";
 
 const id = UserId.make("11111111-1111-1111-1111-111111111111");

--- a/packages/server/src/modules/user/domain/user.aggregate.ts
+++ b/packages/server/src/modules/user/domain/user.aggregate.ts
@@ -1,12 +1,14 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import type * as DateTime from "effect/DateTime";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import {
   UserAddressUpdated,
   UserCreated,
   UserDeleted,
-  UserRoleChanged,
   type UserEvent,
+  UserRoleChanged,
 } from "./user-events.js";
 import { UserRole } from "./user-role.js";
 import { Address } from "./value-objects/address.js";

--- a/packages/server/src/modules/user/infrastructure/user-mapper.ts
+++ b/packages/server/src/modules/user/infrastructure/user-mapper.ts
@@ -3,8 +3,8 @@ import * as DateTime from "effect/DateTime";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { type UserRole } from "../domain/user-role.js";
 import { User } from "../domain/user.aggregate.js";
+import { type UserRole } from "../domain/user-role.js";
 import { Address } from "../domain/value-objects/address.js";
 
 type Row = RowSchemas.UserRow;

--- a/packages/server/src/modules/user/infrastructure/user-mapper.ts
+++ b/packages/server/src/modules/user/infrastructure/user-mapper.ts
@@ -1,6 +1,8 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { type RowSchemas } from "@org/database/index";
 import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { type UserRole } from "../domain/user-role.js";
 import { User } from "../domain/user.aggregate.js";
 import { Address } from "../domain/value-objects/address.js";

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.test.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.test.ts
@@ -1,10 +1,12 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
 import * as User from "../domain/user.aggregate.js";

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.test.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.test.ts
@@ -7,9 +7,9 @@ import * as Option from "effect/Option";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
+import * as User from "../domain/user.aggregate.js";
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
-import * as User from "../domain/user.aggregate.js";
 import { Address } from "../domain/value-objects/address.js";
 import { UserRepositoryFake } from "./user-repository-fake.js";
 

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
@@ -1,9 +1,11 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import * as Effect from "effect/Effect";
 import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
 import { type User } from "../domain/user.aggregate.js";

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
@@ -6,9 +6,9 @@ import * as Ref from "effect/Ref";
 
 import { type UserId } from "@/platform/ids/user-id.js";
 
+import { type User } from "../domain/user.aggregate.js";
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
-import { type User } from "../domain/user.aggregate.js";
 
 const findUserByEmail = (
   store: HashMap.HashMap<UserId, User>,

--- a/packages/server/src/modules/user/infrastructure/user-repository-live.integration.test.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-live.integration.test.ts
@@ -8,9 +8,9 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
 
+import * as User from "@/modules/user/domain/user.aggregate.js";
 import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user-errors.js";
 import { UserRepository } from "@/modules/user/domain/user-repository.js";
-import * as User from "@/modules/user/domain/user.aggregate.js";
 import { Address } from "@/modules/user/domain/value-objects/address.js";
 import { UserRepositoryLive } from "@/modules/user/infrastructure/user-repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";

--- a/packages/server/src/modules/user/infrastructure/user-repository-live.integration.test.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-live.integration.test.ts
@@ -1,10 +1,3 @@
-import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user-errors.js";
-import { UserRepository } from "@/modules/user/domain/user-repository.js";
-import * as User from "@/modules/user/domain/user.aggregate.js";
-import { Address } from "@/modules/user/domain/value-objects/address.js";
-import { UserRepositoryLive } from "@/modules/user/infrastructure/user-repository-live.js";
-import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { describe, it } from "@effect/vitest";
 import { Database } from "@org/database/index";
 import { deepStrictEqual } from "assert";
@@ -14,6 +7,14 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
+
+import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user-errors.js";
+import { UserRepository } from "@/modules/user/domain/user-repository.js";
+import * as User from "@/modules/user/domain/user.aggregate.js";
+import { Address } from "@/modules/user/domain/value-objects/address.js";
+import { UserRepositoryLive } from "@/modules/user/infrastructure/user-repository-live.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
 const bobId = UserId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/user/infrastructure/user-repository-live.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-live.ts
@@ -5,9 +5,9 @@ import * as Option from "effect/Option";
 
 import { type UserId } from "@/platform/ids/user-id.js";
 
+import { type User } from "../domain/user.aggregate.js";
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
-import { type User } from "../domain/user.aggregate.js";
 import * as UserMapper from "./user-mapper.js";
 
 export const UserRepositoryLive = Layer.effect(

--- a/packages/server/src/modules/user/infrastructure/user-repository-live.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-live.ts
@@ -1,8 +1,10 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { UserAlreadyExists, UserNotFound } from "../domain/user-errors.js";
 import { UserRepository } from "../domain/user-repository.js";
 import { type User } from "../domain/user.aggregate.js";

--- a/packages/server/src/modules/user/interface/http/change-role.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/change-role.endpoint.integration.test.ts
@@ -1,12 +1,13 @@
-import { Api } from "@/api.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { UserContract } from "@org/contracts/api/Contracts";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",

--- a/packages/server/src/modules/user/interface/http/change-role.endpoint.ts
+++ b/packages/server/src/modules/user/interface/http/change-role.endpoint.ts
@@ -1,8 +1,9 @@
+import { UserContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
 import { ChangeUserRoleCommand } from "@/modules/user/commands/change-user-role-command.js";
 import { CommandBus } from "@/platform/ddd/command-bus.js";
 import { type EndpointRequest } from "@/platform/http-endpoint.js";
-import { UserContract } from "@org/contracts/api/Contracts";
-import * as Effect from "effect/Effect";
 
 export const changeRoleEndpoint = (
   request: EndpointRequest<typeof UserContract.Group, "changeRole">,

--- a/packages/server/src/modules/user/interface/http/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/create.endpoint.integration.test.ts
@@ -1,14 +1,15 @@
-import { Api } from "@/api.js";
-import { FindUsersQuery } from "@/modules/user/index.js";
-import { QueryBus } from "@/platform/ddd/query-bus.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { UserContract } from "@org/contracts/api/Contracts";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { Api } from "@/api.js";
+import { FindUsersQuery } from "@/modules/user/index.js";
+import { QueryBus } from "@/platform/ddd/query-bus.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",

--- a/packages/server/src/modules/user/interface/http/create.endpoint.ts
+++ b/packages/server/src/modules/user/interface/http/create.endpoint.ts
@@ -1,8 +1,9 @@
+import { UserContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
 import { CreateUserCommand } from "@/modules/user/commands/create-user-command.js";
 import { CommandBus } from "@/platform/ddd/command-bus.js";
 import { type EndpointRequest } from "@/platform/http-endpoint.js";
-import { UserContract } from "@org/contracts/api/Contracts";
-import * as Effect from "effect/Effect";
 
 export const createEndpoint = (request: EndpointRequest<typeof UserContract.Group, "create">) =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/user/interface/http/delete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/delete.endpoint.integration.test.ts
@@ -1,12 +1,13 @@
-import { Api } from "@/api.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { UserContract } from "@org/contracts/api/Contracts";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",

--- a/packages/server/src/modules/user/interface/http/delete.endpoint.ts
+++ b/packages/server/src/modules/user/interface/http/delete.endpoint.ts
@@ -1,8 +1,9 @@
+import { UserContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
 import { DeleteUserCommand } from "@/modules/user/commands/delete-user-command.js";
 import { CommandBus } from "@/platform/ddd/command-bus.js";
 import { type EndpointRequest } from "@/platform/http-endpoint.js";
-import { UserContract } from "@org/contracts/api/Contracts";
-import * as Effect from "effect/Effect";
 
 export const deleteEndpoint = (request: EndpointRequest<typeof UserContract.Group, "delete">) =>
   Effect.gen(function* () {

--- a/packages/server/src/modules/user/interface/http/find.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/find.endpoint.integration.test.ts
@@ -1,10 +1,11 @@
-import { Api } from "@/api.js";
-import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",

--- a/packages/server/src/modules/user/interface/http/find.endpoint.ts
+++ b/packages/server/src/modules/user/interface/http/find.endpoint.ts
@@ -1,8 +1,9 @@
-import { type FindUsersResult, FindUsersQuery } from "@/modules/user/queries/find-users-query.js";
-import { QueryBus } from "@/platform/ddd/query-bus.js";
-import { type EndpointRequest } from "@/platform/http-endpoint.js";
 import { UserContract } from "@org/contracts/api/Contracts";
 import * as Effect from "effect/Effect";
+
+import { FindUsersQuery, type FindUsersResult } from "@/modules/user/queries/find-users-query.js";
+import { QueryBus } from "@/platform/ddd/query-bus.js";
+import { type EndpointRequest } from "@/platform/http-endpoint.js";
 
 const toPaginatedUsersContract = (result: FindUsersResult): UserContract.PaginatedUsers =>
   new UserContract.PaginatedUsers({

--- a/packages/server/src/modules/user/interface/http/user-live.ts
+++ b/packages/server/src/modules/user/interface/http/user-live.ts
@@ -1,9 +1,10 @@
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+
 import { Api } from "@/api.js";
 import { changeRoleEndpoint } from "@/modules/user/interface/http/change-role.endpoint.js";
 import { createEndpoint } from "@/modules/user/interface/http/create.endpoint.js";
 import { deleteEndpoint } from "@/modules/user/interface/http/delete.endpoint.js";
 import { findEndpoint } from "@/modules/user/interface/http/find.endpoint.js";
-import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
 
 export const UserLive = HttpApiBuilder.group(Api, "user", (handlers) =>
   handlers

--- a/packages/server/src/modules/user/queries/find-users-query.ts
+++ b/packages/server/src/modules/user/queries/find-users-query.ts
@@ -1,10 +1,11 @@
-import { type UserRole } from "@/modules/user/domain/user-role.js";
-import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
-import { type UserId } from "@/platform/ids/user-id.js";
 import { type Database } from "@org/database/index";
 import type * as DateTime from "effect/DateTime";
 import type * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+
+import { type UserRole } from "@/modules/user/domain/user-role.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
+import { type UserId } from "@/platform/ids/user-id.js";
 
 export const FindUsersQuery = Schema.TaggedStruct("FindUsersQuery", {
   page: Schema.Number,

--- a/packages/server/src/modules/user/queries/find-users.integration.test.ts
+++ b/packages/server/src/modules/user/queries/find-users.integration.test.ts
@@ -5,12 +5,12 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
 
-import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
+import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import { Address } from "@/modules/user/domain/value-objects/address.js";
 import { UserRepositoryLive } from "@/modules/user/infrastructure/user-repository-live.js";
-import { FindUsersQuery } from "@/modules/user/queries/find-users-query.js";
 import { findUsers } from "@/modules/user/queries/find-users.js";
+import { FindUsersQuery } from "@/modules/user/queries/find-users-query.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 

--- a/packages/server/src/modules/user/queries/find-users.integration.test.ts
+++ b/packages/server/src/modules/user/queries/find-users.integration.test.ts
@@ -1,3 +1,10 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { beforeEach } from "vitest";
+
 import { UserRepository } from "@/modules/user/domain/user-repository.js";
 import * as User from "@/modules/user/domain/user.aggregate.js";
 import { Address } from "@/modules/user/domain/value-objects/address.js";
@@ -6,12 +13,6 @@ import { FindUsersQuery } from "@/modules/user/queries/find-users-query.js";
 import { findUsers } from "@/modules/user/queries/find-users.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import { beforeEach } from "vitest";
 
 const address = Address.make({
   country: "USA",

--- a/packages/server/src/modules/user/queries/find-users.ts
+++ b/packages/server/src/modules/user/queries/find-users.ts
@@ -1,3 +1,7 @@
+import { Database, RowSchemas, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 import { type UserRole } from "@/modules/user/domain/user-role.js";
 import {
   type FindUsersOutput,
@@ -5,9 +9,6 @@ import {
   type FindUsersUserView,
 } from "@/modules/user/queries/find-users-query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { Database, RowSchemas, sql } from "@org/database/index";
-import * as Effect from "effect/Effect";
-import * as Schema from "effect/Schema";
 
 const CountRowStd = Schema.standardSchemaV1(Schema.Struct({ value: Schema.Number }));
 

--- a/packages/server/src/modules/user/queries/user-query-handlers.ts
+++ b/packages/server/src/modules/user/queries/user-query-handlers.ts
@@ -1,5 +1,5 @@
-import { findUsersQuerySpanAttributes } from "@/modules/user/queries/find-users-query.js";
 import { findUsers } from "@/modules/user/queries/find-users.js";
+import { findUsersQuerySpanAttributes } from "@/modules/user/queries/find-users-query.js";
 import { queryHandlers } from "@/platform/ddd/query-bus.js";
 
 export const userQueryHandlers = queryHandlers({

--- a/packages/server/src/modules/user/user-module.ts
+++ b/packages/server/src/modules/user/user-module.ts
@@ -1,4 +1,5 @@
 import * as Layer from "effect/Layer";
+
 import { UserRepositoryLive } from "./infrastructure/user-repository-live.js";
 import { UserLive } from "./interface/http/user-live.js";
 

--- a/packages/server/src/modules/wallet/domain/wallet-errors.ts
+++ b/packages/server/src/modules/wallet/domain/wallet-errors.ts
@@ -1,5 +1,7 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { WalletId } from "./wallet-id.js";
 
 export class WalletAlreadyExistsForUser extends Schema.TaggedError<WalletAlreadyExistsForUser>(

--- a/packages/server/src/modules/wallet/domain/wallet-events.ts
+++ b/packages/server/src/modules/wallet/domain/wallet-events.ts
@@ -1,6 +1,7 @@
 import { DomainEvent } from "@/platform/ddd/domain-event.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import { UserId } from "@/platform/ids/user-id.js";
+
 import { WalletId } from "./wallet-id.js";
 
 export const WalletCreated = DomainEvent("WalletCreated", {

--- a/packages/server/src/modules/wallet/domain/wallet-repository.ts
+++ b/packages/server/src/modules/wallet/domain/wallet-repository.ts
@@ -4,8 +4,8 @@ import type * as Option from "effect/Option";
 
 import { type UserId } from "@/platform/ids/user-id.js";
 
-import { type WalletAlreadyExistsForUser } from "./wallet-errors.js";
 import { type Wallet } from "./wallet.aggregate.js";
+import { type WalletAlreadyExistsForUser } from "./wallet-errors.js";
 
 export type WalletRepositoryShape = {
   readonly insert: (wallet: Wallet) => Effect.Effect<void, WalletAlreadyExistsForUser>;

--- a/packages/server/src/modules/wallet/domain/wallet-repository.ts
+++ b/packages/server/src/modules/wallet/domain/wallet-repository.ts
@@ -1,7 +1,9 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as Option from "effect/Option";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { type WalletAlreadyExistsForUser } from "./wallet-errors.js";
 import { type Wallet } from "./wallet.aggregate.js";
 

--- a/packages/server/src/modules/wallet/domain/wallet.aggregate.test.ts
+++ b/packages/server/src/modules/wallet/domain/wallet.aggregate.test.ts
@@ -2,8 +2,8 @@ import { describe, it } from "@effect/vitest";
 import { deepStrictEqual, ok } from "assert";
 import * as DateTime from "effect/DateTime";
 
-import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
+import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 const walletId = WalletId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");

--- a/packages/server/src/modules/wallet/domain/wallet.aggregate.test.ts
+++ b/packages/server/src/modules/wallet/domain/wallet.aggregate.test.ts
@@ -1,9 +1,10 @@
-import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
-import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual, ok } from "assert";
 import * as DateTime from "effect/DateTime";
+
+import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
+import { UserId } from "@/platform/ids/user-id.js";
 
 const walletId = WalletId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");

--- a/packages/server/src/modules/wallet/domain/wallet.aggregate.ts
+++ b/packages/server/src/modules/wallet/domain/wallet.aggregate.ts
@@ -1,6 +1,8 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import type * as DateTime from "effect/DateTime";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { WalletCreated, type WalletEvent } from "./wallet-events.js";
 import { WalletId } from "./wallet-id.js";
 

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.integration.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.integration.test.ts
@@ -1,3 +1,14 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { Database, RowSchemas, sql } from "@org/database/index";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import * as Option from "effect/Option";
+import { afterAll, beforeAll, beforeEach } from "vitest";
+
 import { Api } from "@/api.js";
 import { UserCreated } from "@/modules/user/index.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
@@ -9,16 +20,6 @@ import { UserId } from "@/platform/ids/user-id.js";
 import { UnitOfWorkLive } from "@/platform/unit-of-work-live.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { TestServerLive } from "@/test-utils/test-server.js";
-import * as HttpApiClient from "@effect/platform/HttpApiClient";
-import { describe, it } from "@effect/vitest";
-import { Database, RowSchemas, sql } from "@org/database/index";
-import { deepStrictEqual, ok } from "assert";
-import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Layer from "effect/Layer";
-import * as ManagedRuntime from "effect/ManagedRuntime";
-import * as Option from "effect/Option";
-import { afterAll, beforeAll, beforeEach } from "vitest";
 
 type ServerContext = Layer.Layer.Success<typeof TestServerLive>;
 type ServerError = Layer.Layer.Error<typeof TestServerLive>;

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.test.ts
@@ -1,14 +1,16 @@
-import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
-import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
-import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
-import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
-import { UserId } from "@/platform/ids/user-id.js";
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual, ok } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
+
+import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
+import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
+import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { handleUserCreated } from "./create-wallet-when-user-is-created.js";
 import { type UserCreatedTrigger } from "./triggers/user-events.js";
 

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.test.ts
@@ -5,9 +5,9 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
-import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.ts
@@ -13,9 +13,9 @@
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
-import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 
 import { type UserCreatedTrigger } from "./triggers/user-events.js";
 

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-user-is-created.ts
@@ -10,11 +10,13 @@
 // net for a case that shouldn't occur given a freshly-minted user id;
 // any other error propagates as a defect.
 
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
 import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
 import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
-import * as DateTime from "effect/DateTime";
-import * as Effect from "effect/Effect";
+
 import { type UserCreatedTrigger } from "./triggers/user-events.js";
 
 export const handleUserCreated = (trigger: UserCreatedTrigger) =>

--- a/packages/server/src/modules/wallet/event-handlers/triggers/user-events.ts
+++ b/packages/server/src/modules/wallet/event-handlers/triggers/user-events.ts
@@ -8,8 +8,9 @@
 // through an adapter that translates the publisher's event into the
 // consumer's trigger type. See ../user-event-adapter.ts.
 
-import { UserId } from "@/platform/ids/user-id.js";
 import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
 
 export const UserCreatedTrigger = Schema.Struct({
   userId: UserId,

--- a/packages/server/src/modules/wallet/infrastructure/wallet-mapper.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-mapper.ts
@@ -1,6 +1,8 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { type RowSchemas } from "@org/database/index";
 import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
 import { WalletId } from "../domain/wallet-id.js";
 import { Wallet } from "../domain/wallet.aggregate.js";
 

--- a/packages/server/src/modules/wallet/infrastructure/wallet-mapper.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-mapper.ts
@@ -3,8 +3,8 @@ import * as DateTime from "effect/DateTime";
 
 import { UserId } from "@/platform/ids/user-id.js";
 
-import { WalletId } from "../domain/wallet-id.js";
 import { Wallet } from "../domain/wallet.aggregate.js";
+import { WalletId } from "../domain/wallet-id.js";
 
 type Row = RowSchemas.WalletRow;
 

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
@@ -1,9 +1,11 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import * as Effect from "effect/Effect";
 import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { WalletAlreadyExistsForUser } from "../domain/wallet-errors.js";
 import { type WalletId } from "../domain/wallet-id.js";
 import { WalletRepository } from "../domain/wallet-repository.js";

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
@@ -6,10 +6,10 @@ import * as Ref from "effect/Ref";
 
 import { type UserId } from "@/platform/ids/user-id.js";
 
+import { type Wallet } from "../domain/wallet.aggregate.js";
 import { WalletAlreadyExistsForUser } from "../domain/wallet-errors.js";
 import { type WalletId } from "../domain/wallet-id.js";
 import { WalletRepository } from "../domain/wallet-repository.js";
-import { type Wallet } from "../domain/wallet.aggregate.js";
 
 const findByUserIdIn = (
   store: HashMap.HashMap<WalletId, Wallet>,

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.integration.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.integration.test.ts
@@ -8,10 +8,10 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
 
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 import { WalletAlreadyExistsForUser } from "@/modules/wallet/domain/wallet-errors.js";
 import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
-import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
 import { WalletRepositoryLive } from "@/modules/wallet/infrastructure/wallet-repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.integration.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.integration.test.ts
@@ -1,10 +1,3 @@
-import { WalletAlreadyExistsForUser } from "@/modules/wallet/domain/wallet-errors.js";
-import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
-import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
-import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
-import { WalletRepositoryLive } from "@/modules/wallet/infrastructure/wallet-repository-live.js";
-import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
@@ -14,6 +7,14 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
+
+import { WalletAlreadyExistsForUser } from "@/modules/wallet/domain/wallet-errors.js";
+import { WalletId } from "@/modules/wallet/domain/wallet-id.js";
+import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
+import * as Wallet from "@/modules/wallet/domain/wallet.aggregate.js";
+import { WalletRepositoryLive } from "@/modules/wallet/infrastructure/wallet-repository-live.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.ts
@@ -1,8 +1,10 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import { Database, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { WalletAlreadyExistsForUser } from "../domain/wallet-errors.js";
 import { WalletRepository } from "../domain/wallet-repository.js";
 import { type Wallet } from "../domain/wallet.aggregate.js";

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.ts
@@ -5,9 +5,9 @@ import * as Option from "effect/Option";
 
 import { type UserId } from "@/platform/ids/user-id.js";
 
+import { type Wallet } from "../domain/wallet.aggregate.js";
 import { WalletAlreadyExistsForUser } from "../domain/wallet-errors.js";
 import { WalletRepository } from "../domain/wallet-repository.js";
-import { type Wallet } from "../domain/wallet.aggregate.js";
 import * as WalletMapper from "./wallet-mapper.js";
 
 export const WalletRepositoryLive = Layer.effect(

--- a/packages/server/src/modules/wallet/interface/events/user-event-adapter.test.ts
+++ b/packages/server/src/modules/wallet/interface/events/user-event-adapter.test.ts
@@ -5,6 +5,12 @@
 // integration test for the publisher-bound flow; this test only
 // asserts the adapter glue (subscribe + translate).
 
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
 import { type UserCreated } from "@/modules/user/index.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
 import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/wallet-repository-fake.js";
@@ -12,11 +18,6 @@ import { UserEventAdapterLive } from "@/modules/wallet/interface/events/user-eve
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { makeDomainEventBusLive } from "@/platform/domain-event-bus-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { describe, it } from "@effect/vitest";
-import { deepStrictEqual, ok } from "assert";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 const TestLayer = UserEventAdapterLive.pipe(
   Layer.provideMerge(makeDomainEventBusLive()),

--- a/packages/server/src/modules/wallet/interface/events/user-event-adapter.ts
+++ b/packages/server/src/modules/wallet/interface/events/user-event-adapter.ts
@@ -10,13 +10,14 @@
 // If `user` adds fields to `UserCreated`, only this file changes —
 // the handler and trigger types stay stable.
 
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
 import { UserCreated } from "@/modules/user/index.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet-repository.js";
 import { handleUserCreated } from "@/modules/wallet/event-handlers/create-wallet-when-user-is-created.js";
 import { type UserCreatedTrigger } from "@/modules/wallet/event-handlers/triggers/user-events.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 
 const toTrigger = (event: UserCreated): UserCreatedTrigger => ({ userId: event.userId });
 

--- a/packages/server/src/modules/wallet/wallet-module.ts
+++ b/packages/server/src/modules/wallet/wallet-module.ts
@@ -1,4 +1,5 @@
 import * as Layer from "effect/Layer";
+
 import { WalletRepositoryLive } from "./infrastructure/wallet-repository-live.js";
 import { UserEventAdapterLive } from "./interface/events/user-event-adapter.js";
 

--- a/packages/server/src/platform/auth/cookie-codec.ts
+++ b/packages/server/src/platform/auth/cookie-codec.ts
@@ -1,7 +1,9 @@
-import { EnvVars } from "@/common/env-vars.js";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
-import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { EnvVars } from "@/common/env-vars.js";
 
 // Signs a session id with HMAC-SHA256 and packs as `<id>.<signature>`.
 // JS-readable callers cannot mint or alter the value without knowing the

--- a/packages/server/src/platform/auth/permissions-resolver.ts
+++ b/packages/server/src/platform/auth/permissions-resolver.ts
@@ -1,8 +1,9 @@
-import { type UserId } from "@/platform/ids/user-id.js";
 import { type Permission } from "@org/contracts/Policy";
 import { Database, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+
+import { type UserId } from "@/platform/ids/user-id.js";
 
 // Slice-scope: read users.role and map role → permissions via a static map.
 // Everything currently flows through the existing __test:* permission set —

--- a/packages/server/src/platform/command-bus-live.ts
+++ b/packages/server/src/platform/command-bus-live.ts
@@ -1,3 +1,5 @@
+import * as Effect from "effect/Effect";
+
 import {
   type CommandBusShape,
   type CommandHandlerEntry,
@@ -5,7 +7,6 @@ import {
   type CommandRegistry,
 } from "@/platform/ddd/command-bus.js";
 import { type SpanAttributeValue } from "@/platform/ddd/span-attributable.js";
-import * as Effect from "effect/Effect";
 
 /**
  * Builds a CommandBus from a full handler set. Takes `CommandHandlers` for

--- a/packages/server/src/platform/ddd/command-bus.ts
+++ b/packages/server/src/platform/ddd/command-bus.ts
@@ -1,5 +1,6 @@
-import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import * as Context from "effect/Context";
+
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 
 // Port for the write-side bus. The bus itself is one Tag; the typed
 // `execute` shape and the registry that names every command/handler pair

--- a/packages/server/src/platform/ddd/domain-event-bus.ts
+++ b/packages/server/src/platform/ddd/domain-event-bus.ts
@@ -1,8 +1,9 @@
-import { type AnyDomainEventSchema, type DomainEvent } from "@/platform/ddd/domain-event.js";
-import { type SpanAttributeValue } from "@/platform/ddd/span-attributable.js";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
+
+import { type AnyDomainEventSchema, type DomainEvent } from "@/platform/ddd/domain-event.js";
+import { type SpanAttributeValue } from "@/platform/ddd/span-attributable.js";
 
 export { DomainEvent } from "@/platform/ddd/domain-event.js";
 

--- a/packages/server/src/platform/ddd/query-bus.ts
+++ b/packages/server/src/platform/ddd/query-bus.ts
@@ -1,5 +1,6 @@
-import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 import * as Context from "effect/Context";
+
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
 
 // Port for the read-side bus. See `command-bus.ts` for the equivalent
 // pattern — semantics are identical, but the split into two buses

--- a/packages/server/src/platform/domain-event-bus-live.ts
+++ b/packages/server/src/platform/domain-event-bus-live.ts
@@ -2,12 +2,12 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 
+import { type DomainEvent } from "@/platform/ddd/domain-event.js";
 import {
   DomainEventBus,
   type DomainEventBusShape,
   type DomainEventSpanAttributes,
 } from "@/platform/ddd/domain-event-bus.js";
-import { type DomainEvent } from "@/platform/ddd/domain-event.js";
 import { type SpanAttributeValue } from "@/platform/ddd/span-attributable.js";
 
 type Handler = (event: DomainEvent) => Effect.Effect<void>;

--- a/packages/server/src/platform/domain-event-bus-live.ts
+++ b/packages/server/src/platform/domain-event-bus-live.ts
@@ -1,3 +1,7 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
 import {
   DomainEventBus,
   type DomainEventBusShape,
@@ -5,9 +9,6 @@ import {
 } from "@/platform/ddd/domain-event-bus.js";
 import { type DomainEvent } from "@/platform/ddd/domain-event.js";
 import { type SpanAttributeValue } from "@/platform/ddd/span-attributable.js";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Ref from "effect/Ref";
 
 type Handler = (event: DomainEvent) => Effect.Effect<void>;
 

--- a/packages/server/src/platform/middlewares/auth-middleware-live.ts
+++ b/packages/server/src/platform/middlewares/auth-middleware-live.ts
@@ -1,3 +1,10 @@
+import * as HttpServerRequest from "@effect/platform/HttpServerRequest";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { UserAuthMiddleware } from "@org/contracts/Policy";
+import * as cookie from "cookie";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
 import { EnvVars } from "@/common/env-vars.js";
 import {
   FindSessionQuery,
@@ -9,12 +16,6 @@ import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 import { PermissionsResolver } from "@/platform/auth/permissions-resolver.js";
 import { CommandBus } from "@/platform/ddd/command-bus.js";
 import { QueryBus } from "@/platform/ddd/query-bus.js";
-import * as HttpServerRequest from "@effect/platform/HttpServerRequest";
-import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
-import { UserAuthMiddleware } from "@org/contracts/Policy";
-import * as cookie from "cookie";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 
 export const UserAuthMiddlewareLive = Layer.effect(
   UserAuthMiddleware,

--- a/packages/server/src/platform/query-bus-live.ts
+++ b/packages/server/src/platform/query-bus-live.ts
@@ -1,3 +1,5 @@
+import * as Effect from "effect/Effect";
+
 import {
   type QueryBusShape,
   type QueryHandlerEntry,
@@ -5,7 +7,6 @@ import {
   type QueryRegistry,
 } from "@/platform/ddd/query-bus.js";
 import { type SpanAttributeValue } from "@/platform/ddd/span-attributable.js";
-import * as Effect from "effect/Effect";
 
 export const makeQueryBus = (handlers: QueryHandlers): QueryBusShape => ({
   execute: ((query: { readonly _tag: string }) => {

--- a/packages/server/src/platform/unit-of-work-live.ts
+++ b/packages/server/src/platform/unit-of-work-live.ts
@@ -1,7 +1,8 @@
-import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import { Database } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
+import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 
 // Production binding for the `UnitOfWork` port: opens a SQL transaction
 // for every `run`, provides `Database.TransactionContext` to the inner

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+
 import * as NodeSdk from "@effect/opentelemetry/NodeSdk";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
@@ -12,7 +14,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
-import { createServer } from "node:http";
+
 import { Api } from "./api.js";
 import { EnvVars } from "./common/env-vars.js";
 import {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,11 +1,11 @@
 import { createServer } from "node:http";
 
 import * as NodeSdk from "@effect/opentelemetry/NodeSdk";
-import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
 import * as HttpMiddleware from "@effect/platform/HttpMiddleware";
 import * as HttpServer from "@effect/platform/HttpServer";
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { Database } from "@org/database/index";

--- a/packages/server/src/test-utils/fake-auth-middleware.test.ts
+++ b/packages/server/src/test-utils/fake-auth-middleware.test.ts
@@ -1,6 +1,7 @@
-import { UserAuthMiddlewareFake } from "@/test-utils/fake-auth-middleware.js";
 import * as Layer from "effect/Layer";
 import { describe, expect, it } from "vitest";
+
+import { UserAuthMiddlewareFake } from "@/test-utils/fake-auth-middleware.js";
 
 // The middleware itself can only be evaluated inside an HTTP request scope
 // (Provided context). End-to-end coverage of the fake's behavior comes from

--- a/packages/server/src/test-utils/fake-auth-middleware.ts
+++ b/packages/server/src/test-utils/fake-auth-middleware.ts
@@ -1,7 +1,8 @@
-import { UserId } from "@/platform/ids/user-id.js";
 import { type Permission, UserAuthMiddleware } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
+import { UserId } from "@/platform/ids/user-id.js";
 
 // Test-only middleware. Existing endpoint integration tests don't carry a
 // session cookie; this returns a deterministic admin CurrentUser so they keep

--- a/packages/server/src/test-utils/identity-unit-of-work.ts
+++ b/packages/server/src/test-utils/identity-unit-of-work.ts
@@ -1,5 +1,6 @@
-import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import * as Layer from "effect/Layer";
+
+import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 
 // Pass-through `UnitOfWork` for unit tests that drive use cases against
 // fake repositories. Inner effects run as-is; no SQL transaction is opened

--- a/packages/server/src/test-utils/recording-event-bus.ts
+++ b/packages/server/src/test-utils/recording-event-bus.ts
@@ -1,8 +1,9 @@
-import { DomainEventBus, type DomainEvent } from "@/platform/ddd/domain-event-bus.js";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
+
+import { type DomainEvent, DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 
 // Test double for `DomainEventBus`: records every dispatched event and
 // ignores `subscribe` calls. Use-case unit tests assert against the

--- a/packages/server/src/test-utils/server-test-runtime.ts
+++ b/packages/server/src/test-utils/server-test-runtime.ts
@@ -1,9 +1,10 @@
-import { truncate } from "@/test-utils/test-database.js";
-import { TestServerLive } from "@/test-utils/test-server.js";
 import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import { afterAll, beforeAll, beforeEach } from "vitest";
+
+import { truncate } from "@/test-utils/test-database.js";
+import { TestServerLive } from "@/test-utils/test-server.js";
 
 type ServerContext = Layer.Layer.Success<typeof TestServerLive>;
 type ServerError = Layer.Layer.Error<typeof TestServerLive>;

--- a/packages/server/src/test-utils/test-database.ts
+++ b/packages/server/src/test-utils/test-database.ts
@@ -1,10 +1,11 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { Database, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import * as pg from "pg";
 
 const rawUrl = process.env.DATABASE_URL_TEST;

--- a/packages/server/src/test-utils/test-server.ts
+++ b/packages/server/src/test-utils/test-server.ts
@@ -1,3 +1,7 @@
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+import * as Layer from "effect/Layer";
+
 import { Api } from "@/api.js";
 import { EnvVars } from "@/common/env-vars.js";
 import {
@@ -23,9 +27,6 @@ import { makeQueryBus } from "@/platform/query-bus-live.js";
 import { UnitOfWorkLive } from "@/platform/unit-of-work-live.js";
 import { UserAuthMiddlewareFake } from "@/test-utils/fake-auth-middleware.js";
 import { TestDatabaseLive } from "@/test-utils/test-database.js";
-import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
-import * as Layer from "effect/Layer";
 
 const CommandBusLive = Layer.succeed(
   CommandBus,

--- a/packages/server/src/test-utils/test-server.ts
+++ b/packages/server/src/test-utils/test-server.ts
@@ -1,5 +1,5 @@
-import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as Layer from "effect/Layer";
 
 import { Api } from "@/api.js";

--- a/packages/test-drivers/src/adapters/playwright/users-page-driver.ts
+++ b/packages/test-drivers/src/adapters/playwright/users-page-driver.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+
 import type {
   CreateUserField,
   CreateUserInput,

--- a/packages/test-drivers/src/adapters/rtl/users-page-driver.ts
+++ b/packages/test-drivers/src/adapters/rtl/users-page-driver.ts
@@ -1,5 +1,6 @@
 import { type RenderResult, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+
 import type {
   CreateUserField,
   CreateUserInput,

--- a/packages/web/app/(authed)/layout.tsx
+++ b/packages/web/app/(authed)/layout.tsx
@@ -15,12 +15,13 @@
 // before rendering. It must NOT be wrapped in try/catch — otherwise
 // the marker is swallowed and the redirect silently fails.
 
-import { Nav } from "@/features/__root/nav";
-import { ApiClient } from "@/services/api-client.shared";
-import { getServerRuntime } from "@/services/runtime.server";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import { redirect } from "next/navigation";
+
+import { Nav } from "@/features/__root/nav";
+import { ApiClient } from "@/services/api-client.shared";
+import { getServerRuntime } from "@/services/runtime.server";
 
 export default async function AuthedLayout({ children }: { children: React.ReactNode }) {
   const runtime = await getServerRuntime();

--- a/packages/web/app/(authed)/page.tsx
+++ b/packages/web/app/(authed)/page.tsx
@@ -1,10 +1,11 @@
+import { Card } from "@org/components/primitives/card";
+import { Skeleton } from "@org/components/primitives/skeleton";
+import React from "react";
+
 import { AddTodo } from "@/features/index/add-todo/add-todo";
 import { TodoList } from "@/features/index/todo-list";
 import { ServerHydrationBoundary } from "@/lib/tanstack-query/server-hydration-boundary";
 import { prefetchTodos } from "@/services/data-access/todos-queries.server";
-import { Card } from "@org/components/primitives/card";
-import { Skeleton } from "@org/components/primitives/skeleton";
-import React from "react";
 
 const SKELETON_COUNT = 3;
 

--- a/packages/web/app/(authed)/users/page.tsx
+++ b/packages/web/app/(authed)/users/page.tsx
@@ -1,10 +1,11 @@
+import { Card } from "@org/components/primitives/card";
+import { Skeleton } from "@org/components/primitives/skeleton";
+import React from "react";
+
 import { CreateUser } from "@/features/users/create-user/create-user";
 import { UserList } from "@/features/users/user-list";
 import { ServerHydrationBoundary } from "@/lib/tanstack-query/server-hydration-boundary";
 import { prefetchUsers } from "@/services/data-access/users-queries.server";
-import { Card } from "@org/components/primitives/card";
-import { Skeleton } from "@org/components/primitives/skeleton";
-import React from "react";
 
 const PAGE_SIZE = 10;
 const INITIAL_VARIABLES = { page: 1, pageSize: PAGE_SIZE } as const;

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,5 +1,7 @@
 import "@org/components/styles/globals.css";
+
 import type { Metadata } from "next";
+
 import { Providers } from "./providers";
 
 export const metadata: Metadata = {

--- a/packages/web/app/providers.tsx
+++ b/packages/web/app/providers.tsx
@@ -14,12 +14,13 @@
 // `<HydrationBoundary>` in each page bridges the two by deserializing
 // the server-only client's dehydrated state into the browser client.
 
-import { makeQueryClient } from "@/lib/query-client.shared";
-import { RuntimeProvider } from "@/services/runtime.client";
 import { Toaster } from "@org/components/primitives/toaster";
 import { ThemeProvider } from "@org/components/providers/theme-provider";
 import { isServer, type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+import { makeQueryClient } from "@/lib/query-client.shared";
+import { RuntimeProvider } from "@/services/runtime.client";
 
 let browserQueryClient: QueryClient | undefined;
 

--- a/packages/web/features/index/add-todo/add-todo.presenter.test.ts
+++ b/packages/web/features/index/add-todo/add-todo.presenter.test.ts
@@ -1,9 +1,11 @@
-import { makePresenterHarness } from "@/test/presenter-harness";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { TodoId } from "@org/contracts/EntityIds";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as Effect from "effect/Effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+
 import { useAddTodoPresenter } from "./add-todo.presenter";
 
 type CreateCalls = ReadonlyArray<TodosContract.CreateTodoPayload>;

--- a/packages/web/features/index/add-todo/add-todo.presenter.ts
+++ b/packages/web/features/index/add-todo/add-todo.presenter.ts
@@ -4,11 +4,12 @@
 // schema-validated submit, mutation dispatch, and reset on success — so
 // the component is pure JSX over the returned form instance.
 
-import { makeFormOptions } from "@/lib/tanstack-query/make-form-options";
-import { useCreateTodoMutation } from "@/services/data-access/use-todos-queries";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { useForm } from "@tanstack/react-form";
 import * as Schema from "effect/Schema";
+
+import { makeFormOptions } from "@/lib/tanstack-query/make-form-options";
+import { useCreateTodoMutation } from "@/services/data-access/use-todos-queries";
 
 export const useAddTodoPresenter = () => {
   const createTodoMutation = useCreateTodoMutation();

--- a/packages/web/features/index/add-todo/add-todo.tsx
+++ b/packages/web/features/index/add-todo/add-todo.tsx
@@ -4,6 +4,7 @@ import { Button } from "@org/components/primitives/button";
 import { Form } from "@org/components/primitives/form";
 import { PlusIcon } from "@org/components/primitives/icon";
 import { Input } from "@org/components/primitives/input";
+
 import { useAddTodoPresenter } from "./add-todo.presenter";
 
 export const AddTodo: React.FC = () => {

--- a/packages/web/features/index/todo-item/todo-item.presenter.test.tsx
+++ b/packages/web/features/index/todo-item/todo-item.presenter.test.tsx
@@ -1,10 +1,12 @@
-import { makePresenterHarness } from "@/test/presenter-harness";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { TodoId } from "@org/contracts/EntityIds";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { afterEach, describe, expect, it } from "vitest";
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+
 import { useTodoItemPresenter } from "./todo-item.presenter";
 
 class TodoNotFoundError extends Data.TaggedError("TodoNotFoundError")<{

--- a/packages/web/features/index/todo-item/todo-item.presenter.ts
+++ b/packages/web/features/index/todo-item/todo-item.presenter.ts
@@ -6,12 +6,13 @@
 // shape; behavior (mutation dispatch, optimistic flags, invalidation)
 // is testable via the presenter without rendering JSX.
 
+import type { TodosContract } from "@org/contracts/api/Contracts";
+import * as React from "react";
+
 import {
   useDeleteTodoMutation,
   useUpdateTodoMutation,
 } from "@/services/data-access/use-todos-queries";
-import type { TodosContract } from "@org/contracts/api/Contracts";
-import * as React from "react";
 
 export const useTodoItemPresenter = (todo: TodosContract.Todo) => {
   const updateTodo = useUpdateTodoMutation();

--- a/packages/web/features/index/todo-item/todo-item.tsx
+++ b/packages/web/features/index/todo-item/todo-item.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from "@org/components/primitives/checkbox";
 import { TrashIcon } from "@org/components/primitives/icon";
 import { Label } from "@org/components/primitives/label";
 import type { TodosContract } from "@org/contracts/api/Contracts";
+
 import { useTodoItemPresenter } from "./todo-item.presenter";
 
 export const TodoItem: React.FC<{ todo: TodosContract.Todo }> = ({ todo }) => {

--- a/packages/web/features/index/todo-list.presenter.test.tsx
+++ b/packages/web/features/index/todo-list.presenter.test.tsx
@@ -1,9 +1,11 @@
-import { makePresenterHarness } from "@/test/presenter-harness";
 import { TodosContract } from "@org/contracts/api/Contracts";
 import { TodoId } from "@org/contracts/EntityIds";
 import { renderHook, waitFor } from "@testing-library/react";
 import * as Effect from "effect/Effect";
 import { afterEach, describe, expect, it } from "vitest";
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+
 import { useTodoListPresenter } from "./todo-list.presenter";
 
 const mkTodo = (i: number): TodosContract.Todo =>

--- a/packages/web/features/index/todo-list.tsx
+++ b/packages/web/features/index/todo-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as Array from "effect/Array";
+
 import { TodoItem } from "./todo-item/todo-item";
 import { useTodoListPresenter } from "./todo-list.presenter";
 

--- a/packages/web/features/users/__tests__/create-user.integration.test.tsx
+++ b/packages/web/features/users/__tests__/create-user.integration.test.tsx
@@ -15,15 +15,16 @@
 // create and assertion — MSW resolves the most recently registered
 // handler first.
 
+import { rtlUsersDriver } from "@org/test-drivers/adapters/rtl/users-page-driver";
+import * as React from "react";
+import { describe, it } from "vitest";
+
 import { CreateUser } from "@/features/users/create-user/create-user";
 import { UserList } from "@/features/users/user-list";
 import { makeUser } from "@/test/fixtures";
 import { handlers } from "@/test/handlers";
 import { renderWithHarness } from "@/test/integration-harness";
 import { installMswLifecycle, server } from "@/test/msw-server";
-import { rtlUsersDriver } from "@org/test-drivers/adapters/rtl/users-page-driver";
-import * as React from "react";
-import { describe, it } from "vitest";
 
 installMswLifecycle();
 

--- a/packages/web/features/users/create-user/create-user.presenter.test.ts
+++ b/packages/web/features/users/create-user/create-user.presenter.test.ts
@@ -1,9 +1,11 @@
-import { makePresenterHarness } from "@/test/presenter-harness";
 import { UserContract } from "@org/contracts/api/Contracts";
 import { UserId } from "@org/contracts/EntityIds";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as Effect from "effect/Effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+
 import { useCreateUserPresenter } from "./create-user.presenter";
 
 type CreateCalls = ReadonlyArray<UserContract.CreateUserPayload>;

--- a/packages/web/features/users/create-user/create-user.presenter.ts
+++ b/packages/web/features/users/create-user/create-user.presenter.ts
@@ -5,11 +5,12 @@
 // reset on success — so the component is pure JSX over the returned
 // form instance.
 
-import { makeFormOptions } from "@/lib/tanstack-query/make-form-options";
-import { useCreateUserMutation } from "@/services/data-access/use-users-queries";
 import { UserContract } from "@org/contracts/api/Contracts";
 import { useForm } from "@tanstack/react-form";
 import * as Schema from "effect/Schema";
+
+import { makeFormOptions } from "@/lib/tanstack-query/make-form-options";
+import { useCreateUserMutation } from "@/services/data-access/use-users-queries";
 
 export const useCreateUserPresenter = () => {
   const createUserMutation = useCreateUserMutation();

--- a/packages/web/features/users/create-user/create-user.tsx
+++ b/packages/web/features/users/create-user/create-user.tsx
@@ -4,6 +4,7 @@ import { Button } from "@org/components/primitives/button";
 import { Form } from "@org/components/primitives/form";
 import { Input } from "@org/components/primitives/input";
 import { Label } from "@org/components/primitives/label";
+
 import { useCreateUserPresenter } from "./create-user.presenter";
 
 export const CreateUser: React.FC = () => {

--- a/packages/web/features/users/user-list.presenter.test.tsx
+++ b/packages/web/features/users/user-list.presenter.test.tsx
@@ -1,10 +1,12 @@
-import { makePresenterHarness } from "@/test/presenter-harness";
 import { UserContract } from "@org/contracts/api/Contracts";
 import { UserId } from "@org/contracts/EntityIds";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+
 import { useUserListPresenter } from "./user-list.presenter";
 
 const mkUser = (i: number): UserContract.User =>

--- a/packages/web/features/users/user-list.presenter.ts
+++ b/packages/web/features/users/user-list.presenter.ts
@@ -5,8 +5,10 @@
 // `user-list.view-model.ts` Tier-3 module. Page changes drive new
 // fetches via the queryKey (page is part of the variables).
 
-import { useUsersSuspenseQuery } from "@/services/data-access/use-users-queries";
 import * as React from "react";
+
+import { useUsersSuspenseQuery } from "@/services/data-access/use-users-queries";
+
 import { computePaginationView } from "./user-list.view-model";
 
 const DEFAULT_PAGE_SIZE = 10;

--- a/packages/web/features/users/user-list.tsx
+++ b/packages/web/features/users/user-list.tsx
@@ -10,6 +10,7 @@ import { Button } from "@org/components/primitives/button";
 import { ChevronLeftIcon, ChevronRightIcon } from "@org/components/primitives/icon";
 import * as Array from "effect/Array";
 import * as React from "react";
+
 import { useUserListPresenter } from "./user-list.presenter";
 
 export const UserList: React.FC = () => {

--- a/packages/web/features/users/user-list.view-model.test.ts
+++ b/packages/web/features/users/user-list.view-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { computePaginationView } from "./user-list.view-model";
 
 describe("computePaginationView — empty set", () => {

--- a/packages/web/lib/query-client.server.ts
+++ b/packages/web/lib/query-client.server.ts
@@ -6,6 +6,7 @@ import "server-only";
 
 import { type QueryClient } from "@tanstack/react-query";
 import React from "react";
+
 import { makeQueryClient } from "./query-client.shared";
 
 export const getQueryClient = React.cache((): QueryClient => makeQueryClient());

--- a/packages/web/lib/tanstack-query/effect-prefetch.server.test.ts
+++ b/packages/web/lib/tanstack-query/effect-prefetch.server.test.ts
@@ -11,6 +11,7 @@ import { QueryClient as TanstackQueryClient } from "@tanstack/react-query";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { prefetchEffectQuery } from "./effect-prefetch.server";
 
 vi.mock("server-only", () => ({}));

--- a/packages/web/lib/tanstack-query/effect-prefetch.server.ts
+++ b/packages/web/lib/tanstack-query/effect-prefetch.server.ts
@@ -12,11 +12,12 @@
 // rather than dragging the whole tree into a generic 500.
 import "server-only";
 
+import type { QueryKey } from "@tanstack/react-query";
+import type * as Effect from "effect/Effect";
+
 import { getQueryClient } from "@/lib/query-client.server";
 import type { ApiClient } from "@/services/api-client.shared";
 import { getServerRuntime } from "@/services/runtime.server";
-import type { QueryKey } from "@tanstack/react-query";
-import type * as Effect from "effect/Effect";
 
 export const prefetchEffectQuery = async <A, E>(args: {
   queryKey: QueryKey;

--- a/packages/web/lib/tanstack-query/make-form-options.test.ts
+++ b/packages/web/lib/tanstack-query/make-form-options.test.ts
@@ -1,5 +1,6 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vitest";
+
 import { makeFormOptions, validateWithSchema } from "./make-form-options";
 
 const EmailField = Schema.Struct({

--- a/packages/web/lib/tanstack-query/query-data-helpers.test.ts
+++ b/packages/web/lib/tanstack-query/query-data-helpers.test.ts
@@ -1,8 +1,10 @@
-import { QueryClient } from "@/services/common/query-client";
 import { QueryClient as TanstackQueryClient } from "@tanstack/react-query";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import { describe, expect, it } from "vitest";
+
+import { QueryClient } from "@/services/common/query-client";
+
 import { makeHelpers, makeQueryKey } from "./query-data-helpers";
 
 type User = { readonly id: string; readonly name: string };

--- a/packages/web/lib/tanstack-query/query-data-helpers.ts
+++ b/packages/web/lib/tanstack-query/query-data-helpers.ts
@@ -1,6 +1,8 @@
-import { QueryClient } from "@/services/common/query-client";
 import * as Effect from "effect/Effect";
 import * as mutative from "mutative";
+
+import { QueryClient } from "@/services/common/query-client";
+
 import { type QueryVariables } from "./use-effect-mutation";
 
 export type QueryDataUpdater<TData> = (draft: mutative.Draft<TData>) => void;

--- a/packages/web/lib/tanstack-query/server-hydration-boundary.tsx
+++ b/packages/web/lib/tanstack-query/server-hydration-boundary.tsx
@@ -20,9 +20,10 @@
 
 import "server-only";
 
-import { getQueryClient } from "@/lib/query-client.server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import * as React from "react";
+
+import { getQueryClient } from "@/lib/query-client.server";
 
 export const ServerHydrationBoundary = async ({
   children,

--- a/packages/web/lib/tanstack-query/use-effect-mutation.test.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-mutation.test.tsx
@@ -4,11 +4,13 @@
 // extraction) — not the TanStack Query state machine, which the
 // library already covers.
 
-import { makePresenterHarness } from "@/test/presenter-harness";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { makePresenterHarness } from "@/test/presenter-harness";
+
 import { QueryDefect, useEffectMutation } from "./use-effect-mutation";
 
 class TaggedA extends Data.TaggedError("TaggedA")<{ readonly message: string }> {}

--- a/packages/web/lib/tanstack-query/use-effect-mutation.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-mutation.tsx
@@ -9,13 +9,11 @@
 // Mutations, by contrast, are user-driven and want toast feedback
 // inline.
 
-import { Toast } from "@/services/common/toast";
-import { type ClientRuntimeContext, useRuntime } from "@/services/runtime.client";
 import {
   type QueryKey,
+  useMutation,
   type UseMutationOptions,
   type UseMutationResult,
-  useMutation,
 } from "@tanstack/react-query";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
@@ -23,6 +21,9 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Predicate from "effect/Predicate";
 import * as React from "react";
+
+import { Toast } from "@/services/common/toast";
+import { type ClientRuntimeContext, useRuntime } from "@/services/runtime.client";
 
 export class QueryDefect extends Data.TaggedError("QueryDefect")<{
   cause: unknown;

--- a/packages/web/lib/tanstack-query/use-effect-suspense-query.test.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-suspense-query.test.tsx
@@ -4,10 +4,6 @@
 //   - defect: wrapped in QueryDefect and thrown
 //   - cache hit: hydrated value is read without invoking the runtime
 
-import { ApiClient } from "@/services/api-client.shared";
-import { QueryClient } from "@/services/common/query-client";
-import { type ClientManagedRuntime, RuntimeContext } from "@/services/runtime.client";
-import { RecordingToast } from "@/test/recording-toast";
 import { QueryClientProvider, QueryClient as TanstackQueryClient } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import * as Data from "effect/Data";
@@ -16,6 +12,12 @@ import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClient } from "@/services/api-client.shared";
+import { QueryClient } from "@/services/common/query-client";
+import { type ClientManagedRuntime, RuntimeContext } from "@/services/runtime.client";
+import { RecordingToast } from "@/test/recording-toast";
+
 import { QueryDefect } from "./use-effect-mutation";
 import { useEffectSuspenseQuery } from "./use-effect-suspense-query";
 

--- a/packages/web/lib/tanstack-query/use-effect-suspense-query.test.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-suspense-query.test.tsx
@@ -4,7 +4,7 @@
 //   - defect: wrapped in QueryDefect and thrown
 //   - cache hit: hydrated value is read without invoking the runtime
 
-import { QueryClientProvider, QueryClient as TanstackQueryClient } from "@tanstack/react-query";
+import { QueryClient as TanstackQueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";

--- a/packages/web/lib/tanstack-query/use-effect-suspense-query.tsx
+++ b/packages/web/lib/tanstack-query/use-effect-suspense-query.tsx
@@ -19,7 +19,6 @@
 // applied here — server-prefetched failures are a routing concern, not
 // a UI-feedback concern.
 
-import { type ClientRuntimeContext, useRuntime } from "@/services/runtime.client";
 import {
   type QueryKey,
   useSuspenseQuery,
@@ -29,6 +28,9 @@ import * as Cause from "effect/Cause";
 import type * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as React from "react";
+
+import { type ClientRuntimeContext, useRuntime } from "@/services/runtime.client";
+
 import { QueryDefect } from "./use-effect-mutation";
 
 type EffectfulError<Tag extends string = string> = { _tag: Tag };

--- a/packages/web/services/api-client.client.ts
+++ b/packages/web/services/api-client.client.ts
@@ -19,6 +19,7 @@ import * as HttpClient from "@effect/platform/HttpClient";
 import { DomainApi } from "@org/contracts/DomainApi";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
 import { ApiClient } from "./api-client.shared";
 
 const FetchWithCredentials = FetchHttpClient.layer.pipe(

--- a/packages/web/services/api-client.server.ts
+++ b/packages/web/services/api-client.server.ts
@@ -19,6 +19,7 @@ import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
 import { DomainApi } from "@org/contracts/DomainApi";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+
 import { ApiClient } from "./api-client.shared";
 
 const SERVER_INTERNAL_URL = process.env.SERVER_INTERNAL_URL ?? "http://localhost:3001";

--- a/packages/web/services/data-access/todos-queries.server.ts
+++ b/packages/web/services/data-access/todos-queries.server.ts
@@ -7,6 +7,7 @@
 import "server-only";
 
 import { prefetchEffectQuery } from "@/lib/tanstack-query/effect-prefetch.server";
+
 import { todosQuery, todosQueryKey } from "./todos-queries";
 
 export const prefetchTodos = (): Promise<void> =>

--- a/packages/web/services/data-access/todos-queries.ts
+++ b/packages/web/services/data-access/todos-queries.ts
@@ -9,11 +9,12 @@
 // (provided by the client runtime); on the server we don't run
 // mutations, so the helper's R is satisfied only client-side.
 
-import { QueryData } from "@/lib/tanstack-query";
-import { ApiClient } from "@/services/api-client.shared";
 import type { TodosContract } from "@org/contracts/api/Contracts";
 import type { TodoId } from "@org/contracts/EntityIds";
 import * as Effect from "effect/Effect";
+
+import { QueryData } from "@/lib/tanstack-query";
+import { ApiClient } from "@/services/api-client.shared";
 
 const todosKey = QueryData.makeQueryKey("todos");
 const todosHelpers = QueryData.makeHelpers<Array<TodosContract.Todo>>(todosKey);

--- a/packages/web/services/data-access/use-todos-queries.ts
+++ b/packages/web/services/data-access/use-todos-queries.ts
@@ -6,6 +6,7 @@
 // the same in-flight feedback the existing SPA used.
 
 import { useEffectMutation, useEffectSuspenseQuery } from "@/lib/tanstack-query";
+
 import { createTodo, deleteTodo, todosQuery, todosQueryKey, updateTodo } from "./todos-queries";
 
 export const useTodosSuspenseQuery = () =>

--- a/packages/web/services/data-access/use-users-queries.ts
+++ b/packages/web/services/data-access/use-users-queries.ts
@@ -7,6 +7,7 @@
 // to get data on first paint.
 
 import { useEffectMutation, useEffectSuspenseQuery } from "@/lib/tanstack-query";
+
 import { createUser, type UsersListVariables, usersQuery, usersQueryKey } from "./users-queries";
 
 // Generic params on `useEffectSuspenseQuery` are inferred — the error

--- a/packages/web/services/data-access/users-queries.server.ts
+++ b/packages/web/services/data-access/users-queries.server.ts
@@ -7,6 +7,7 @@
 import "server-only";
 
 import { prefetchEffectQuery } from "@/lib/tanstack-query/effect-prefetch.server";
+
 import { type UsersListVariables, usersQuery, usersQueryKey } from "./users-queries";
 
 export const prefetchUsers = (variables: UsersListVariables): Promise<void> =>

--- a/packages/web/services/data-access/users-queries.ts
+++ b/packages/web/services/data-access/users-queries.ts
@@ -6,10 +6,11 @@
 // hook). Both runtimes provide the shared `ApiClient` tag, so the
 // same Effect runs in either context — only the transport differs.
 
-import { QueryData } from "@/lib/tanstack-query";
-import { ApiClient } from "@/services/api-client.shared";
 import type { UserContract } from "@org/contracts/api/Contracts";
 import * as Effect from "effect/Effect";
+
+import { QueryData } from "@/lib/tanstack-query";
+import { ApiClient } from "@/services/api-client.shared";
 
 export type UsersListVariables = { page: number; pageSize: number };
 

--- a/packages/web/services/runtime.client.tsx
+++ b/packages/web/services/runtime.client.tsx
@@ -13,13 +13,15 @@
 //   data-access mutation invalidation paths (query-data-helpers.ts)
 //   target the same cache the components read from.
 
-import { QueryClient } from "@/services/common/query-client";
-import { Toast } from "@/services/common/toast";
-import { WebSdkLive } from "@/services/common/web-sdk.client";
 import { type QueryClient as TanstackQueryClient } from "@tanstack/react-query";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as React from "react";
+
+import { QueryClient } from "@/services/common/query-client";
+import { Toast } from "@/services/common/toast";
+import { WebSdkLive } from "@/services/common/web-sdk.client";
+
 import { ApiClientLive } from "./api-client.client";
 
 // `WebSdkLive` is `provide`d (not `mergeAll`'d): it satisfies the

--- a/packages/web/services/runtime.server.ts
+++ b/packages/web/services/runtime.server.ts
@@ -12,6 +12,7 @@ import "server-only";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import { cookies } from "next/headers";
 import React from "react";
+
 import { ApiClientLive } from "./api-client.server";
 import { type ApiClient } from "./api-client.shared";
 

--- a/packages/web/test/fixtures/user.test.ts
+++ b/packages/web/test/fixtures/user.test.ts
@@ -8,6 +8,7 @@ import * as UserContract from "@org/contracts/api/UserContract";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vitest";
+
 import { makeCreateUserPayload, makePaginatedUsers, makeUser } from "./user";
 
 const roundTrip = <A, I>(schema: Schema.Schema<A, I>, value: A) =>

--- a/packages/web/test/handlers/auth.ts
+++ b/packages/web/test/handlers/auth.ts
@@ -11,6 +11,7 @@
 import * as AuthContract from "@org/contracts/api/AuthContract";
 import * as Effect from "effect/Effect";
 import { http, HttpResponse } from "msw";
+
 import { makeCurrentUser } from "../fixtures/auth";
 import { getEndpoint, TEST_API_BASE, typedHandler } from "../typed-handler";
 

--- a/packages/web/test/handlers/users.ts
+++ b/packages/web/test/handlers/users.ts
@@ -5,6 +5,7 @@
 import * as UserContract from "@org/contracts/api/UserContract";
 import type { UserId } from "@org/contracts/EntityIds";
 import * as Effect from "effect/Effect";
+
 import { makePaginatedUsers, makeUser } from "../fixtures/user";
 import { getEndpoint, typedHandler } from "../typed-handler";
 

--- a/packages/web/test/integration-harness.tsx
+++ b/packages/web/test/integration-harness.tsx
@@ -8,11 +8,6 @@
 // `server.use(...)` before calling `renderWithHarness(<RoutePage />)`,
 // then drive the UI through the RTL page driver in `packages/test-drivers`.
 
-import { ApiClient } from "@/services/api-client.shared";
-import { QueryClient as QueryClientService } from "@/services/common/query-client";
-import { Toast } from "@/services/common/toast";
-import { WebSdkLive } from "@/services/common/web-sdk.client";
-import { RuntimeContext, type ClientManagedRuntime } from "@/services/runtime.client";
 import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { Toaster } from "@org/components/primitives/toaster";
@@ -24,6 +19,13 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as React from "react";
+
+import { ApiClient } from "@/services/api-client.shared";
+import { QueryClient as QueryClientService } from "@/services/common/query-client";
+import { Toast } from "@/services/common/toast";
+import { WebSdkLive } from "@/services/common/web-sdk.client";
+import { type ClientManagedRuntime, RuntimeContext } from "@/services/runtime.client";
+
 import { TEST_API_BASE } from "./typed-handler";
 
 const ApiClientTestLive = Layer.effect(

--- a/packages/web/test/msw-server.ts
+++ b/packages/web/test/msw-server.ts
@@ -6,6 +6,7 @@
 
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+
 import { defaultHandlers } from "./handlers";
 
 export const server = setupServer();

--- a/packages/web/test/presenter-harness.tsx
+++ b/packages/web/test/presenter-harness.tsx
@@ -4,15 +4,16 @@
 // and sonner-backed Toast. Tests assert on toast calls via
 // `getToasts()` and on QueryClient state via `queryClient`.
 
-import { ApiClient } from "@/services/api-client.shared";
-import { QueryClient } from "@/services/common/query-client";
-import { RuntimeContext } from "@/services/runtime.client";
-import { RecordedToasts, RecordingToast, type ToastCall } from "@/test/recording-toast";
 import { QueryClientProvider, QueryClient as TanstackQueryClient } from "@tanstack/react-query";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as React from "react";
+
+import { ApiClient } from "@/services/api-client.shared";
+import { QueryClient } from "@/services/common/query-client";
+import { RuntimeContext } from "@/services/runtime.client";
+import { RecordedToasts, RecordingToast, type ToastCall } from "@/test/recording-toast";
 
 export type PresenterHarness = {
   readonly wrapper: React.FC<{ children: React.ReactNode }>;

--- a/packages/web/test/presenter-harness.tsx
+++ b/packages/web/test/presenter-harness.tsx
@@ -4,7 +4,7 @@
 // and sonner-backed Toast. Tests assert on toast calls via
 // `getToasts()` and on QueryClient state via `queryClient`.
 
-import { QueryClientProvider, QueryClient as TanstackQueryClient } from "@tanstack/react-query";
+import { QueryClient as TanstackQueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";

--- a/packages/web/test/recording-toast.ts
+++ b/packages/web/test/recording-toast.ts
@@ -2,11 +2,12 @@
 // the sonner DOM. Presenter tests assert via `getToasts()` on the
 // harness; the Toast service itself stays unchanged in production.
 
-import { Toast } from "@/services/common/toast";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
+
+import { Toast } from "@/services/common/toast";
 
 export type ToastCall = { readonly kind: "success" | "error"; readonly message: string };
 

--- a/packages/web/test/setup.ts
+++ b/packages/web/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
 import { afterEach, expect, vi } from "vitest";

--- a/packages/web/test/typed-handler.test.ts
+++ b/packages/web/test/typed-handler.test.ts
@@ -12,6 +12,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
 import { getEndpoint, typedHandler } from "./typed-handler";
 
 const server = setupServer();

--- a/packages/web/test/typed-handler.ts
+++ b/packages/web/test/typed-handler.ts
@@ -18,10 +18,10 @@ import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import {
-  http,
-  HttpResponse,
   type DefaultBodyType,
+  http,
   type HttpHandler,
+  HttpResponse,
   type JsonBodyType,
   type StrictRequest,
 } from "msw";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
-      prettier-plugin-organize-imports:
-        specifier: 4.3.0
-        version: 4.3.0(prettier@3.8.3)(typescript@5.7.3)
       prettier-plugin-tailwindcss:
         specifier: 0.8.0
         version: 0.8.0(prettier-plugin-organize-imports@4.3.0(prettier@3.8.3)(typescript@5.7.3))(prettier@3.8.3)
@@ -11372,6 +11369,7 @@ snapshots:
     dependencies:
       prettier: 3.8.3
       typescript: 5.7.3
+    optional: true
 
   prettier-plugin-tailwindcss@0.8.0(prettier-plugin-organize-imports@4.3.0(prettier@3.8.3)(typescript@5.7.3))(prettier@3.8.3):
     dependencies:


### PR DESCRIPTION
## Summary
- Turn on `simple-import-sort/imports` and `simple-import-sort/exports` in `eslint.config.mjs`. Both plugins were already installed and registered — they were just disabled.
- Ran `pnpm lint --fix` across the monorepo so existing files conform to the deterministic order the rule will enforce going forward. The bulk of the diff is mechanical reordering.

## Test plan
- [x] `pnpm check:all` passes locally (lint + lint:deps + lint:tests + typecheck + tests + storybook build)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)