### PR TITLE
feat(organization): Org Admin roles + IsOrgAdmin policy (Phase 4)

### DIFF
--- a/packages/database/migrations/V016__create_table_organization_organization_roles.sql
+++ b/packages/database/migrations/V016__create_table_organization_organization_roles.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "organization"."organization_roles" (
+	"organization_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" varchar(32) NOT NULL,
+	"issued_by" uuid NOT NULL,
+	"created_at" timestamp with time zone NOT NULL DEFAULT now(),
+	CONSTRAINT "organization_roles_pkey" PRIMARY KEY ("organization_id", "user_id", "role"),
+	CONSTRAINT "organization_roles_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organization"."organizations"("id") ON DELETE CASCADE,
+	CONSTRAINT "organization_roles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "user"."users"("id") ON DELETE CASCADE,
+	CONSTRAINT "organization_roles_issued_by_users_id_fk" FOREIGN KEY ("issued_by") REFERENCES "user"."users"("id") ON DELETE RESTRICT
+);
+
+CREATE INDEX "organization_roles_user_id_organization_id_idx" ON "organization"."organization_roles"("user_id", "organization_id");

--- a/packages/database/src/row-schemas/organization.ts
+++ b/packages/database/src/row-schemas/organization.ts
@@ -37,3 +37,15 @@ export type InvitationRow = typeof InvitationRow.Type;
 
 export const InvitationRowStd: StandardSchemaV1<unknown, InvitationRow> =
   Schema.standardSchemaV1(InvitationRow);
+
+export const OrganizationRoleRow = Schema.Struct({
+  organization_id: Schema.UUID,
+  user_id: Schema.UUID,
+  role: Schema.String,
+  issued_by: Schema.UUID,
+  created_at: Schema.DateTimeUtcFromDate,
+});
+export type OrganizationRoleRow = typeof OrganizationRoleRow.Type;
+
+export const OrganizationRoleRowStd: StandardSchemaV1<unknown, OrganizationRoleRow> =
+  Schema.standardSchemaV1(OrganizationRoleRow);

--- a/packages/server/src/modules/organization/commands/create-organization-command.ts
+++ b/packages/server/src/modules/organization/commands/create-organization-command.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 
 import { type MembershipRepository } from "@/modules/organization/domain/membership-repository.js";
 import { type OrganizationRepository } from "@/modules/organization/domain/organization-repository.js";
