### PR TITLE
fix(test-drivers): target sonner v2 toasts by data attribute, not role

### DIFF
--- a/packages/test-drivers/src/adapters/playwright/users-page-driver.ts
+++ b/packages/test-drivers/src/adapters/playwright/users-page-driver.ts
@@ -57,13 +57,18 @@ export const playwrightUsersDriver = (page: Page): UsersPageDriver => {
     },
 
     expectToast: async (kind: ToastKind, message: string) => {
-      // sonner renders toasts as <li role="status"> elements under
-      // a region. Assert by text + role; sonner doesn't carry a
-      // stable kind attribute we can pivot on at this tier, so the
-      // `kind` parameter is documentation-only here.
-      const toast = page.getByRole("status").filter({ hasText: message });
+      // sonner v2 renders each toast as `<li data-sonner-toast
+      // data-type="success|error|...">`. Earlier this driver looked for
+      // `role="status"`, but sonner v2 doesn't set that role — happy-path
+      // specs that only call `expectUserInList` never exercised this
+      // method, so the bug stayed hidden until a negative-path spec ran
+      // it. `data-sonner-toast` is sonner's stable attribute and
+      // `data-type` lets us pin the kind that was previously
+      // documentation-only.
+      const toast = page
+        .locator(`[data-sonner-toast][data-type="${kind}"]`)
+        .filter({ hasText: message });
       await expect(toast).toBeVisible();
-      void kind;
     },
   };
 };

--- a/packages/test-drivers/src/adapters/rtl/users-page-driver.ts
+++ b/packages/test-drivers/src/adapters/rtl/users-page-driver.ts
@@ -35,9 +35,11 @@ export const rtlUsersDriver = (
 ): UsersPageDriver => {
   const user = userEvent.setup();
   // sonner's <Toaster /> renders to document.body, not inside
-  // `rendered.container`. Use `within(document.body)` to find it.
+  // `rendered.container`. The toast lookup uses `document.querySelectorAll`
+  // directly against `[data-sonner-toast]` rather than going through
+  // `within(document.body)`, because sonner v2 doesn't tag its toasts
+  // with `role="status"` (the API `within` is otherwise good at).
   const formScope = within(rendered.container);
-  const bodyScope = within(document.body);
 
   const fieldInput = (field: CreateUserField) => formScope.getByTestId(testIdByField[field]);
 
@@ -99,10 +101,16 @@ export const rtlUsersDriver = (
           }
           return;
         }
-        // sonner default: each toast renders as a <li> under a region
-        // with role="status". Filter by message text.
-        const matches = bodyScope.queryAllByText(message, { exact: false });
-        if (matches.length === 0) {
+        // sonner v2 renders `<li data-sonner-toast data-type="success|error|..."`
+        // and the parent region is `role="region"`, not `role="status"`.
+        // Match by stable attribute + kind + text so a mis-typed toast
+        // (e.g. error rendered as success) fails the assertion.
+        const toasts = document.querySelectorAll(`[data-sonner-toast][data-type="${kind}"]`);
+        const lowered = message.toLowerCase();
+        const match = Array.from(toasts).some((t) =>
+          (t.textContent ?? "").toLowerCase().includes(lowered),
+        );
+        if (!match) {
           throw new Error(`expected ${kind} toast "${message}" in DOM, none found`);
         }
       });


### PR DESCRIPTION
## Summary
The Playwright job on #61 failed: `add-user-errors.spec.ts` couldn't find the duplicate-email toast.

Root cause: both the Playwright and RTL drivers' `expectToast` looked for `role="status"`, but **sonner v2 doesn't tag toasts with that role** — the parent region is `role="region"` and toast items carry no role at all. Every prior spec used `expectUserInList` only, so the broken selector was never exercised. My new negative-path spec was the first to call it.

## Changes
- Playwright + RTL drivers now select `[data-sonner-toast][data-type="<kind>"]` filtered by text. `data-sonner-toast` is sonner's stable item attribute and `data-type` carries the success/error/etc. kind.
- This also makes the `kind` parameter meaningful instead of documentation-only — a test asking for a success toast no longer silently passes on an error toast with the same text.

## Test plan
- [x] `pnpm check:all` green locally (lint + lint:deps + lint:tests + typecheck + 249 unit/integration tests + Storybook build)
- [x] `vitest run features/users/__tests__` — both `create-user.integration.test.tsx` (which uses RTL `expectToast` against the real Toaster DOM) and `user-list.integration.test.tsx` still pass
- [ ] CI Playwright job re-runs and `add-user-errors.spec.ts` passes

The failing run that motivated this: https://github.com/dataquail/functional-domain-driven-hexagon/actions/runs/26062685654/job/76626398911

🤖 Generated with [Claude Code](https://claude.com/claude-code)