+import { type OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
 import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
@@ -24,11 +25,16 @@ export const createOrganizationCommandSpanAttributes: SpanAttributesExtractor<
   CreateOrganizationCommand
 > = (cmd) => ({ "organization.name": cmd.name, "actor.user.id": cmd.actorUserId });
 
-// Raw handler effect — `OrganizationRepository` and `MembershipRepository`
-// are discharged by the wrap in `organization-command-handlers.ts`;
-// the bus-registered output type lives there.
+// Raw handler effect — `OrganizationRepository`, `MembershipRepository`,
+// and `OrganizationRolesRepository` are discharged by the wrap in
+// `organization-command-handlers.ts`; the bus-registered output type
+// lives there.
 export type CreateOrganizationOutput = Effect.Effect<
   OrganizationId,
   PersistenceUnavailable,
-  OrganizationRepository | MembershipRepository | DomainEventBus | UnitOfWork
+  | OrganizationRepository
+  | MembershipRepository
+  | OrganizationRolesRepository
+  | DomainEventBus
+  | UnitOfWork
 >;

--- a/packages/server/src/modules/organization/commands/create-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/create-organization.test.ts
@@ -9,8 +9,11 @@ import { type MembershipCreated } from "@/modules/organization/domain/membership
 import { MembershipRepository } from "@/modules/organization/domain/membership-repository.js";
 import { type OrganizationCreated } from "@/modules/organization/domain/organization-events.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization-repository.js";
+import { type OrganizationRoleGranted } from "@/modules/organization/domain/organization-role-events.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/membership-repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/organization-repository-fake.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
@@ -20,6 +23,7 @@ const actorUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 const TestLayer = Layer.mergeAll(
   OrganizationRepositoryFake,
   MembershipRepositoryFake,
+  OrganizationRolesRepositoryFake,
   RecordingEventBus,
   IdentityUnitOfWork,
 );
@@ -60,5 +64,30 @@ describe("createOrganization", () => {
       deepStrictEqual(event.userId, actorUserId);
       deepStrictEqual(event.organizationId, id);
     }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect(
+    "grants the creator the `admin` OrganizationRole and publishes OrganizationRoleGranted",
+    () =>
+      Effect.gen(function* () {
+        const orgRolesRepo = yield* OrganizationRolesRepository;
+        const rec = yield* RecordedEvents;
+        const id = yield* createOrganization(
+          CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
+        );
+        const roles = yield* orgRolesRepo.findByUserIdAndOrgId(actorUserId, id);
+        deepStrictEqual(
+          roles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
+          [{ role: "admin", issuedBy: actorUserId }],
+        );
+        const events = yield* rec.byTag<OrganizationRoleGranted>("OrganizationRoleGranted");
+        deepStrictEqual(events.length, 1);
+        const event = events[0];
+        if (event === undefined) throw new Error("expected OrganizationRoleGranted event");
+        deepStrictEqual(event.userId, actorUserId);
+        deepStrictEqual(event.organizationId, id);
+        deepStrictEqual(event.role, "admin");
+        deepStrictEqual(event.issuedBy, actorUserId);
+      }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/packages/server/src/modules/organization/commands/create-organization.ts
+++ b/packages/server/src/modules/organization/commands/create-organization.ts
@@ -2,6 +2,7 @@ import * as crypto from "node:crypto";
 
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as Either from "effect/Either";
 
 import {
   type CreateOrganizationCommand,
@@ -11,21 +12,31 @@ import * as Membership from "@/modules/organization/domain/membership.aggregate.
 import { MembershipRepository } from "@/modules/organization/domain/membership-repository.js";
 import * as Organization from "@/modules/organization/domain/organization.aggregate.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization-repository.js";
+import * as OrganizationRoles from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
 import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 
-// Creating an org also creates the creator's Membership in the same
-// unit of work — orgs without their first member are degenerate, and
-// the only path to first-membership for any non-creator is an
-// Invitation (which requires an existing org). Both aggregates'
-// events are dispatched together so Phase 4's default-bundle handler
-// can subscribe to MembershipCreated for the creator's grants in the
-// same transaction.
+// Creating an org also creates the creator's Membership AND grants the
+// creator the `admin` OrganizationRole in the same unit of work —
+// orgs without their first member are degenerate, and an org with no
+// admin would be unmanageable (per Phase 4, only Org Admins can
+// invite/remove members). The only path to first-membership for any
+// non-creator is an Invitation (which requires an existing org with
+// an admin to issue it).
+//
+// The admin grant is system-issued (`issuedBy = actorUserId`) — the
+// creator promotes themselves on org creation as a constitutive
+// invariant of org creation. This bypasses the `CannotPromoteSelf`
+// invariant on the explicit `GrantOrganizationRoleCommand` path
+// because that invariant guards interactive self-elevation through the
+// bus, not the system-level seed.
 export const createOrganization = (cmd: CreateOrganizationCommand): CreateOrganizationOutput =>
   Effect.gen(function* () {
     const orgRepo = yield* OrganizationRepository;
     const memberRepo = yield* MembershipRepository;
+    const orgRolesRepo = yield* OrganizationRolesRepository;
     const bus = yield* DomainEventBus;
     const uow = yield* UnitOfWork;
     const now = yield* DateTime.now;
@@ -36,12 +47,24 @@ export const createOrganization = (cmd: CreateOrganizationCommand): CreateOrgani
       organizationId: id,
       now,
     });
+    // `grantRole` returns `Either<Result, AlreadyHasOrganizationRole>`.
+    // We just constructed `empty(...)` so the only way this could be a
+    // Left is a domain-model defect — die explicitly so the typed
+    // error channel stays clean for the bus signature.
+    const seedRoles = OrganizationRoles.empty(cmd.actorUserId, id);
+    const grantEither = OrganizationRoles.grantRole(seedRoles, "admin", cmd.actorUserId);
+    if (Either.isLeft(grantEither)) {
+      return yield* Effect.die(grantEither.left);
+    }
+    const grantResult = grantEither.right;
+
     yield* uow
       .run(
         Effect.gen(function* () {
           yield* orgRepo.insert(organization);
           yield* memberRepo.insert(membership);
-          yield* bus.dispatch([...orgEvents, ...memberEvents]);
+          yield* orgRolesRepo.save(grantResult.organizationRoles);
+          yield* bus.dispatch([...orgEvents, ...memberEvents, ...grantResult.events]);
         }),
       )
       .pipe(Effect.catchTag("DatabaseError", Effect.die));

--- a/packages/server/src/modules/organization/commands/grant-organization-role-command.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role-command.ts
@@ -1,0 +1,43 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { OrganizationRole } from "@/modules/organization/domain/organization-role.js";
+import {
+  type AlreadyHasOrganizationRole,
+  type CannotPromoteSelfInOrganization,
+} from "@/modules/organization/domain/organization-role-errors.js";
+import { type OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/unit-of-work.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+export const GrantOrganizationRoleCommand = Schema.TaggedStruct("GrantOrganizationRoleCommand", {
+  // The user receiving the role.
+  userId: UserId,
+  organizationId: OrganizationId,
+  role: OrganizationRole,
+  // The user dispatching the command. Carried explicitly (rather than
+  // pulled from `CurrentUser`) so the bus boundary stays uniform — the
+  // HTTP endpoint is the one place that translates request-context
+  // into command input. Persisted as `issued_by` for audit.
+  actorUserId: UserId,
+});
+export type GrantOrganizationRoleCommand = typeof GrantOrganizationRoleCommand.Type;
+
+export const grantOrganizationRoleCommandSpanAttributes: SpanAttributesExtractor<
+  GrantOrganizationRoleCommand
+> = (cmd) => ({
+  "user.id": cmd.userId,
+  "organization.id": cmd.organizationId,
+  "organization.role": cmd.role,
+  "actor.user.id": cmd.actorUserId,
+});
+
+export type GrantOrganizationRoleOutput = Effect.Effect<
+  void,
+  AlreadyHasOrganizationRole | CannotPromoteSelfInOrganization | PersistenceUnavailable,
+  OrganizationRolesRepository | DomainEventBus | UnitOfWork
+>;

--- a/packages/server/src/modules/organization/commands/grant-organization-role.test.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
+import { grantOrganizationRole } from "@/modules/organization/commands/grant-organization-role.js";
+import { GrantOrganizationRoleCommand } from "@/modules/organization/commands/grant-organization-role-command.js";
+import {
+  AlreadyHasOrganizationRole,
+  CannotPromoteSelfInOrganization,
+} from "@/modules/organization/domain/organization-role-errors.js";
+import { type OrganizationRoleGranted } from "@/modules/organization/domain/organization-role-events.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
+
+const TestLayer = Layer.mergeAll(
+  OrganizationRolesRepositoryFake,
+  RecordingEventBus,
+  IdentityUnitOfWork,
+);
+
+const targetId = UserId.make("11111111-1111-1111-1111-111111111111");
+const actorId = UserId.make("99999999-9999-9999-9999-999999999999");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+
+describe("grantOrganizationRole", () => {
+  it.effect("persists the role and publishes OrganizationRoleGranted with issuedBy", () =>
+    Effect.gen(function* () {
+      const repo = yield* OrganizationRolesRepository;
+      const rec = yield* RecordedEvents;
+
+      yield* grantOrganizationRole(
+        GrantOrganizationRoleCommand.make({
+          userId: targetId,
+          organizationId: orgId,
+          role: "admin",
+          actorUserId: actorId,
+        }),
+      );
+
+      const roles = yield* repo.findByUserIdAndOrgId(targetId, orgId);
+      deepStrictEqual(
+        roles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
+        [{ role: "admin", issuedBy: actorId }],
+      );
+
+      const events = yield* rec.byTag<OrganizationRoleGranted>("OrganizationRoleGranted");
+      deepStrictEqual(events.length, 1);
+      const event = events[0];
+      if (event === undefined) throw new Error("expected OrganizationRoleGranted event");
+      deepStrictEqual(event.userId, targetId);
+      deepStrictEqual(event.organizationId, orgId);
+      deepStrictEqual(event.role, "admin");
+      deepStrictEqual(event.issuedBy, actorId);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails CannotPromoteSelfInOrganization when actor equals target", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        grantOrganizationRole(
+          GrantOrganizationRoleCommand.make({
+            userId: targetId,
+            organizationId: orgId,
+            role: "admin",
+            actorUserId: targetId,
+          }),
+        ),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof CannotPromoteSelfInOrganization, true);
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails AlreadyHasOrganizationRole when the role is already granted", () =>
+    Effect.gen(function* () {
+      const cmd = GrantOrganizationRoleCommand.make({
+        userId: targetId,
+        organizationId: orgId,
+        role: "admin",
+        actorUserId: actorId,
+      });
+      yield* grantOrganizationRole(cmd);
+      const exit = yield* Effect.exit(grantOrganizationRole(cmd));
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof AlreadyHasOrganizationRole, true);
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/organization/commands/grant-organization-role.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role.ts
@@ -1,0 +1,44 @@
+import * as Effect from "effect/Effect";
+
+import {
+  type GrantOrganizationRoleCommand,
+  type GrantOrganizationRoleOutput,
+} from "@/modules/organization/commands/grant-organization-role-command.js";
+import { CannotPromoteSelfInOrganization } from "@/modules/organization/domain/organization-role-errors.js";
+import * as OrganizationRoles from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
+import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
+
+export const grantOrganizationRole = (
+  cmd: GrantOrganizationRoleCommand,
+): GrantOrganizationRoleOutput =>
+  Effect.gen(function* () {
+    // Command-level invariant: a user can't grant themselves an org role.
+    // Mirrors `CannotPromoteSelf` in the role module — prevents
+    // self-elevation regardless of the policy layer's decision.
+    if (cmd.actorUserId === cmd.userId) {
+      return yield* Effect.fail(
+        new CannotPromoteSelfInOrganization({
+          userId: cmd.userId,
+          organizationId: cmd.organizationId,
+        }),
+      );
+    }
+
+    const repo = yield* OrganizationRolesRepository;
+    const bus = yield* DomainEventBus;
+    const uow = yield* UnitOfWork;
+
+    const aggregate = yield* repo.findByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+    const result = yield* OrganizationRoles.grantRole(aggregate, cmd.role, cmd.actorUserId);
+
+    yield* uow
+      .run(
+        Effect.gen(function* () {
+          yield* repo.save(result.organizationRoles);
+          yield* bus.dispatch(result.events);
+        }),
+      )
+      .pipe(Effect.catchTag("DatabaseError", Effect.die));
+  });

--- a/packages/server/src/modules/organization/commands/leave-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/leave-organization.test.ts
@@ -13,6 +13,7 @@ import { type MembershipRevoked } from "@/modules/organization/domain/membership
 import { MembershipRepository } from "@/modules/organization/domain/membership-repository.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/membership-repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/organization-repository-fake.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -23,6 +24,7 @@ const userId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 const TestLayer = Layer.mergeAll(
   OrganizationRepositoryFake,
   MembershipRepositoryFake,
+  OrganizationRolesRepositoryFake,
   RecordingEventBus,
   IdentityUnitOfWork,
 );

--- a/packages/server/src/modules/organization/commands/remove-member.test.ts
+++ b/packages/server/src/modules/organization/commands/remove-member.test.ts
@@ -15,6 +15,7 @@ import { type MembershipRevoked } from "@/modules/organization/domain/membership
 import { MembershipRepository } from "@/modules/organization/domain/membership-repository.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/membership-repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/organization-repository-fake.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -26,6 +27,7 @@ const otherUserId = UserId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 const TestLayer = Layer.mergeAll(
   OrganizationRepositoryFake,
   MembershipRepositoryFake,
+  OrganizationRolesRepositoryFake,
   RecordingEventBus,
   IdentityUnitOfWork,
 );

--- a/packages/server/src/modules/organization/commands/restore-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/restore-organization.test.ts
@@ -18,6 +18,7 @@ import { type OrganizationRestored } from "@/modules/organization/domain/organiz
 import { OrganizationRepository } from "@/modules/organization/domain/organization-repository.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/membership-repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/organization-repository-fake.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -28,6 +29,7 @@ const actorUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 const TestLayer = Layer.mergeAll(
   OrganizationRepositoryFake,
   MembershipRepositoryFake,
+  OrganizationRolesRepositoryFake,
   RecordingEventBus,
   IdentityUnitOfWork,
 );

--- a/packages/server/src/modules/organization/commands/revoke-organization-role-command.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role-command.ts
@@ -1,0 +1,33 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { OrganizationRole } from "@/modules/organization/domain/organization-role.js";
+import { type DoesNotHaveOrganizationRole } from "@/modules/organization/domain/organization-role-errors.js";
+import { type OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/unit-of-work.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+export const RevokeOrganizationRoleCommand = Schema.TaggedStruct("RevokeOrganizationRoleCommand", {
+  userId: UserId,
+  organizationId: OrganizationId,
+  role: OrganizationRole,
+});
+export type RevokeOrganizationRoleCommand = typeof RevokeOrganizationRoleCommand.Type;
+
+export const revokeOrganizationRoleCommandSpanAttributes: SpanAttributesExtractor<
+  RevokeOrganizationRoleCommand
+> = (cmd) => ({
+  "user.id": cmd.userId,
+  "organization.id": cmd.organizationId,
+  "organization.role": cmd.role,
+});
+
+export type RevokeOrganizationRoleOutput = Effect.Effect<
+  void,
+  DoesNotHaveOrganizationRole | PersistenceUnavailable,
+  OrganizationRolesRepository | DomainEventBus | UnitOfWork
+>;

--- a/packages/server/src/modules/organization/commands/revoke-organization-role.test.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
+import { grantOrganizationRole } from "@/modules/organization/commands/grant-organization-role.js";
+import { GrantOrganizationRoleCommand } from "@/modules/organization/commands/grant-organization-role-command.js";
+import { revokeOrganizationRole } from "@/modules/organization/commands/revoke-organization-role.js";
+import { RevokeOrganizationRoleCommand } from "@/modules/organization/commands/revoke-organization-role-command.js";
+import { DoesNotHaveOrganizationRole } from "@/modules/organization/domain/organization-role-errors.js";
+import { type OrganizationRoleRevoked } from "@/modules/organization/domain/organization-role-events.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
+
+const TestLayer = Layer.mergeAll(
+  OrganizationRolesRepositoryFake,
+  RecordingEventBus,
+  IdentityUnitOfWork,
+);
+
+const targetId = UserId.make("11111111-1111-1111-1111-111111111111");
+const actorId = UserId.make("99999999-9999-9999-9999-999999999999");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+
+describe("revokeOrganizationRole", () => {
+  it.effect("removes the role and publishes OrganizationRoleRevoked", () =>
+    Effect.gen(function* () {
+      const repo = yield* OrganizationRolesRepository;
+      const rec = yield* RecordedEvents;
+
+      yield* grantOrganizationRole(
+        GrantOrganizationRoleCommand.make({
+          userId: targetId,
+          organizationId: orgId,
+          role: "admin",
+          actorUserId: actorId,
+        }),
+      );
+
+      yield* revokeOrganizationRole(
+        RevokeOrganizationRoleCommand.make({
+          userId: targetId,
+          organizationId: orgId,
+          role: "admin",
+        }),
+      );
+
+      const roles = yield* repo.findByUserIdAndOrgId(targetId, orgId);
+      deepStrictEqual([...roles.roles], []);
+
+      const events = yield* rec.byTag<OrganizationRoleRevoked>("OrganizationRoleRevoked");
+      deepStrictEqual(events.length, 1);
+      const event = events[0];
+      if (event === undefined) throw new Error("expected OrganizationRoleRevoked event");
+      deepStrictEqual(event.userId, targetId);
+      deepStrictEqual(event.organizationId, orgId);
+      deepStrictEqual(event.role, "admin");
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails DoesNotHaveOrganizationRole when the role isn't held", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        revokeOrganizationRole(
+          RevokeOrganizationRoleCommand.make({
+            userId: targetId,
+            organizationId: orgId,
+            role: "admin",
+          }),
+        ),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof DoesNotHaveOrganizationRole, true);
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/organization/commands/revoke-organization-role.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role.ts
@@ -1,0 +1,31 @@
+import * as Effect from "effect/Effect";
+
+import {
+  type RevokeOrganizationRoleCommand,
+  type RevokeOrganizationRoleOutput,
+} from "@/modules/organization/commands/revoke-organization-role-command.js";
+import * as OrganizationRoles from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
+import { UnitOfWork } from "@/platform/ddd/unit-of-work.js";
+
+export const revokeOrganizationRole = (
+  cmd: RevokeOrganizationRoleCommand,
+): RevokeOrganizationRoleOutput =>
+  Effect.gen(function* () {
+    const repo = yield* OrganizationRolesRepository;
+    const bus = yield* DomainEventBus;
+    const uow = yield* UnitOfWork;
+
+    const aggregate = yield* repo.findByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+    const result = yield* OrganizationRoles.revokeRole(aggregate, cmd.role);
+
+    yield* uow
+      .run(
+        Effect.gen(function* () {
+          yield* repo.save(result.organizationRoles);
+          yield* bus.dispatch(result.events);
+        }),
+      )
+      .pipe(Effect.catchTag("DatabaseError", Effect.die));
+  });

--- a/packages/server/src/modules/organization/commands/soft-delete-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/soft-delete-organization.test.ts
@@ -13,6 +13,7 @@ import { type OrganizationSoftDeleted } from "@/modules/organization/domain/orga
 import { OrganizationRepository } from "@/modules/organization/domain/organization-repository.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/membership-repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/organization-repository-fake.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -23,6 +24,7 @@ const actorUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 const TestLayer = Layer.mergeAll(
   OrganizationRepositoryFake,
   MembershipRepositoryFake,
+  OrganizationRolesRepositoryFake,
   RecordingEventBus,
   IdentityUnitOfWork,
 );

--- a/packages/server/src/modules/organization/domain/organization-role-errors.ts
+++ b/packages/server/src/modules/organization/domain/organization-role-errors.ts
@@ -1,0 +1,39 @@
+import * as Schema from "effect/Schema";
+
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { OrganizationRole } from "./organization-role.js";
+
+// Aggregate invariant: a role can only be granted once per (user,
+// organization). Surfaces from `OrganizationRoles.grantRole` and is
+// translated to a 409-style conflict (or absorbed as idempotent) at
+// the command boundary.
+export class AlreadyHasOrganizationRole extends Schema.TaggedError<AlreadyHasOrganizationRole>(
+  "AlreadyHasOrganizationRole",
+)("AlreadyHasOrganizationRole", {
+  userId: UserId,
+  organizationId: OrganizationId,
+  role: OrganizationRole,
+}) {}
+
+// Aggregate invariant: a role can only be revoked if it is currently
+// held. Surfaces from `OrganizationRoles.revokeRole`.
+export class DoesNotHaveOrganizationRole extends Schema.TaggedError<DoesNotHaveOrganizationRole>(
+  "DoesNotHaveOrganizationRole",
+)("DoesNotHaveOrganizationRole", {
+  userId: UserId,
+  organizationId: OrganizationId,
+  role: OrganizationRole,
+}) {}
+
+// Command-level domain invariant: the actor of a role grant cannot be
+// the target. Mirrors the role module's `CannotPromoteSelf` — prevents
+// an actor from promoting themselves regardless of the policy layer's
+// decision. The HTTP endpoint translates this to a 403 Forbidden.
+export class CannotPromoteSelfInOrganization extends Schema.TaggedError<CannotPromoteSelfInOrganization>(
+  "CannotPromoteSelfInOrganization",
+)("CannotPromoteSelfInOrganization", {
+  userId: UserId,
+  organizationId: OrganizationId,
+}) {}

--- a/packages/server/src/modules/organization/domain/organization-role-events.ts
+++ b/packages/server/src/modules/organization/domain/organization-role-events.ts
@@ -1,0 +1,40 @@
+import { DomainEvent } from "@/platform/ddd/domain-event.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { OrganizationRole } from "./organization-role.js";
+
+export const OrganizationRoleGranted = DomainEvent("OrganizationRoleGranted", {
+  userId: UserId,
+  organizationId: OrganizationId,
+  role: OrganizationRole,
+  issuedBy: UserId,
+});
+export type OrganizationRoleGranted = typeof OrganizationRoleGranted.Type;
+
+export const organizationRoleGrantedSpanAttributes: SpanAttributesExtractor<
+  OrganizationRoleGranted
+> = (event) => ({
+  "user.id": event.userId,
+  "organization.id": event.organizationId,
+  "organization.role": event.role,
+  "issued.by.user.id": event.issuedBy,
+});
+
+export const OrganizationRoleRevoked = DomainEvent("OrganizationRoleRevoked", {
+  userId: UserId,
+  organizationId: OrganizationId,
+  role: OrganizationRole,
+});
+export type OrganizationRoleRevoked = typeof OrganizationRoleRevoked.Type;
+
+export const organizationRoleRevokedSpanAttributes: SpanAttributesExtractor<
+  OrganizationRoleRevoked
+> = (event) => ({
+  "user.id": event.userId,
+  "organization.id": event.organizationId,
+  "organization.role": event.role,
+});
+
+export type OrganizationRoleEvent = OrganizationRoleGranted | OrganizationRoleRevoked;

--- a/packages/server/src/modules/organization/domain/organization-role.ts
+++ b/packages/server/src/modules/organization/domain/organization-role.ts
@@ -1,0 +1,12 @@
+import * as Schema from "effect/Schema";
+
+// Closed set of role names a user can hold within one organization.
+// Phase 4 introduces only `admin` — the role that gates org-management
+// operations (invite, remove-member, future promote/demote). Plain
+// membership (per the `Membership` aggregate + `IsMember` check) is the
+// floor; this enum names the *elevated* roles above that floor.
+//
+// Adding a new role: extend the literal here (and `KNOWN_ORG_ROLES` in
+// `organization-roles-mapper.ts` and `organization-role-service-live.ts`).
+export const OrganizationRole = Schema.Literal("admin");
+export type OrganizationRole = typeof OrganizationRole.Type;

--- a/packages/server/src/modules/organization/domain/organization-roles-repository.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles-repository.ts
@@ -1,0 +1,30 @@
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+import { type OrganizationRoles } from "./organization-roles.aggregate.js";
+
+// Dumb persistence port. The aggregate carries the invariants
+// (uniqueness, "revoke only what's held"); the repository only knows
+// how to save and fetch the resulting state.
+//
+// `findByUserIdAndOrgId` returns an empty `OrganizationRoles` aggregate
+// if no rows are stored — the absence of any rows is a valid "no roles
+// yet" state, not a NotFound condition. Mirrors `RolesRepository`.
+export type OrganizationRolesRepositoryShape = {
+  readonly save: (
+    organizationRoles: OrganizationRoles,
+  ) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findByUserIdAndOrgId: (
+    userId: UserId,
+    organizationId: OrganizationId,
+  ) => Effect.Effect<OrganizationRoles, PersistenceUnavailable>;
+};
+
+export class OrganizationRolesRepository extends Context.Tag("OrganizationRolesRepository")<
+  OrganizationRolesRepository,
+  OrganizationRolesRepositoryShape
+>() {}

--- a/packages/server/src/modules/organization/domain/organization-roles.aggregate.test.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles.aggregate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Either from "effect/Either";
+
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import {
+  AlreadyHasOrganizationRole,
+  DoesNotHaveOrganizationRole,
+} from "./organization-role-errors.js";
+import { type OrganizationRoleEvent } from "./organization-role-events.js";
+import * as OrganizationRoles from "./organization-roles.aggregate.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
+
+const expectEvent = <T extends OrganizationRoleEvent["_tag"]>(
+  events: ReadonlyArray<OrganizationRoleEvent>,
+  tag: T,
+): Extract<OrganizationRoleEvent, { _tag: T }> => {
+  const event = events[0];
+  if (event?._tag !== tag) {
+    throw new Error(`expected ${tag}, got ${String(event?._tag)}`);
+  }
+  return event as Extract<OrganizationRoleEvent, { _tag: T }>;
+};
+
+describe("OrganizationRoles.empty", () => {
+  it("constructs an aggregate with no roles", () => {
+    const aggregate = OrganizationRoles.empty(userId, orgId);
+    deepStrictEqual(aggregate.userId, userId);
+    deepStrictEqual(aggregate.organizationId, orgId);
+    deepStrictEqual([...aggregate.roles], []);
+  });
+});
+
+describe("OrganizationRoles.hasRole", () => {
+  it("returns false on an empty aggregate", () => {
+    deepStrictEqual(
+      OrganizationRoles.hasRole(OrganizationRoles.empty(userId, orgId), "admin"),
+      false,
+    );
+  });
+
+  it("returns true once the role is granted", () => {
+    const result = OrganizationRoles.grantRole(
+      OrganizationRoles.empty(userId, orgId),
+      "admin",
+      issuedBy,
+    );
+    if (Either.isLeft(result)) throw new Error("expected Right");
+    deepStrictEqual(OrganizationRoles.hasRole(result.right.organizationRoles, "admin"), true);
+  });
+});
+
+describe("OrganizationRoles.grantRole", () => {
+  it("adds the role and emits OrganizationRoleGranted carrying issuedBy", () => {
+    const result = OrganizationRoles.grantRole(
+      OrganizationRoles.empty(userId, orgId),
+      "admin",
+      issuedBy,
+    );
+    if (Either.isLeft(result)) throw new Error("expected Right");
+    deepStrictEqual(
+      result.right.organizationRoles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
+      [{ role: "admin", issuedBy }],
+    );
+    const event = expectEvent(result.right.events, "OrganizationRoleGranted");
+    deepStrictEqual(event.userId, userId);
+    deepStrictEqual(event.organizationId, orgId);
+    deepStrictEqual(event.role, "admin");
+    deepStrictEqual(event.issuedBy, issuedBy);
+  });
+
+  it("fails AlreadyHasOrganizationRole when the role is already held", () => {
+    const first = OrganizationRoles.grantRole(
+      OrganizationRoles.empty(userId, orgId),
+      "admin",
+      issuedBy,
+    );
+    if (Either.isLeft(first)) throw new Error("expected Right");
+    const second = OrganizationRoles.grantRole(first.right.organizationRoles, "admin", issuedBy);
+    deepStrictEqual(Either.isLeft(second), true);
+    if (Either.isLeft(second)) {
+      deepStrictEqual(second.left instanceof AlreadyHasOrganizationRole, true);
+    }
+  });
+});
+
+describe("OrganizationRoles.revokeRole", () => {
+  it("removes the role and emits OrganizationRoleRevoked", () => {
+    const granted = OrganizationRoles.grantRole(
+      OrganizationRoles.empty(userId, orgId),
+      "admin",
+      issuedBy,
+    );
+    if (Either.isLeft(granted)) throw new Error("expected Right");
+    const result = OrganizationRoles.revokeRole(granted.right.organizationRoles, "admin");
+    if (Either.isLeft(result)) throw new Error("expected Right");
+    deepStrictEqual([...result.right.organizationRoles.roles], []);
+    const event = expectEvent(result.right.events, "OrganizationRoleRevoked");
+    deepStrictEqual(event.userId, userId);
+    deepStrictEqual(event.organizationId, orgId);
+    deepStrictEqual(event.role, "admin");
+  });
+
+  it("fails DoesNotHaveOrganizationRole when the role isn't held", () => {
+    const result = OrganizationRoles.revokeRole(OrganizationRoles.empty(userId, orgId), "admin");
+    deepStrictEqual(Either.isLeft(result), true);
+    if (Either.isLeft(result)) {
+      deepStrictEqual(result.left instanceof DoesNotHaveOrganizationRole, true);
+    }
+  });
+});

--- a/packages/server/src/modules/organization/domain/organization-roles.aggregate.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles.aggregate.ts
@@ -1,0 +1,115 @@
+import * as Either from "effect/Either";
+import * as Schema from "effect/Schema";
+
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { OrganizationRole } from "./organization-role.js";
+import {
+  AlreadyHasOrganizationRole,
+  DoesNotHaveOrganizationRole,
+} from "./organization-role-errors.js";
+import {
+  type OrganizationRoleEvent,
+  OrganizationRoleGranted,
+  OrganizationRoleRevoked,
+} from "./organization-role-events.js";
+
+// One role assignment for a (user, org) pair, carrying the audit trail
+// of who issued it. The aggregate models this as a record (not just a
+// role name) so the DELETE-then-INSERT-all save in the repository
+// round-trips `issued_by` rather than dropping it on every re-save.
+export class IssuedRole extends Schema.Class<IssuedRole>("IssuedRole")({
+  role: OrganizationRole,
+  issuedBy: UserId,
+}) {}
+
+// The set of roles assigned to one user within one organization.
+// Aggregate root, identified by the composite `(userId, organizationId)`.
+// Modeled as an array at the schema layer for stable serialization but
+// treated as a set semantically — `grantRole` / `revokeRole` enforce
+// uniqueness on the `role` axis. Mirrors `Roles` in the role module,
+// scoped to an organization plus an audit column.
+export class OrganizationRoles extends Schema.Class<OrganizationRoles>("OrganizationRoles")({
+  userId: UserId,
+  organizationId: OrganizationId,
+  roles: Schema.Array(IssuedRole),
+}) {}
+
+export type Result = {
+  readonly organizationRoles: OrganizationRoles;
+  readonly events: ReadonlyArray<OrganizationRoleEvent>;
+};
+
+// Factory for the "no roles yet" case — used by the command handler
+// when the repo's `findByUserIdAndOrgId` returns nothing.
+export const empty = (userId: UserId, organizationId: OrganizationId): OrganizationRoles =>
+  OrganizationRoles.make({ userId, organizationId, roles: [] });
+
+export const hasRole = (aggregate: OrganizationRoles, role: OrganizationRole): boolean =>
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- comparison is provably constant while `OrganizationRole` has a single literal; becomes a real comparison once a second role lands.
+  aggregate.roles.some((r) => r.role === role);
+
+// Aggregate-protected invariant: a role can only be granted once.
+export const grantRole = (
+  aggregate: OrganizationRoles,
+  role: OrganizationRole,
+  issuedBy: UserId,
+): Either.Either<Result, AlreadyHasOrganizationRole> => {
+  if (hasRole(aggregate, role)) {
+    return Either.left(
+      new AlreadyHasOrganizationRole({
+        userId: aggregate.userId,
+        organizationId: aggregate.organizationId,
+        role,
+      }),
+    );
+  }
+  return Either.right({
+    organizationRoles: OrganizationRoles.make({
+      userId: aggregate.userId,
+      organizationId: aggregate.organizationId,
+      roles: [...aggregate.roles, IssuedRole.make({ role, issuedBy })],
+    }),
+    events: [
+      OrganizationRoleGranted.make({
+        userId: aggregate.userId,
+        organizationId: aggregate.organizationId,
+        role,
+        issuedBy,
+      }),
+    ],
+  });
+};
+
+// Aggregate-protected invariant: only a role currently held can be
+// revoked.
+export const revokeRole = (
+  aggregate: OrganizationRoles,
+  role: OrganizationRole,
+): Either.Either<Result, DoesNotHaveOrganizationRole> => {
+  if (!hasRole(aggregate, role)) {
+    return Either.left(
+      new DoesNotHaveOrganizationRole({
+        userId: aggregate.userId,
+        organizationId: aggregate.organizationId,
+        role,
+      }),
+    );
+  }
+  return Either.right({
+    organizationRoles: OrganizationRoles.make({
+      userId: aggregate.userId,
+      organizationId: aggregate.organizationId,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- filter is provably constant while `OrganizationRole` has a single literal; becomes a real filter once a second role lands.
+      roles: aggregate.roles.filter((r) => r.role !== role),
+    }),
+    events: [
+      OrganizationRoleRevoked.make({
+        userId: aggregate.userId,
+        organizationId: aggregate.organizationId,
+        role,
+      }),
+    ],
+  });
+};

--- a/packages/server/src/modules/organization/index.ts
+++ b/packages/server/src/modules/organization/index.ts
@@ -1,10 +1,12 @@
 export { AcceptInvitationCommand } from "./commands/accept-invitation-command.js";
 export { CreateOrganizationCommand } from "./commands/create-organization-command.js";
+export { GrantOrganizationRoleCommand } from "./commands/grant-organization-role-command.js";
 export { InviteUserCommand } from "./commands/invite-user-command.js";
 export { LeaveOrganizationCommand } from "./commands/leave-organization-command.js";
 export { RemoveMemberCommand } from "./commands/remove-member-command.js";
 export { RestoreOrganizationCommand } from "./commands/restore-organization-command.js";
 export { RevokeInvitationCommand } from "./commands/revoke-invitation-command.js";
+export { RevokeOrganizationRoleCommand } from "./commands/revoke-organization-role-command.js";
 export { SoftDeleteOrganizationCommand } from "./commands/soft-delete-organization-command.js";
 export {
   InvitationAccepted,
@@ -12,24 +14,32 @@ export {
   InvitationRevoked,
 } from "./domain/invitation-events.js";
 export { MembershipCreated, MembershipRevoked } from "./domain/membership-events.js";
-// MembershipServiceLive wraps the module's internal MembershipRepository
-// into the platform-layer `MembershipService` ACL. Composed at the API
-// layer (server.ts / test-server.ts) so policies — currently the org's
-// own `IsMember`, future modules' policies as Phase 4 lands — can
-// consume the generalized boolean shape without importing the repo type.
 export {
   OrganizationCreated,
   OrganizationRestored,
   OrganizationSoftDeleted,
 } from "./domain/organization-events.js";
+export { CannotPromoteSelfInOrganization } from "./domain/organization-role-errors.js";
+export {
+  OrganizationRoleGranted,
+  OrganizationRoleRevoked,
+} from "./domain/organization-role-events.js";
+// MembershipServiceLive wraps the module's internal MembershipRepository
+// into the platform-layer `MembershipService` ACL. OrganizationRoleServiceLive
+// (Phase 4) plays the same role for the per-(user, org) role assignments.
+// Both compose at the API layer (server.ts / test-server.ts) so policies
+// — `IsMember`, `IsOrgAdmin`, future modules' admin checks — can consume
+// the generalized shape without importing the repos.
 export { MembershipServiceLive } from "./membership-service-live.js";
 export { organizationCommandHandlers } from "./organization-command-handlers.js";
 export { organizationEventSpanAttributes } from "./organization-event-span-attributes.js";
 export { OrganizationModuleLive } from "./organization-module.js";
 export { organizationQueryHandlers } from "./organization-query-handlers.js";
+export { OrganizationRoleServiceLive } from "./organization-role-service-live.js";
 export { organizationPolicies, OrganizationResource } from "./policies/organization-policies.js";
 export {
   OrganizationResolverEntry,
   OrganizationResolverEntryLive,
 } from "./policies/organization-resource-resolver.js";
 export { FindAllOrganizationsQuery } from "./queries/find-all-organizations-query.js";
+export { FindUserOrganizationRolesQuery } from "./queries/find-user-organization-roles-query.js";

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-mapper.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-mapper.ts
@@ -1,0 +1,38 @@
+import { type RowSchemas } from "@org/database/index";
+
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { type OrganizationRole } from "../domain/organization-role.js";
+import { IssuedRole, OrganizationRoles } from "../domain/organization-roles.aggregate.js";
+
+// Closed set of recognized role names. Mirrors the `OrganizationRole`
+// Schema literal in `domain/organization-role.ts` — adding a new role
+// requires updating both.
+const KNOWN_ROLES = new Set<string>(["admin"]);
+
+const narrow = (role: string): role is OrganizationRole => KNOWN_ROLES.has(role);
+
+// Builds an `OrganizationRoles` aggregate from raw
+// `organization.organization_roles` rows. The caller (the live
+// repository) groups rows by `(user_id, organization_id)` and hands
+// the slice for one pair here. Unknown role strings (never inserted by
+// application code) are filtered out rather than crashing the read —
+// defense in depth, same pattern as `role-mapper.ts`.
+export const toDomain = (
+  userId: UserId,
+  organizationId: OrganizationId,
+  rows: ReadonlyArray<RowSchemas.OrganizationRoleRow>,
+): OrganizationRoles =>
+  OrganizationRoles.make({
+    userId,
+    organizationId,
+    roles: rows
+      .filter((r) => narrow(r.role))
+      .map((r) =>
+        IssuedRole.make({
+          role: r.role as OrganizationRole,
+          issuedBy: UserId.make(r.issued_by),
+        }),
+      ),
+  });

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Either from "effect/Either";
+
+import {
+  empty as emptyOrgRoles,
+  grantRole,
+} from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { OrganizationRolesRepositoryFake } from "./organization-roles-repository-fake.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
+
+describe("OrganizationRolesRepositoryFake", () => {
+  it.effect("returns an empty aggregate for a previously-unseen (user, org) pair", () =>
+    Effect.gen(function* () {
+      const repo = yield* OrganizationRolesRepository;
+      const roles = yield* repo.findByUserIdAndOrgId(userId, orgId);
+      deepStrictEqual(roles.userId, userId);
+      deepStrictEqual(roles.organizationId, orgId);
+      deepStrictEqual([...roles.roles], []);
+    }).pipe(Effect.provide(OrganizationRolesRepositoryFake)),
+  );
+
+  it.effect("round-trips a saved aggregate via findByUserIdAndOrgId", () =>
+    Effect.gen(function* () {
+      const repo = yield* OrganizationRolesRepository;
+      const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
+      if (Either.isLeft(granted)) throw new Error("expected Right");
+      yield* repo.save(granted.right.organizationRoles);
+      const fetched = yield* repo.findByUserIdAndOrgId(userId, orgId);
+      deepStrictEqual(
+        fetched.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
+        [{ role: "admin", issuedBy }],
+      );
+    }).pipe(Effect.provide(OrganizationRolesRepositoryFake)),
+  );
+});

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.ts
@@ -1,0 +1,48 @@
+import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import {
+  empty as emptyOrgRoles,
+  type OrganizationRoles,
+} from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+// Keyed by composite identity serialized as "<userId>|<organizationId>".
+// The HashMap value carries the full `OrganizationRoles` aggregate so
+// reads round-trip the entire set of roles (and their issuers).
+const key = (userId: UserId, organizationId: OrganizationId): string =>
+  `${userId}|${organizationId}`;
+
+// In-memory `OrganizationRolesRepository` for use-case unit tests.
+// Composes with `IdentityUnitOfWork` and `RecordingEventBus` the same
+// way `RolesRepositoryFake` does.
+export const OrganizationRolesRepositoryFake = Layer.effect(
+  OrganizationRolesRepository,
+  Effect.gen(function* () {
+    const store = yield* Ref.make(HashMap.empty<string, OrganizationRoles>());
+
+    const save = (organizationRoles: OrganizationRoles): Effect.Effect<void> =>
+      Ref.update(
+        store,
+        HashMap.set(
+          key(organizationRoles.userId, organizationRoles.organizationId),
+          organizationRoles,
+        ),
+      );
+
+    const findByUserIdAndOrgId = (
+      userId: UserId,
+      organizationId: OrganizationId,
+    ): Effect.Effect<OrganizationRoles> =>
+      Effect.map(Ref.get(store), (m) => {
+        const found = HashMap.get(m, key(userId, organizationId));
+        return found._tag === "Some" ? found.value : emptyOrgRoles(userId, organizationId);
+      });
+
+    return OrganizationRolesRepository.of({ save, findByUserIdAndOrgId });
+  }),
+);

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from "@effect/vitest";
+import { Database, sql } from "@org/database/index";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Either from "effect/Either";
+import * as Layer from "effect/Layer";
+import { beforeEach } from "vitest";
+
+import {
+  empty as emptyOrgRoles,
+  grantRole,
+  revokeRole,
+} from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/organization-roles-repository-live.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
+
+// organization.organization_roles FKs to "user".users(id) (twice — for
+// user_id + issued_by) and organization.organizations(id). Each test
+// seeds the FK rows via raw SQL since the org module's barrel doesn't
+// (and shouldn't) re-export the user module's repository internals.
+const seedFixtures = Effect.gen(function* () {
+  const db = yield* Database.Database;
+  yield* db
+    .execute((client) =>
+      client.query(sql.unsafe`
+        INSERT INTO "user".users (id, email, country, street, postal_code, created_at, updated_at)
+        VALUES (${userId}, 'alice@example.com', 'USA', '123 Main St', '12345', now(), now())
+      `),
+    )
+    .pipe(Effect.orDie);
+  yield* db
+    .execute((client) =>
+      client.query(sql.unsafe`
+        INSERT INTO "user".users (id, email, country, street, postal_code, created_at, updated_at)
+        VALUES (${issuedBy}, 'admin@example.com', 'USA', '1 Admin Way', '12345', now(), now())
+      `),
+    )
+    .pipe(Effect.orDie);
+  yield* db
+    .execute((client) =>
+      client.query(sql.unsafe`
+        INSERT INTO "organization".organizations (id, name, created_at, updated_at, deleted_at)
+        VALUES (${orgId}, 'Acme', now(), now(), null)
+      `),
+    )
+    .pipe(Effect.orDie);
+});
+
+const TestLayer = OrganizationRolesRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("OrganizationRolesRepositoryLive (integration)", () => {
+  beforeEach(async () => {
+    await Effect.runPromise(
+      truncate("organization.organization_roles", "organization.organizations", "user.users").pipe(
+        Effect.provide(TestDatabaseLive),
+      ),
+    );
+  });
+
+  describe("findByUserIdAndOrgId", () => {
+    it.effect("returns an empty aggregate when no rows exist", () =>
+      Effect.gen(function* () {
+        yield* seedFixtures;
+        const repo = yield* OrganizationRolesRepository;
+        const roles = yield* repo.findByUserIdAndOrgId(userId, orgId);
+        deepStrictEqual(roles.userId, userId);
+        deepStrictEqual(roles.organizationId, orgId);
+        deepStrictEqual([...roles.roles], []);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+  });
+
+  describe("save", () => {
+    it.effect("persists granted roles with the issuedBy audit and round-trips", () =>
+      Effect.gen(function* () {
+        yield* seedFixtures;
+        const repo = yield* OrganizationRolesRepository;
+        const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
+        if (Either.isLeft(granted)) throw new Error("expected Right");
+        yield* repo.save(granted.right.organizationRoles);
+        const fetched = yield* repo.findByUserIdAndOrgId(userId, orgId);
+        deepStrictEqual(
+          fetched.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
+          [{ role: "admin", issuedBy }],
+        );
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("replaces existing rows when an aggregate revokes a role", () =>
+      Effect.gen(function* () {
+        yield* seedFixtures;
+        const repo = yield* OrganizationRolesRepository;
+        const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
+        if (Either.isLeft(granted)) throw new Error("expected Right");
+        yield* repo.save(granted.right.organizationRoles);
+        const revoked = revokeRole(granted.right.organizationRoles, "admin");
+        if (Either.isLeft(revoked)) throw new Error("expected Right");
+        yield* repo.save(revoked.right.organizationRoles);
+        const fetched = yield* repo.findByUserIdAndOrgId(userId, orgId);
+        deepStrictEqual([...fetched.roles], []);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+  });
+});

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.ts
@@ -1,0 +1,92 @@
+import { Database, RowSchemas, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import { type OrganizationRoles } from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import * as OrganizationRolesMapper from "@/modules/organization/infrastructure/organization-roles-mapper.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
+
+export const OrganizationRolesRepositoryLive = Layer.effect(
+  OrganizationRolesRepository,
+  Effect.gen(function* () {
+    const db = yield* Database.Database;
+
+    // Aggregate persistence: replace the (user, org) row set with
+    // whatever the aggregate now holds. The DELETE + N INSERTs must run
+    // on the same connection to be atomic. Same strategy as
+    // `RolesRepositoryLive.save` — reuse the ambient `TransactionContext`
+    // if a `UnitOfWork.run` already opened one, otherwise open a private
+    // `db.transaction` so the repo is internally atomic even when called
+    // bare. Either way the statements share one connection.
+    const writeStatements = (organizationRoles: OrganizationRoles) =>
+      Effect.gen(function* () {
+        const tx = yield* Database.TransactionContext;
+        yield* tx((client) =>
+          client.query(sql.unsafe`
+            DELETE FROM "organization".organization_roles
+            WHERE user_id = ${organizationRoles.userId}
+              AND organization_id = ${organizationRoles.organizationId}
+          `),
+        );
+        for (const r of organizationRoles.roles) {
+          yield* tx((client) =>
+            client.query(sql.unsafe`
+              INSERT INTO "organization".organization_roles
+                (organization_id, user_id, role, issued_by)
+              VALUES (
+                ${organizationRoles.organizationId},
+                ${organizationRoles.userId},
+                ${r.role},
+                ${r.issuedBy}
+              )
+            `),
+          );
+        }
+      });
+
+    const save = (organizationRoles: OrganizationRoles) =>
+      Effect.serviceOption(Database.TransactionContext).pipe(
+        Effect.flatMap((existing) =>
+          Option.isSome(existing)
+            ? writeStatements(organizationRoles).pipe(
+                Database.TransactionContext.provide(existing.value),
+              )
+            : db.transaction((tx) =>
+                writeStatements(organizationRoles).pipe(Database.TransactionContext.provide(tx)),
+              ),
+        ),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("OrganizationRolesRepository.save"),
+      );
+
+    const findByUserIdAndOrgId = db.makeQuery(
+      (execute, args: { userId: UserId; organizationId: OrganizationId }) =>
+        execute((client) =>
+          client.any(sql.type(RowSchemas.OrganizationRoleRowStd)`
+            SELECT organization_id, user_id, role, issued_by, created_at
+            FROM "organization".organization_roles
+            WHERE user_id = ${args.userId}
+              AND organization_id = ${args.organizationId}
+          `),
+        ).pipe(
+          Effect.map((rows) =>
+            OrganizationRolesMapper.toDomain(args.userId, args.organizationId, rows),
+          ),
+          Effect.catchTag("DatabaseError", Effect.die),
+          translatePersistenceUnavailable,
+          Effect.withSpan("OrganizationRolesRepository.findByUserIdAndOrgId"),
+        ),
+    );
+
+    return OrganizationRolesRepository.of({
+      save,
+      findByUserIdAndOrgId: (userId, organizationId) =>
+        findByUserIdAndOrgId({ userId, organizationId }),
+    });
+  }),
+);

--- a/packages/server/src/modules/organization/interface/http/restore.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/restore.endpoint.integration.test.ts
@@ -85,10 +85,10 @@ memberSuite("POST /orgs/:id/restore (integration, non-super-admin caller)", () =
     { server: TestServerLiveAsMember, seedSuperAdminCaller: true },
   );
 
-  // Seeds an org directly via SQL so the member-caller is NOT a member
-  // of it — `restore`'s policy is `any(SuperAdminOnly, IsMember)`, so
+  // Seeds an org directly via SQL so the member-caller is NOT an admin
+  // of it — `restore`'s policy is `any(SuperAdminOnly, IsOrgAdmin)`, so
   // the 403 path requires both halves to fail.
-  it("returns 403 Forbidden for a caller who's neither a super-admin nor a member", async () => {
+  it("returns 403 Forbidden for a caller who's neither a super-admin nor an org admin", async () => {
     await run(
       Effect.gen(function* () {
         const orgId = "11111111-1111-1111-1111-111111111111" as never;

--- a/packages/server/src/modules/organization/organization-command-handlers.ts
+++ b/packages/server/src/modules/organization/organization-command-handlers.ts
@@ -11,6 +11,11 @@ import {
   type CreateOrganizationCommand,
   createOrganizationCommandSpanAttributes,
 } from "@/modules/organization/commands/create-organization-command.js";
+import { grantOrganizationRole } from "@/modules/organization/commands/grant-organization-role.js";
+import {
+  type GrantOrganizationRoleCommand,
+  grantOrganizationRoleCommandSpanAttributes,
+} from "@/modules/organization/commands/grant-organization-role-command.js";
 import { inviteUser } from "@/modules/organization/commands/invite-user.js";
 import {
   type InviteUserCommand,
@@ -36,6 +41,11 @@ import {
   type RevokeInvitationCommand,
   revokeInvitationCommandSpanAttributes,
 } from "@/modules/organization/commands/revoke-invitation-command.js";
+import { revokeOrganizationRole } from "@/modules/organization/commands/revoke-organization-role.js";
+import {
+  type RevokeOrganizationRoleCommand,
+  revokeOrganizationRoleCommandSpanAttributes,
+} from "@/modules/organization/commands/revoke-organization-role-command.js";
 import { softDeleteOrganization } from "@/modules/organization/commands/soft-delete-organization.js";
 import {
   type SoftDeleteOrganizationCommand,
@@ -55,9 +65,15 @@ import {
   type OrganizationNotDeleted,
   type OrganizationNotFound,
 } from "@/modules/organization/domain/organization-errors.js";
+import {
+  type AlreadyHasOrganizationRole,
+  type CannotPromoteSelfInOrganization,
+  type DoesNotHaveOrganizationRole,
+} from "@/modules/organization/domain/organization-role-errors.js";
 import { InvitationRepositoryLive } from "@/modules/organization/infrastructure/invitation-repository-live.js";
 import { MembershipRepositoryLive } from "@/modules/organization/infrastructure/membership-repository-live.js";
 import { OrganizationRepositoryLive } from "@/modules/organization/infrastructure/organization-repository-live.js";
+import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/organization-roles-repository-live.js";
 import { commandHandlers } from "@/platform/ddd/command-bus.js";
 import { type DomainEventBus } from "@/platform/ddd/domain-event-bus.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
@@ -121,6 +137,18 @@ type RevokeInvitationBusOutput = Effect.Effect<
   DomainEventBus | UnitOfWork | Database.Database
 >;
 
+type GrantOrganizationRoleBusOutput = Effect.Effect<
+  void,
+  AlreadyHasOrganizationRole | CannotPromoteSelfInOrganization | PersistenceUnavailable,
+  DomainEventBus | UnitOfWork | Database.Database
+>;
+
+type RevokeOrganizationRoleBusOutput = Effect.Effect<
+  void,
+  DoesNotHaveOrganizationRole | PersistenceUnavailable,
+  DomainEventBus | UnitOfWork | Database.Database
+>;
+
 declare module "@/platform/ddd/command-bus.js" {
   interface CommandRegistry {
     CreateOrganizationCommand: {
@@ -155,6 +183,14 @@ declare module "@/platform/ddd/command-bus.js" {
       readonly command: RevokeInvitationCommand;
       readonly output: RevokeInvitationBusOutput;
     };
+    GrantOrganizationRoleCommand: {
+      readonly command: GrantOrganizationRoleCommand;
+      readonly output: GrantOrganizationRoleBusOutput;
+    };
+    RevokeOrganizationRoleCommand: {
+      readonly command: RevokeOrganizationRoleCommand;
+      readonly output: RevokeOrganizationRoleBusOutput;
+    };
   }
 }
 
@@ -164,6 +200,7 @@ export const organizationCommandHandlers = commandHandlers({
       createOrganization(cmd).pipe(
         Effect.provide(OrganizationRepositoryLive),
         Effect.provide(MembershipRepositoryLive),
+        Effect.provide(OrganizationRolesRepositoryLive),
       ),
     spanAttributes: createOrganizationCommandSpanAttributes,
   },
@@ -204,5 +241,15 @@ export const organizationCommandHandlers = commandHandlers({
     handle: (cmd): RevokeInvitationBusOutput =>
       revokeInvitation(cmd).pipe(Effect.provide(InvitationRepositoryLive)),
     spanAttributes: revokeInvitationCommandSpanAttributes,
+  },
+  GrantOrganizationRoleCommand: {
+    handle: (cmd): GrantOrganizationRoleBusOutput =>
+      grantOrganizationRole(cmd).pipe(Effect.provide(OrganizationRolesRepositoryLive)),
+    spanAttributes: grantOrganizationRoleCommandSpanAttributes,
+  },
+  RevokeOrganizationRoleCommand: {
+    handle: (cmd): RevokeOrganizationRoleBusOutput =>
+      revokeOrganizationRole(cmd).pipe(Effect.provide(OrganizationRolesRepositoryLive)),
+    spanAttributes: revokeOrganizationRoleCommandSpanAttributes,
   },
 });

--- a/packages/server/src/modules/organization/organization-event-span-attributes.ts
+++ b/packages/server/src/modules/organization/organization-event-span-attributes.ts
@@ -12,6 +12,10 @@ import {
   organizationRestoredSpanAttributes,
   organizationSoftDeletedSpanAttributes,
 } from "@/modules/organization/domain/organization-events.js";
+import {
+  organizationRoleGrantedSpanAttributes,
+  organizationRoleRevokedSpanAttributes,
+} from "@/modules/organization/domain/organization-role-events.js";
 import { eventSpanAttributes } from "@/platform/ddd/domain-event-bus.js";
 
 export const organizationEventSpanAttributes = eventSpanAttributes({
@@ -23,4 +27,6 @@ export const organizationEventSpanAttributes = eventSpanAttributes({
   InvitationIssued: invitationIssuedSpanAttributes,
   InvitationAccepted: invitationAcceptedSpanAttributes,
   InvitationRevoked: invitationRevokedSpanAttributes,
+  OrganizationRoleGranted: organizationRoleGrantedSpanAttributes,
+  OrganizationRoleRevoked: organizationRoleRevokedSpanAttributes,
 });

--- a/packages/server/src/modules/organization/organization-query-handlers.ts
+++ b/packages/server/src/modules/organization/organization-query-handlers.ts
@@ -1,13 +1,46 @@
+import { type Database } from "@org/database/index";
+import * as Effect from "effect/Effect";
+
+import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/organization-roles-repository-live.js";
 import { findAllOrganizations } from "@/modules/organization/queries/find-all-organizations.js";
 import { findAllOrganizationsQuerySpanAttributes } from "@/modules/organization/queries/find-all-organizations-query.js";
+import { findUserOrganizationRoles } from "@/modules/organization/queries/find-user-organization-roles.js";
+import {
+  type FindUserOrganizationRolesQuery,
+  findUserOrganizationRolesQuerySpanAttributes,
+  type FindUserOrganizationRolesResult,
+} from "@/modules/organization/queries/find-user-organization-roles-query.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
 import { queryHandlers } from "@/platform/ddd/query-bus.js";
 
-// `FindAllOrganizationsQuery` reads SQL directly (no OrganizationRepository
-// in R) so the handler doesn't need wrapping. Lives at module root for
-// symmetry with `organization-command-handlers.ts`.
+type FindUserOrganizationRolesBusOutput = Effect.Effect<
+  FindUserOrganizationRolesResult,
+  PersistenceUnavailable,
+  Database.Database
+>;
+
+declare module "@/platform/ddd/query-bus.js" {
+  interface QueryRegistry {
+    FindUserOrganizationRolesQuery: {
+      readonly query: FindUserOrganizationRolesQuery;
+      readonly output: FindUserOrganizationRolesBusOutput;
+    };
+  }
+}
+
+// `FindAllOrganizationsQuery` reads SQL directly (no repository in R)
+// so the handler doesn't need wrapping. `FindUserOrganizationRolesQuery`
+// goes through the `OrganizationRolesRepository` and is wrapped with
+// `OrganizationRolesRepositoryLive` to discharge that dep before the
+// bus dispatch.
 export const organizationQueryHandlers = queryHandlers({
   FindAllOrganizationsQuery: {
     handle: findAllOrganizations,
     spanAttributes: findAllOrganizationsQuerySpanAttributes,
+  },
+  FindUserOrganizationRolesQuery: {
+    handle: (q): FindUserOrganizationRolesBusOutput =>
+      findUserOrganizationRoles(q).pipe(Effect.provide(OrganizationRolesRepositoryLive)),
+    spanAttributes: findUserOrganizationRolesQuerySpanAttributes,
   },
 });

--- a/packages/server/src/modules/organization/organization-role-service-live.ts
+++ b/packages/server/src/modules/organization/organization-role-service-live.ts
@@ -1,0 +1,38 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/organization-roles-repository-live.js";
+import {
+  type OrganizationRoleName,
+  OrganizationRoleService,
+} from "@/platform/ddd/organization-role-service.js";
+
+const KNOWN_ROLES = new Set<string>(["admin"]);
+const narrow = (role: string): role is OrganizationRoleName => KNOWN_ROLES.has(role);
+
+// Wraps the org module's own `OrganizationRolesRepository` into the
+// generalized `OrganizationRoleService` ACL. Same shape as
+// `MembershipServiceLive` — the repo is internally provided so
+// consuming policies see only the platform-layer service Tag in R.
+// Effect's Layer memoization shares one repo instance with the
+// command-handler wraps that also reference it.
+export const OrganizationRoleServiceLive = Layer.effect(
+  OrganizationRoleService,
+  Effect.gen(function* () {
+    const repo = yield* OrganizationRolesRepository;
+    return OrganizationRoleService.of({
+      findOrganizationPermissions: (userId, organizationId) =>
+        repo.findByUserIdAndOrgId(userId, organizationId).pipe(
+          Effect.map((aggregate) => ({
+            userId: aggregate.userId,
+            organizationId: aggregate.organizationId,
+            roles: aggregate.roles
+              .map((r) => r.role)
+              .filter((r): r is OrganizationRoleName => narrow(r)),
+          })),
+          Effect.withSpan("OrganizationRoleService.findOrganizationPermissions"),
+        ),
+    });
+  }),
+).pipe(Layer.provide(OrganizationRolesRepositoryLive));

--- a/packages/server/src/modules/organization/policies/is-org-admin.ts
+++ b/packages/server/src/modules/organization/policies/is-org-admin.ts
@@ -1,0 +1,28 @@
+import * as Effect from "effect/Effect";
+
+import type * as PolicyRegistry from "@/platform/auth/policy-registry.js";
+import { OrganizationRoleService } from "@/platform/ddd/organization-role-service.js";
+
+// Per-org "is this caller an admin of this organization?" check.
+// Consumes the platform-layer `OrganizationRoleService` ACL (never the
+// org module's `OrganizationRolesRepository` directly) so the dep graph
+// stays acyclic and the consuming-policy surface depends only on the
+// generalized role-name shape.
+//
+// Typed via `PolicyRegistry.CheckFor<"organization", "update">` so the
+// R channel resolves to the full `PolicyDeps` set — that lets
+// `Authz.any(SuperAdminOnly, IsOrgAdmin)` type-check uniformly even
+// though each check uses a different platform service (RoleService vs
+// OrganizationRoleService). Same shape as `IsMember`.
+//
+// Composed via `Authz.any(SuperAdminOnly, IsOrgAdmin)` so super-admins
+// bypass the per-org role lookup (short-circuit on the first `true`).
+export const IsOrgAdmin: PolicyRegistry.CheckFor<"organization", "update"> = (
+  caller,
+  organization,
+) =>
+  Effect.gen(function* () {
+    const orgRoles = yield* OrganizationRoleService;
+    const perms = yield* orgRoles.findOrganizationPermissions(caller.userId, organization.id);
+    return perms.roles.includes("admin");
+  });

--- a/packages/server/src/modules/organization/policies/organization-policies.ts
+++ b/packages/server/src/modules/organization/policies/organization-policies.ts
@@ -4,15 +4,17 @@ import type * as PolicyRegistry from "@/platform/auth/policy-registry.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 import { type Organization } from "../domain/organization.aggregate.js";
-import { IsMember } from "./is-member.js";
+import { IsOrgAdmin } from "./is-org-admin.js";
 
-// Phase 3 contribution. `update` now allows any member of the org (in
-// addition to super-admins) — the same policy gates invite, revoke,
-// remove-member endpoints. `delete` stays super-admin-only because
-// tombstoning an org is a platform-level operation. `read` will become
-// `any(SuperAdminOnly, IsMember)` once a `findMyOrganizations` endpoint
-// lands; the admin-side `findAll` reads use `Actions.Read` flat without
-// an id and remain super-admin-only.
+// Phase 4 contribution. `update` (which gates invite, revoke,
+// remove-member, and future promote/demote endpoints) now requires the
+// `admin` OrganizationRole — plain members no longer manage members.
+// The creator of an org is auto-granted `admin` in
+// `create-organization.ts`. `read` stays super-admin-only because the
+// only `Authz.hasPermissions("organization", Actions.Read)` call site
+// today is the admin-side `findAll` listing (flat, no id) — `IsMember`
+// can't run against a missing resource. `delete` stays super-admin-only
+// — tombstoning an org is a platform-level operation.
 
 declare module "@/platform/auth/resource-resolver-registry.js" {
   interface ResourceResolverMap {
@@ -35,7 +37,7 @@ export const OrganizationResource = "organization" as const;
 export const organizationPolicies: PolicyRegistry.PolicyContribution = {
   organization: {
     read: SuperAdminOnly,
-    update: Check.any(SuperAdminOnly, IsMember),
+    update: Check.any(SuperAdminOnly, IsOrgAdmin),
     delete: SuperAdminOnly,
   },
 };

--- a/packages/server/src/modules/organization/queries/find-user-organization-roles-query.ts
+++ b/packages/server/src/modules/organization/queries/find-user-organization-roles-query.ts
@@ -1,0 +1,46 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type OrganizationRole } from "@/modules/organization/domain/organization-role.js";
+import { type OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Read-side projection of a user's roles within one organization.
+// Returns an empty roles array if the user holds none — absence isn't
+// NotFound. Other modules' policies don't depend on this query
+// directly; the platform-layer `OrganizationRoleService` (`platform/
+// ddd/organization-role-service.ts`) wraps it and maps to a generalized
+// shape.
+export const FindUserOrganizationRolesQuery = Schema.TaggedStruct(
+  "FindUserOrganizationRolesQuery",
+  {
+    userId: UserId,
+    organizationId: OrganizationId,
+  },
+);
+export type FindUserOrganizationRolesQuery = typeof FindUserOrganizationRolesQuery.Type;
+
+export type FindUserOrganizationRolesResult = {
+  readonly userId: UserId;
+  readonly organizationId: OrganizationId;
+  readonly roles: ReadonlyArray<OrganizationRole>;
+};
+
+export const findUserOrganizationRolesQuerySpanAttributes: SpanAttributesExtractor<
+  FindUserOrganizationRolesQuery
+> = (query) => ({
+  "query.userId": query.userId,
+  "query.organizationId": query.organizationId,
+});
+
+// Raw handler effect — `OrganizationRolesRepository` is discharged by
+// the wrap in `organization-query-handlers.ts`; the bus-registered
+// output type lives there.
+export type FindUserOrganizationRolesOutput = Effect.Effect<
+  FindUserOrganizationRolesResult,
+  PersistenceUnavailable,
+  OrganizationRolesRepository
+>;

--- a/packages/server/src/modules/organization/queries/find-user-organization-roles.test.ts
+++ b/packages/server/src/modules/organization/queries/find-user-organization-roles.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Either from "effect/Either";
+
+import {
+  empty as emptyOrgRoles,
+  grantRole,
+} from "@/modules/organization/domain/organization-roles.aggregate.js";
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/organization-roles-repository-fake.js";
+import { findUserOrganizationRoles } from "@/modules/organization/queries/find-user-organization-roles.js";
+import { FindUserOrganizationRolesQuery } from "@/modules/organization/queries/find-user-organization-roles-query.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
+
+describe("findUserOrganizationRoles", () => {
+  it.effect("returns an empty roles array for a (user, org) with none granted", () =>
+    Effect.gen(function* () {
+      const result = yield* findUserOrganizationRoles(
+        FindUserOrganizationRolesQuery.make({ userId, organizationId: orgId }),
+      );
+      deepStrictEqual(result.userId, userId);
+      deepStrictEqual(result.organizationId, orgId);
+      deepStrictEqual([...result.roles], []);
+    }).pipe(Effect.provide(OrganizationRolesRepositoryFake)),
+  );
+
+  it.effect("returns the granted roles, projected to bare role names", () =>
+    Effect.gen(function* () {
+      const repo = yield* OrganizationRolesRepository;
+      const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
+      if (Either.isLeft(granted)) throw new Error("expected Right");
+      yield* repo.save(granted.right.organizationRoles);
+      const result = yield* findUserOrganizationRoles(
+        FindUserOrganizationRolesQuery.make({ userId, organizationId: orgId }),
+      );
+      deepStrictEqual([...result.roles], ["admin"]);
+    }).pipe(Effect.provide(OrganizationRolesRepositoryFake)),
+  );
+});

--- a/packages/server/src/modules/organization/queries/find-user-organization-roles.ts
+++ b/packages/server/src/modules/organization/queries/find-user-organization-roles.ts
@@ -1,0 +1,24 @@
+import * as Effect from "effect/Effect";
+
+import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles-repository.js";
+import {
+  type FindUserOrganizationRolesOutput,
+  type FindUserOrganizationRolesQuery,
+} from "@/modules/organization/queries/find-user-organization-roles-query.js";
+
+// Goes through the repository (rather than reading SQL directly) so the
+// `OrganizationRoles` aggregate's mapping logic is the single source of
+// truth for "what counts as a recognized role." Same shape as
+// `findUserRoles` in the role module.
+export const findUserOrganizationRoles = (
+  query: FindUserOrganizationRolesQuery,
+): FindUserOrganizationRolesOutput =>
+  Effect.gen(function* () {
+    const repo = yield* OrganizationRolesRepository;
+    const aggregate = yield* repo.findByUserIdAndOrgId(query.userId, query.organizationId);
+    return {
+      userId: aggregate.userId,
+      organizationId: aggregate.organizationId,
+      roles: aggregate.roles.map((r) => r.role),
+    };
+  });

--- a/packages/server/src/platform/auth/authz.test.ts
+++ b/packages/server/src/platform/auth/authz.test.ts
@@ -8,6 +8,7 @@ import * as Layer from "effect/Layer";
 
 import { UserId } from "@/platform/ids/user-id.js";
 import { makeMembershipServiceFake } from "@/test-utils/membership-service-fake.js";
+import { makeOrganizationRoleServiceFake } from "@/test-utils/organization-role-service-fake.js";
 import { makeRoleServiceFake } from "@/test-utils/role-service-fake.js";
 
 import { Actions } from "./actions.js";
@@ -72,6 +73,7 @@ const provideRegistries = (opts: {
     // consume them, but the R channel still needs satisfying.
     makeRoleServiceFake(new Map()),
     makeMembershipServiceFake(),
+    makeOrganizationRoleServiceFake(),
   );
 
 const provideCurrentUser = (caller: CurrentUser["Type"]) => Layer.succeed(CurrentUserTag, caller);
@@ -95,6 +97,7 @@ describe("makePolicyRegistry — array-of-checks AND composition", () => {
           }),
           makeRoleServiceFake(new Map()),
           makeMembershipServiceFake(),
+          makeOrganizationRoleServiceFake(),
         ),
       ),
       Effect.provide(provideCurrentUser(callerMember)),
@@ -130,6 +133,7 @@ describe("makePolicyRegistry — array-of-checks AND composition", () => {
           }),
           makeRoleServiceFake(new Map()),
           makeMembershipServiceFake(),
+          makeOrganizationRoleServiceFake(),
         ),
       ),
       Effect.provide(provideCurrentUser(callerMember)),

--- a/packages/server/src/platform/auth/policy-registry.ts
+++ b/packages/server/src/platform/auth/policy-registry.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 import { type MembershipService } from "@/platform/ddd/membership-service.js";
+import { type OrganizationRoleService } from "@/platform/ddd/organization-role-service.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
 import { type RoleService } from "@/platform/ddd/role-service.js";
 
@@ -12,11 +13,13 @@ import { type ResourceName, type ResourceTypeFor } from "./resource-resolver-reg
 
 // Closed set of cross-cutting services a registered check may depend
 // on. Today: `RoleService` (the platform-layer ACL over the role
-// module) + `MembershipService` (the platform-layer ACL over the org
-// module's memberships). Both are platform/ddd/ shaped services, never
-// the source module's domain types — keeps consuming policies decoupled
-// and keeps the dep graph acyclic.
-export type PolicyDeps = RoleService | MembershipService;
+// module), `MembershipService` (the platform-layer ACL over the org
+// module's memberships), `OrganizationRoleService` (the platform-layer
+// ACL over the org module's per-(user, org) role assignments — Phase
+// 4). All three are platform/ddd/ shaped services, never the source
+// module's domain types — keeps consuming policies decoupled and keeps
+// the dep graph acyclic.
+export type PolicyDeps = RoleService | MembershipService | OrganizationRoleService;
 export type PolicyErrors = PersistenceUnavailable;
 
 // Registry of policy checks, keyed by (resource, action). Actions are

--- a/packages/server/src/platform/ddd/organization-role-service.ts
+++ b/packages/server/src/platform/ddd/organization-role-service.ts
@@ -1,0 +1,36 @@
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+import { type PersistenceUnavailable } from "@/platform/ddd/persistence-unavailable.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+// The set of org-scoped role names exposed to cross-module consumers.
+// Deliberately a closed literal union here — duplicated from the org
+// module's `OrganizationRole` Schema literal on purpose, so consuming
+// modules (the org's own `IsOrgAdmin` check, future modules' policies)
+// depend only on this ACL and not on the org module's domain types.
+export type OrganizationRoleName = "admin";
+
+export type OrganizationPermissions = {
+  readonly userId: UserId;
+  readonly organizationId: OrganizationId;
+  readonly roles: ReadonlyArray<OrganizationRoleName>;
+};
+
+// Platform-layer ACL between the org module's `OrganizationRoles`
+// aggregate and any policy that needs to ask "which roles does this
+// user hold inside this org?" — e.g. `IsOrgAdmin`, future per-resource
+// modules' admin checks. Mirrors `RoleService`'s shape, scoped to a
+// (user, organization) pair instead of a platform-wide user.
+export type OrganizationRoleServiceShape = {
+  readonly findOrganizationPermissions: (
+    userId: UserId,
+    organizationId: OrganizationId,
+  ) => Effect.Effect<OrganizationPermissions, PersistenceUnavailable>;
+};
+
+export class OrganizationRoleService extends Context.Tag("OrganizationRoleService")<
+  OrganizationRoleService,
+  OrganizationRoleServiceShape
+>() {}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -32,6 +32,7 @@ import {
   organizationQueryHandlers,
   OrganizationResolverEntry,
   OrganizationResolverEntryLive,
+  OrganizationRoleServiceLive,
 } from "./modules/organization/index.js";
 import {
   roleCommandHandlers,
@@ -130,6 +131,7 @@ const ApiLive = HttpApiBuilder.api(Api).pipe(
     UserAuthMiddlewareLive,
     RoleServiceLive,
     MembershipServiceLive,
+    OrganizationRoleServiceLive,
     DomainEventBusLive,
     UnitOfWorkLive,
   ]),

--- a/packages/server/src/test-utils/organization-role-service-fake.ts
+++ b/packages/server/src/test-utils/organization-role-service-fake.ts
@@ -1,0 +1,32 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import {
+  type OrganizationRoleName,
+  OrganizationRoleService,
+} from "@/platform/ddd/organization-role-service.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+// Factory for an in-memory `OrganizationRoleService` Layer keyed by a
+// `${userId}::${organizationId}` composite. Use in unit tests of
+// policies / checks that depend on per-org roles, where you don't want
+// to wire the repository + query bus + plumbing to validate a boolean
+// predicate.
+export const makeOrganizationRoleServiceFake = (
+  rolesByPair: ReadonlyMap<
+    `${UserId}::${OrganizationId}`,
+    ReadonlyArray<OrganizationRoleName>
+  > = new Map(),
+) =>
+  Layer.succeed(
+    OrganizationRoleService,
+    OrganizationRoleService.of({
+      findOrganizationPermissions: (userId, organizationId) =>
+        Effect.succeed({
+          userId,
+          organizationId,
+          roles: rolesByPair.get(`${userId}::${organizationId}`) ?? [],
+        }),
+    }),
+  );

--- a/packages/server/src/test-utils/test-server.ts
+++ b/packages/server/src/test-utils/test-server.ts
@@ -21,6 +21,7 @@ import {
   organizationQueryHandlers,
   OrganizationResolverEntry,
   OrganizationResolverEntryLive,
+  OrganizationRoleServiceLive,
 } from "@/modules/organization/index.js";
 import {
   roleCommandHandlers,
@@ -120,6 +121,7 @@ export const makeTestServerLive = (authMiddleware: Layer.Layer<UserAuthMiddlewar
       authMiddleware,
       RoleServiceLive,
       MembershipServiceLive,
+      OrganizationRoleServiceLive,
       DomainEventBusLive,
       UnitOfWorkLive,
     ]),


### PR DESCRIPTION
## Summary

Introduces per-(user, org) **organization roles** so we can distinguish Org Admins from plain members. Only Org Admins can invite/remove members (and, in future, promote/demote); the org creator is auto-granted `admin` on creation.

This is modeled as first-class **roles** (mirroring the platform `role` module), not a capability-grant table — keeping the code as the source of truth for which actions a role permits, rather than encoding resource/action pairs in the DB.

- **Migration V016**: `organization.organization_roles` — `(organization_id, user_id, role, issued_by, created_at)`, composite PK on `(organization_id, user_id, role)`, FKs to `"user".users` (twice: subject + issuer) and `organization.organizations`.
- **Domain**: `OrganizationRoles` aggregate (set semantics over `IssuedRole`, carrying `issuedBy` for audit), grant/revoke invariants, events (`OrganizationRoleGranted/Revoked`), errors (`AlreadyHasOrganizationRole`, `DoesNotHaveOrganizationRole`, `CannotPromoteSelfInOrganization`), dumb repository (port/fake/live/mapper).
- **Commands**: `GrantOrganizationRoleCommand`, `RevokeOrganizationRoleCommand` (grant carries the self-promotion guard). **Query**: `FindUserOrganizationRolesQuery`. Both bus-registered.
- **Platform ACL**: `OrganizationRoleService` (port in `platform/ddd/`, Live in the org module, fake in `test-utils/`). `PolicyDeps` widened to include it.
- **Policy**: new `IsOrgAdmin` check; organization `update` policy is now `any(SuperAdminOnly, IsOrgAdmin)` — gates invite / revoke-invitation / remove-member / restore. `read` and `delete` unchanged (super-admin-only).
- **Creator seed**: `create-organization` grants the creator the `admin` role in the same unit of work as the org + first membership.

### Notes for reviewers
- `IsMember` / `MembershipService` are no longer referenced by any registered policy (the `update` gate moved from `IsMember` → `IsOrgAdmin`). Left in place as scaffolding for a future "my organizations" membership-scoped policy; happy to delete if preferred.
- Action vocabulary stays CRUD-only; "invite/remove/promote" are command-level operations gated by the `update` policy, not new action strings.

## Test plan
- [x] `OrganizationRoles` aggregate unit tests (grant/revoke/uniqueness/issuedBy)
- [x] Repository fake unit + live integration (issuedBy round-trip, revoke replace)
- [x] Grant/revoke command unit tests (incl. CannotPromoteSelfInOrganization, AlreadyHas/DoesNotHave)
- [x] `FindUserOrganizationRoles` query unit test
- [x] `create-organization` seeds creator admin role + event
- [x] `restore` endpoint 403 path updated for IsOrgAdmin
- [x] `pnpm check:all` green (lint, dep-cruise, parity, typecheck, 331 server tests incl. integration, Storybook build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)