### PR TITLE
feat(todos): org-scope todos under /orgs/:orgId/todos (Phase 5)

### DIFF
--- a/packages/contracts/src/api/OrganizationContract.ts
+++ b/packages/contracts/src/api/OrganizationContract.ts
@@ -126,6 +126,7 @@ export class AcceptInvitationResponse extends Schema.Class<AcceptInvitationRespo
 
 export class Group extends HttpApiGroup.make("organization")
   .middleware(UserAuthMiddleware)
+  .add(HttpApiEndpoint.get("findMine", "/").addSuccess(Schema.Array(Organization)))
   .add(
     HttpApiEndpoint.post("create", "/")
       .setPayload(CreateOrganizationPayload)

--- a/packages/contracts/src/api/TodosContract.ts
+++ b/packages/contracts/src/api/TodosContract.ts
@@ -4,7 +4,7 @@ import * as HttpApiSchema from "@effect/platform/HttpApiSchema";
 import * as Schema from "effect/Schema";
 
 import * as CustomHttpApiError from "../CustomHttpApiError.js";
-import { TodoId } from "../EntityIds.js";
+import { OrganizationId, TodoId } from "../EntityIds.js";
 import { UserAuthMiddleware } from "../Policy.js";
 
 export class TodoNotFoundError extends Schema.TaggedError<TodoNotFoundError>("TodoNotFoundError")(
@@ -28,27 +28,45 @@ export class CreateTodoPayload extends Schema.Class<CreateTodoPayload>("CreateTo
 }) {}
 
 export class UpdateTodoPayload extends Schema.Class<UpdateTodoPayload>("UpdateTodoPayload")({
-  id: TodoId,
   title: Todo.fields.title,
   completed: Todo.fields.completed,
 }) {}
 
+// Phase 5: todos are org-scoped. Every endpoint carries the owning
+// org in the path (`/orgs/:orgId/todos`) and is gated by org
+// membership — a non-member gets 403 (`Forbidden`). The `:id` for
+// update/delete moves to the path (REST-shaped, matching the org
+// module's `/:orgId/members/:userId`).
 export class Group extends HttpApiGroup.make("todos")
   .middleware(UserAuthMiddleware)
-  .add(HttpApiEndpoint.get("get", "/").addSuccess(Schema.Array(Todo)))
-  .add(HttpApiEndpoint.post("create", "/").addSuccess(Todo).setPayload(CreateTodoPayload))
   .add(
-    HttpApiEndpoint.put("update", "/:id")
-      .addError(TodoNotFoundError)
-      .addSuccess(Todo)
-      .setPayload(UpdateTodoPayload),
+    HttpApiEndpoint.get("get", "/:orgId/todos")
+      .setPath(Schema.Struct({ orgId: OrganizationId }))
+      .addError(CustomHttpApiError.Forbidden)
+      .addSuccess(Schema.Array(Todo)),
   )
   .add(
-    HttpApiEndpoint.del("delete", "/:id")
+    HttpApiEndpoint.post("create", "/:orgId/todos")
+      .setPath(Schema.Struct({ orgId: OrganizationId }))
+      .setPayload(CreateTodoPayload)
+      .addError(CustomHttpApiError.Forbidden)
+      .addSuccess(Todo),
+  )
+  .add(
+    HttpApiEndpoint.put("update", "/:orgId/todos/:id")
+      .setPath(Schema.Struct({ orgId: OrganizationId, id: TodoId }))
+      .setPayload(UpdateTodoPayload)
+      .addError(CustomHttpApiError.Forbidden)
       .addError(TodoNotFoundError)
-      .addSuccess(Schema.Void)
-      .setPayload(TodoId),
+      .addSuccess(Todo),
+  )
+  .add(
+    HttpApiEndpoint.del("delete", "/:orgId/todos/:id")
+      .setPath(Schema.Struct({ orgId: OrganizationId, id: TodoId }))
+      .addError(CustomHttpApiError.Forbidden)
+      .addError(TodoNotFoundError)
+      .addSuccess(Schema.Void),
   )
   // Group-wide 503 surface — see UserContract for rationale.
   .addError(CustomHttpApiError.ServiceUnavailable)
-  .prefix("/todos") {}
+  .prefix("/orgs") {}

--- a/packages/database/migrations/V017__alter_todos_add_organization_id.sql
+++ b/packages/database/migrations/V017__alter_todos_add_organization_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "todos"."todos"
+	ADD COLUMN "organization_id" uuid NOT NULL
+	REFERENCES "organization"."organizations"("id") ON DELETE CASCADE;
+
+CREATE INDEX "todos_organization_id_idx" ON "todos"."todos"("organization_id");

--- a/packages/database/src/row-schemas/todos.ts
+++ b/packages/database/src/row-schemas/todos.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 
 export const TodoRow = Schema.Struct({
   id: Schema.UUID,
+  organization_id: Schema.UUID,
   title: Schema.String,
   completed: Schema.Boolean,
   created_at: Schema.DateTimeUtcFromDate,

--- a/packages/server/src/modules/organization/index.ts
+++ b/packages/server/src/modules/organization/index.ts
@@ -42,4 +42,5 @@ export {
   OrganizationResolverEntryLive,
 } from "./policies/organization-resource-resolver.js";
 export { FindAllOrganizationsQuery } from "./queries/find-all-organizations-query.js";
+export { FindMembershipQuery } from "./queries/find-membership-query.js";
 export { FindUserOrganizationRolesQuery } from "./queries/find-user-organization-roles-query.js";

--- a/packages/server/src/modules/organization/index.ts
+++ b/packages/server/src/modules/organization/index.ts
@@ -43,4 +43,5 @@ export {
 } from "./policies/organization-resource-resolver.js";
 export { FindAllOrganizationsQuery } from "./queries/find-all-organizations-query.js";
 export { FindMembershipQuery } from "./queries/find-membership-query.js";
+export { FindMyOrganizationsQuery } from "./queries/find-my-organizations-query.js";
 export { FindUserOrganizationRolesQuery } from "./queries/find-user-organization-roles-query.js";

--- a/packages/server/src/modules/organization/interface/http/find-mine.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/find-mine.endpoint.integration.test.ts
@@ -1,0 +1,60 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("GET /orgs (integration — findMine)", () => {
+  const { run } = useServerTestRuntime(
+    ["organization.memberships", "organization.organizations", "platform.roles", "user.users"],
+    { seedSuperAdminCaller: true },
+  );
+
+  it("returns the caller's organizations, most-recently-created first", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        yield* client.organization.create({ payload: { name: "Acme" } });
+        yield* client.organization.create({ payload: { name: "Beta" } });
+
+        const orgs = yield* client.organization.findMine();
+        deepStrictEqual(
+          orgs.map((o) => o.name),
+          ["Beta", "Acme"],
+        );
+      }),
+    );
+  });
+
+  it("returns empty when the caller has no memberships", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const orgs = yield* client.organization.findMine();
+        deepStrictEqual([...orgs], []);
+      }),
+    );
+  });
+
+  it("hides soft-deleted orgs", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        yield* client.organization.create({ payload: { name: "Acme" } });
+        const { id: betaId } = yield* client.organization.create({ payload: { name: "Beta" } });
+        yield* client.organization.softDelete({ path: { id: betaId } });
+
+        const orgs = yield* client.organization.findMine();
+        deepStrictEqual(
+          orgs.map((o) => o.name),
+          ["Acme"],
+        );
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/organization/interface/http/find-mine.endpoint.ts
+++ b/packages/server/src/modules/organization/interface/http/find-mine.endpoint.ts
@@ -1,0 +1,35 @@
+import { OrganizationContract } from "@org/contracts/api/Contracts";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import {
+  FindMyOrganizationsQuery,
+  type FindMyOrganizationsView,
+} from "@/modules/organization/queries/find-my-organizations-query.js";
+import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+const toContract = (view: FindMyOrganizationsView): OrganizationContract.Organization =>
+  new OrganizationContract.Organization({
+    id: view.id,
+    name: view.name,
+    createdAt: view.createdAt,
+    updatedAt: view.updatedAt,
+    deletedAt: null,
+  });
+
+// Authenticated, no `Authz.hasPermissions` gate — the query filters by
+// `CurrentUser.userId` server-side, so the caller can only see their
+// own memberships. Used by the frontend to resolve "which org am I in"
+// until the route reshape (Phase 8) puts orgId in the URL.
+export const findMineEndpoint = (
+  _request: EndpointRequest<typeof OrganizationContract.Group, "findMine">,
+) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const queryBus = yield* QueryBus;
+    const result = yield* queryBus.execute(
+      FindMyOrganizationsQuery.make({ userId: currentUser.userId }),
+    );
+    return result.organizations.map(toContract);
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("OrganizationLive.findMine"));

--- a/packages/server/src/modules/organization/interface/http/organization-live.ts
+++ b/packages/server/src/modules/organization/interface/http/organization-live.ts
@@ -4,6 +4,7 @@ import { Api } from "@/api.js";
 import { acceptInvitationEndpoint } from "@/modules/organization/interface/http/accept-invitation.endpoint.js";
 import { createEndpoint } from "@/modules/organization/interface/http/create.endpoint.js";
 import { findAllEndpoint } from "@/modules/organization/interface/http/find-all.endpoint.js";
+import { findMineEndpoint } from "@/modules/organization/interface/http/find-mine.endpoint.js";
 import { inviteEndpoint } from "@/modules/organization/interface/http/invite.endpoint.js";
 import { leaveEndpoint } from "@/modules/organization/interface/http/leave.endpoint.js";
 import { removeMemberEndpoint } from "@/modules/organization/interface/http/remove-member.endpoint.js";
@@ -16,6 +17,7 @@ import { softDeleteEndpoint } from "@/modules/organization/interface/http/soft-d
 // (self). All Authz checks live inside the endpoints.
 export const OrganizationLive = HttpApiBuilder.group(Api, "organization", (handlers) =>
   handlers
+    .handle("findMine", findMineEndpoint)
     .handle("create", createEndpoint)
     .handle("softDelete", softDeleteEndpoint)
     .handle("restore", restoreEndpoint)

--- a/packages/server/src/modules/organization/membership-service-live.ts
+++ b/packages/server/src/modules/organization/membership-service-live.ts
@@ -1,24 +1,32 @@
+import { Database } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { MembershipRepository } from "@/modules/organization/domain/ports/repositories/membership-repository.js";
-import { MembershipRepositoryLive } from "@/modules/organization/infrastructure/membership-repository-live.js";
+import { FindMembershipQuery } from "@/modules/organization/queries/find-membership-query.js";
 import { MembershipService } from "@/platform/ddd/ports/membership-service.js";
+import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
 
-// Wraps the org module's own `MembershipRepository` into the generalized
-// `MembershipService` ACL. The Live provides `MembershipRepositoryLive`
-// internally — Effect's Layer memoization shares one instance with the
-// command-handler wraps that also reference it.
+// Surfaces the org module's membership state to policies via the
+// generalized `MembershipService` ACL. Delegates through the query bus
+// (`FindMembershipQuery`) rather than reaching the `MembershipRepository`
+// in-process, so the cross-module membership lookup is an explicit query
+// against the org module — the single source of truth. Same shape as
+// `RoleServiceLive`: the query handler self-wraps its repository, leaving
+// `Database` as the dispatch's residual R, which we capture and provide
+// inline so the `MembershipService` Tag stays R = never for consumers.
 export const MembershipServiceLive = Layer.effect(
   MembershipService,
   Effect.gen(function* () {
-    const repo = yield* MembershipRepository;
+    const queryBus = yield* QueryBus;
+    const db = yield* Database.Database;
+
     return MembershipService.of({
       isMember: (userId, organizationId) =>
-        repo.findByUserIdAndOrgId(userId, organizationId).pipe(
-          Effect.map(() => true),
-          Effect.catchTag("MembershipNotFound", () => Effect.succeed(false)),
+        queryBus.execute(FindMembershipQuery.make({ userId, organizationId })).pipe(
+          Effect.provideService(Database.Database, db),
+          Effect.map((result) => result.isMember),
+          Effect.withSpan("MembershipService.isMember"),
         ),
     });
   }),
-).pipe(Layer.provide(MembershipRepositoryLive));
+);

--- a/packages/server/src/modules/organization/organization-query-handlers.ts
+++ b/packages/server/src/modules/organization/organization-query-handlers.ts
@@ -11,6 +11,8 @@ import {
   findMembershipQuerySpanAttributes,
   type FindMembershipResult,
 } from "@/modules/organization/queries/find-membership-query.js";
+import { findMyOrganizations } from "@/modules/organization/queries/find-my-organizations.js";
+import { findMyOrganizationsQuerySpanAttributes } from "@/modules/organization/queries/find-my-organizations-query.js";
 import { findUserOrganizationRoles } from "@/modules/organization/queries/find-user-organization-roles.js";
 import {
   type FindUserOrganizationRolesQuery,
@@ -54,6 +56,10 @@ export const organizationQueryHandlers = queryHandlers({
   FindAllOrganizationsQuery: {
     handle: findAllOrganizations,
     spanAttributes: findAllOrganizationsQuerySpanAttributes,
+  },
+  FindMyOrganizationsQuery: {
+    handle: findMyOrganizations,
+    spanAttributes: findMyOrganizationsQuerySpanAttributes,
   },
   FindUserOrganizationRolesQuery: {
     handle: (q): FindUserOrganizationRolesBusOutput =>

--- a/packages/server/src/modules/organization/organization-query-handlers.ts
+++ b/packages/server/src/modules/organization/organization-query-handlers.ts
@@ -1,9 +1,16 @@
 import { type Database } from "@org/database/index";
 import * as Effect from "effect/Effect";
 
+import { MembershipRepositoryLive } from "@/modules/organization/infrastructure/membership-repository-live.js";
 import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/organization-roles-repository-live.js";
 import { findAllOrganizations } from "@/modules/organization/queries/find-all-organizations.js";
 import { findAllOrganizationsQuerySpanAttributes } from "@/modules/organization/queries/find-all-organizations-query.js";
+import { findMembership } from "@/modules/organization/queries/find-membership.js";
+import {
+  type FindMembershipQuery,
+  findMembershipQuerySpanAttributes,
+  type FindMembershipResult,
+} from "@/modules/organization/queries/find-membership-query.js";
 import { findUserOrganizationRoles } from "@/modules/organization/queries/find-user-organization-roles.js";
 import {
   type FindUserOrganizationRolesQuery,
@@ -19,20 +26,30 @@ type FindUserOrganizationRolesBusOutput = Effect.Effect<
   Database.Database
 >;
 
+type FindMembershipBusOutput = Effect.Effect<
+  FindMembershipResult,
+  PersistenceUnavailable,
+  Database.Database
+>;
+
 declare module "@/platform/ddd/ports/query-bus.js" {
   interface QueryRegistry {
     FindUserOrganizationRolesQuery: {
       readonly query: FindUserOrganizationRolesQuery;
       readonly output: FindUserOrganizationRolesBusOutput;
     };
+    FindMembershipQuery: {
+      readonly query: FindMembershipQuery;
+      readonly output: FindMembershipBusOutput;
+    };
   }
 }
 
 // `FindAllOrganizationsQuery` reads SQL directly (no repository in R)
 // so the handler doesn't need wrapping. `FindUserOrganizationRolesQuery`
-// goes through the `OrganizationRolesRepository` and is wrapped with
-// `OrganizationRolesRepositoryLive` to discharge that dep before the
-// bus dispatch.
+// and `FindMembershipQuery` go through their repositories and are
+// wrapped with the corresponding `*RepositoryLive` to discharge that
+// dep before the bus dispatch.
 export const organizationQueryHandlers = queryHandlers({
   FindAllOrganizationsQuery: {
     handle: findAllOrganizations,
@@ -42,5 +59,10 @@ export const organizationQueryHandlers = queryHandlers({
     handle: (q): FindUserOrganizationRolesBusOutput =>
       findUserOrganizationRoles(q).pipe(Effect.provide(OrganizationRolesRepositoryLive)),
     spanAttributes: findUserOrganizationRolesQuerySpanAttributes,
+  },
+  FindMembershipQuery: {
+    handle: (q): FindMembershipBusOutput =>
+      findMembership(q).pipe(Effect.provide(MembershipRepositoryLive)),
+    spanAttributes: findMembershipQuerySpanAttributes,
   },
 });

--- a/packages/server/src/modules/organization/policies/is-member.ts
+++ b/packages/server/src/modules/organization/policies/is-member.ts
@@ -1,24 +1,11 @@
-import * as Effect from "effect/Effect";
-
+import { makeIsOrgMember } from "@/platform/auth/policies/is-org-member.js";
 import type * as PolicyRegistry from "@/platform/auth/policy-registry.js";
-import { MembershipService } from "@/platform/ddd/ports/membership-service.js";
 
-// Per-org "is this caller a member?" check. Consumes the platform-layer
-// `MembershipService` ACL (never the org module's `MembershipRepository`
-// directly) so the dep graph stays acyclic and the consuming-policy
-// surface depends only on the generalized boolean shape.
-//
-// Typed via `PolicyRegistry.CheckFor<"organization", "update">` so the
-// R channel resolves to the full `PolicyDeps` set — that lets
-// `Authz.any(SuperAdminOnly, IsMember)` type-check uniformly even
-// though the two halves use different deps (RoleService vs
-// MembershipService). Same pattern as user-module's `IsSelf`.
-//
-// Composed via `Authz.any(SuperAdminOnly, IsMember)` so super-admins
-// bypass the membership lookup entirely (short-circuit on the first
-// `true`).
-export const IsMember: PolicyRegistry.CheckFor<"organization", "update"> = (caller, organization) =>
-  Effect.gen(function* () {
-    const memberships = yield* MembershipService;
-    return yield* memberships.isMember(caller.userId, organization.id);
-  });
+// "Is this caller a member of the org?" — the `organization` resource
+// resolves to the Organization aggregate, so the org id is `.id`. All
+// the lookup logic lives in the shared `makeIsOrgMember` factory
+// (platform), over the `MembershipService` ACL. Composed via
+// `Authz.any(SuperAdminOnly, IsMember)` so super-admins bypass.
+export const IsMember: PolicyRegistry.CheckFor<"organization", "update"> = makeIsOrgMember(
+  (organization) => organization.id,
+);

--- a/packages/server/src/modules/organization/queries/find-membership-query.ts
+++ b/packages/server/src/modules/organization/queries/find-membership-query.ts
@@ -1,0 +1,36 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type MembershipRepository } from "@/modules/organization/domain/ports/repositories/membership-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Read-side "is this user a member of this org?" projection. Backs the
+// platform-layer `MembershipService` ACL: `MembershipServiceLive`
+// dispatches this query through the bus so the membership determination
+// is an explicit cross-module query against the org module (the single
+// source of truth), not an in-process repo reach.
+export const FindMembershipQuery = Schema.TaggedStruct("FindMembershipQuery", {
+  userId: UserId,
+  organizationId: OrganizationId,
+});
+export type FindMembershipQuery = typeof FindMembershipQuery.Type;
+
+export type FindMembershipResult = {
+  readonly isMember: boolean;
+};
+
+export const findMembershipQuerySpanAttributes: SpanAttributesExtractor<FindMembershipQuery> = (
+  query,
+) => ({ "query.userId": query.userId, "query.organizationId": query.organizationId });
+
+// Raw handler effect — `MembershipRepository` is discharged by the wrap
+// in `organization-query-handlers.ts`; the bus-registered output type
+// lives there.
+export type FindMembershipOutput = Effect.Effect<
+  FindMembershipResult,
+  PersistenceUnavailable,
+  MembershipRepository
+>;

--- a/packages/server/src/modules/organization/queries/find-membership.test.ts
+++ b/packages/server/src/modules/organization/queries/find-membership.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import * as Membership from "@/modules/organization/domain/membership.aggregate.js";
+import { MembershipRepository } from "@/modules/organization/domain/ports/repositories/membership-repository.js";
+import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/membership-repository-fake.js";
+import { findMembership } from "@/modules/organization/queries/find-membership.js";
+import { FindMembershipQuery } from "@/modules/organization/queries/find-membership-query.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+
+describe("findMembership", () => {
+  it.effect("returns isMember=false when no membership row exists", () =>
+    Effect.gen(function* () {
+      const result = yield* findMembership(
+        FindMembershipQuery.make({ userId, organizationId: orgId }),
+      );
+      deepStrictEqual(result.isMember, false);
+    }).pipe(Effect.provide(MembershipRepositoryFake)),
+  );
+
+  it.effect("returns isMember=true once the membership exists", () =>
+    Effect.gen(function* () {
+      const repo = yield* MembershipRepository;
+      const { membership } = Membership.create({ userId, organizationId: orgId, now });
+      yield* repo.insert(membership);
+      const result = yield* findMembership(
+        FindMembershipQuery.make({ userId, organizationId: orgId }),
+      );
+      deepStrictEqual(result.isMember, true);
+    }).pipe(Effect.provide(MembershipRepositoryFake)),
+  );
+});

--- a/packages/server/src/modules/organization/queries/find-membership.ts
+++ b/packages/server/src/modules/organization/queries/find-membership.ts
@@ -1,0 +1,19 @@
+import * as Effect from "effect/Effect";
+
+import { MembershipRepository } from "@/modules/organization/domain/ports/repositories/membership-repository.js";
+import {
+  type FindMembershipOutput,
+  type FindMembershipQuery,
+} from "@/modules/organization/queries/find-membership-query.js";
+
+// Goes through the repository so the org module stays the single source
+// of truth for membership. Absence (`MembershipNotFound`) is the normal
+// "not a member" answer, mapped to `false` — not an error.
+export const findMembership = (query: FindMembershipQuery): FindMembershipOutput =>
+  Effect.gen(function* () {
+    const repo = yield* MembershipRepository;
+    return yield* repo.findByUserIdAndOrgId(query.userId, query.organizationId).pipe(
+      Effect.map(() => ({ isMember: true })),
+      Effect.catchTag("MembershipNotFound", () => Effect.succeed({ isMember: false })),
+    );
+  });

--- a/packages/server/src/modules/organization/queries/find-my-organizations-query.ts
+++ b/packages/server/src/modules/organization/queries/find-my-organizations-query.ts
@@ -1,0 +1,52 @@
+import { type Database } from "@org/database/index";
+import type * as DateTime from "effect/DateTime";
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Lists the organizations the caller is a member of. Used by the
+// frontend to resolve "which org am I working in" without needing to
+// pass an orgId on every URL until the route reshape lands.
+//
+// Tombstoned orgs are filtered out — a soft-deleted org should not
+// appear in the caller's chooser.
+export const FindMyOrganizationsQuery = Schema.TaggedStruct("FindMyOrganizationsQuery", {
+  userId: UserId,
+});
+export type FindMyOrganizationsQuery = typeof FindMyOrganizationsQuery.Type;
+
+export const findMyOrganizationsQuerySpanAttributes: SpanAttributesExtractor<
+  FindMyOrganizationsQuery
+> = (query) => ({
+  "query.userId": query.userId,
+});
+
+export type FindMyOrganizationsView = {
+  readonly id: OrganizationId;
+  readonly name: string;
+  readonly createdAt: DateTime.Utc;
+  readonly updatedAt: DateTime.Utc;
+};
+
+export type FindMyOrganizationsResult = {
+  readonly organizations: ReadonlyArray<FindMyOrganizationsView>;
+};
+
+export type FindMyOrganizationsOutput = Effect.Effect<
+  FindMyOrganizationsResult,
+  PersistenceUnavailable,
+  Database.Database
+>;
+
+declare module "@/platform/ddd/ports/query-bus.js" {
+  interface QueryRegistry {
+    FindMyOrganizationsQuery: {
+      readonly query: FindMyOrganizationsQuery;
+      readonly output: FindMyOrganizationsOutput;
+    };
+  }
+}

--- a/packages/server/src/modules/organization/queries/find-my-organizations.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-my-organizations.integration.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "@effect/vitest";
+import { Database, sql } from "@org/database/index";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { beforeEach } from "vitest";
+
+import * as Membership from "@/modules/organization/domain/membership.aggregate.js";
+import * as Organization from "@/modules/organization/domain/organization.aggregate.js";
+import { MembershipRepository } from "@/modules/organization/domain/ports/repositories/membership-repository.js";
+import { OrganizationRepository } from "@/modules/organization/domain/ports/repositories/organization-repository.js";
+import { MembershipRepositoryLive } from "@/modules/organization/infrastructure/membership-repository-live.js";
+import { OrganizationRepositoryLive } from "@/modules/organization/infrastructure/organization-repository-live.js";
+import { findMyOrganizations } from "@/modules/organization/queries/find-my-organizations.js";
+import { FindMyOrganizationsQuery } from "@/modules/organization/queries/find-my-organizations-query.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+
+const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
+const bobId = UserId.make("22222222-2222-2222-2222-222222222222");
+const acmeId = OrganizationId.make("33333333-3333-3333-3333-333333333333");
+const betaId = OrganizationId.make("44444444-4444-4444-4444-444444444444");
+const now = DateTime.unsafeMake(new Date("2026-01-01T00:00:00Z"));
+
+const TestLayer = Layer.mergeAll(OrganizationRepositoryLive, MembershipRepositoryLive).pipe(
+  Layer.provideMerge(TestDatabaseLive),
+);
+
+const seedUsers = Effect.gen(function* () {
+  const db = yield* Database.Database;
+  yield* db
+    .execute((client) =>
+      client.query(sql.unsafe`
+        INSERT INTO "user".users (id, email, country, street, postal_code, created_at, updated_at)
+        VALUES (${aliceId}, 'alice@example.com', 'USA', '123 Main St', '12345', now(), now()),
+               (${bobId}, 'bob@example.com', 'USA', '456 Main St', '12345', now(), now())
+      `),
+    )
+    .pipe(Effect.orDie);
+});
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("findMyOrganizations (integration)", () => {
+  beforeEach(async () => {
+    await Effect.runPromise(
+      truncate("organization.memberships", "organization.organizations", "user.users").pipe(
+        Effect.provide(TestDatabaseLive),
+      ),
+    );
+  });
+
+  it.effect("returns only orgs the caller is a member of", () =>
+    Effect.gen(function* () {
+      yield* seedUsers;
+      const orgs = yield* OrganizationRepository;
+      const memberships = yield* MembershipRepository;
+      yield* orgs.insert(Organization.create({ id: acmeId, name: "Acme", now }).organization);
+      yield* orgs.insert(Organization.create({ id: betaId, name: "Beta", now }).organization);
+      yield* memberships.insert(
+        Membership.create({ userId: aliceId, organizationId: acmeId, now }).membership,
+      );
+      // Bob is a member of Beta, not Acme — must not leak into Alice's view.
+      yield* memberships.insert(
+        Membership.create({ userId: bobId, organizationId: betaId, now }).membership,
+      );
+
+      const result = yield* findMyOrganizations(FindMyOrganizationsQuery.make({ userId: aliceId }));
+      deepStrictEqual(
+        result.organizations.map((o) => o.name),
+        ["Acme"],
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("returns an empty list when the caller has no memberships", () =>
+    Effect.gen(function* () {
+      yield* seedUsers;
+      const result = yield* findMyOrganizations(FindMyOrganizationsQuery.make({ userId: aliceId }));
+      deepStrictEqual([...result.organizations], []);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("hides soft-deleted orgs", () =>
+    Effect.gen(function* () {
+      yield* seedUsers;
+      const orgs = yield* OrganizationRepository;
+      const memberships = yield* MembershipRepository;
+      const { organization: acme } = Organization.create({ id: acmeId, name: "Acme", now });
+      yield* orgs.insert(acme);
+      yield* memberships.insert(
+        Membership.create({ userId: aliceId, organizationId: acmeId, now }).membership,
+      );
+      const deleted = Organization.softDelete(acme, { now });
+      if (deleted._tag !== "Right") throw new Error("expected Right");
+      yield* orgs.update(deleted.right.organization);
+
+      const result = yield* findMyOrganizations(FindMyOrganizationsQuery.make({ userId: aliceId }));
+      deepStrictEqual([...result.organizations], []);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/organization/queries/find-my-organizations.ts
+++ b/packages/server/src/modules/organization/queries/find-my-organizations.ts
@@ -1,0 +1,45 @@
+import { Database, RowSchemas, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+
+import {
+  type FindMyOrganizationsOutput,
+  type FindMyOrganizationsQuery,
+  type FindMyOrganizationsView,
+} from "@/modules/organization/queries/find-my-organizations-query.js";
+import { PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+
+const toView = (row: RowSchemas.OrganizationRow): FindMyOrganizationsView => ({
+  id: OrganizationId.make(row.id),
+  name: row.name,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+// Both tables live in the `organization` schema, so the join is
+// intra-schema (allowed by ADR-0021's `no-cross-schema-slonik-access`
+// rule). Tombstoned orgs are filtered out — a soft-deleted org should
+// not appear in the caller's chooser.
+export const findMyOrganizations = (query: FindMyOrganizationsQuery): FindMyOrganizationsOutput =>
+  Effect.gen(function* () {
+    const db = yield* Database.Database;
+    const rows = yield* db
+      .execute((client) =>
+        client.any(sql.type(RowSchemas.OrganizationRowStd)`
+          SELECT o.*
+          FROM "organization".memberships m
+          JOIN "organization".organizations o ON o.id = m.organization_id
+          WHERE m.user_id = ${query.userId}
+            AND o.deleted_at IS NULL
+          ORDER BY o.created_at DESC
+        `),
+      )
+      .pipe(
+        Effect.catchTag("DatabaseError", Effect.die),
+        Effect.catchTag("DatabaseUnavailable", (e) =>
+          Effect.fail(new PersistenceUnavailable({ message: e.message })),
+        ),
+      );
+
+    return { organizations: rows.map(toView) };
+  });

--- a/packages/server/src/modules/todos/commands/create-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/create-todo-command.ts
@@ -5,10 +5,12 @@ import { type TodosRepository } from "@/modules/todos/domain/ports/repositories/
 import { type Todo } from "@/modules/todos/domain/todo.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 export const CreateTodoCommand = Schema.TaggedStruct("CreateTodoCommand", {
   title: Schema.String,
+  organizationId: OrganizationId,
   userId: UserId,
 });
 export type CreateTodoCommand = typeof CreateTodoCommand.Type;
@@ -17,7 +19,7 @@ export type CreateTodoCommand = typeof CreateTodoCommand.Type;
 // annotated from inside the handler instead.
 export const createTodoCommandSpanAttributes: SpanAttributesExtractor<CreateTodoCommand> = (
   cmd,
-) => ({ "user.id": cmd.userId });
+) => ({ "user.id": cmd.userId, "organization.id": cmd.organizationId });
 
 // Raw handler effect — `TodosRepository` is discharged by the wrap in
 // `todo-command-handlers.ts`; the bus-registered output type lives there.

--- a/packages/server/src/modules/todos/commands/create-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.test.ts
@@ -4,31 +4,38 @@ import * as Effect from "effect/Effect";
 
 import { TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-repository.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { createTodo } from "./create-todo.js";
 import { CreateTodoCommand } from "./create-todo-command.js";
 
 const aliceUserId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 
 describe("createTodo", () => {
-  it.effect("inserts a todo with completed=false and returns it", () =>
+  it.effect("inserts a todo scoped to the org with completed=false and returns it", () =>
     Effect.gen(function* () {
       const repo = yield* TodosRepository;
       const todo = yield* createTodo(
-        CreateTodoCommand.make({ title: "Buy milk", userId: aliceUserId }),
+        CreateTodoCommand.make({ title: "Buy milk", organizationId: orgId, userId: aliceUserId }),
       );
       deepStrictEqual(todo.title, "Buy milk");
       deepStrictEqual(todo.completed, false);
-      const stored = yield* repo.findById(todo.id);
+      deepStrictEqual(todo.organizationId, orgId);
+      const stored = yield* repo.findById(orgId, todo.id);
       deepStrictEqual(stored.title, "Buy milk");
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );
 
   it.effect("each call gets a unique id", () =>
     Effect.gen(function* () {
-      const a = yield* createTodo(CreateTodoCommand.make({ title: "A", userId: aliceUserId }));
-      const b = yield* createTodo(CreateTodoCommand.make({ title: "B", userId: aliceUserId }));
+      const a = yield* createTodo(
+        CreateTodoCommand.make({ title: "A", organizationId: orgId, userId: aliceUserId }),
+      );
+      const b = yield* createTodo(
+        CreateTodoCommand.make({ title: "B", organizationId: orgId, userId: aliceUserId }),
+      );
       deepStrictEqual(a.id === b.id, false);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/create-todo.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.ts
@@ -15,7 +15,12 @@ export const createTodo = (cmd: CreateTodoCommand): CreateTodoOutput =>
     const id = TodoId.make(yield* Effect.sync(() => crypto.randomUUID()));
     yield* Effect.annotateCurrentSpan("todo.id", id);
     const now = yield* DateTime.now;
-    const todo = Todo.create({ id, title: cmd.title, now });
+    const todo = Todo.create({
+      id,
+      organizationId: cmd.organizationId,
+      title: cmd.title,
+      now,
+    });
     yield* repo.insert(todo);
     return todo;
   });

--- a/packages/server/src/modules/todos/commands/delete-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo-command.ts
@@ -6,17 +6,19 @@ import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 export const DeleteTodoCommand = Schema.TaggedStruct("DeleteTodoCommand", {
   todoId: TodoId,
+  organizationId: OrganizationId,
   userId: UserId,
 });
 export type DeleteTodoCommand = typeof DeleteTodoCommand.Type;
 
 export const deleteTodoCommandSpanAttributes: SpanAttributesExtractor<DeleteTodoCommand> = (
   cmd,
-) => ({ "todo.id": cmd.todoId, "user.id": cmd.userId });
+) => ({ "todo.id": cmd.todoId, "organization.id": cmd.organizationId, "user.id": cmd.userId });
 
 // Raw handler effect — `TodosRepository` is discharged by the wrap in
 // `todo-command-handlers.ts`; the bus-registered output type lives there.

--- a/packages/server/src/modules/todos/commands/delete-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.test.ts
@@ -9,6 +9,7 @@ import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { deleteTodo } from "./delete-todo.js";
@@ -16,15 +17,21 @@ import { DeleteTodoCommand } from "./delete-todo-command.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const aliceUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const otherOrgId = OrganizationId.make("33333333-3333-3333-3333-333333333333");
 const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 
 describe("deleteTodo", () => {
   it.effect("removes the todo from the repository", () =>
     Effect.gen(function* () {
       const repo = yield* TodosRepository;
-      yield* repo.insert(Todo.create({ id: aliceId, title: "Buy milk", now }));
-      yield* deleteTodo(DeleteTodoCommand.make({ todoId: aliceId, userId: aliceUserId }));
-      const exit = yield* Effect.exit(repo.findById(aliceId));
+      yield* repo.insert(
+        Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now }),
+      );
+      yield* deleteTodo(
+        DeleteTodoCommand.make({ todoId: aliceId, organizationId: orgId, userId: aliceUserId }),
+      );
+      const exit = yield* Effect.exit(repo.findById(orgId, aliceId));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );
@@ -32,13 +39,41 @@ describe("deleteTodo", () => {
   it.effect("fails TodoNotFound when the todo doesn't exist", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
-        deleteTodo(DeleteTodoCommand.make({ todoId: aliceId, userId: aliceUserId })),
+        deleteTodo(
+          DeleteTodoCommand.make({ todoId: aliceId, organizationId: orgId, userId: aliceUserId }),
+        ),
       );
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
         deepStrictEqual(error instanceof TodoNotFound, true);
       }
+    }).pipe(Effect.provide(TodosRepositoryFake)),
+  );
+
+  it.effect("fails TodoNotFound when the todo belongs to a different org (tenant isolation)", () =>
+    Effect.gen(function* () {
+      const repo = yield* TodosRepository;
+      yield* repo.insert(
+        Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now }),
+      );
+      const exit = yield* Effect.exit(
+        deleteTodo(
+          DeleteTodoCommand.make({
+            todoId: aliceId,
+            organizationId: otherOrgId,
+            userId: aliceUserId,
+          }),
+        ),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof TodoNotFound, true);
+      }
+      // The original (correct-org) row is untouched.
+      const stillThere = yield* repo.findById(orgId, aliceId);
+      deepStrictEqual(stillThere.id, aliceId);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );
 });

--- a/packages/server/src/modules/todos/commands/delete-todo.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.ts
@@ -9,5 +9,5 @@ import { TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-
 export const deleteTodo = (cmd: DeleteTodoCommand): DeleteTodoOutput =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    yield* repo.remove(cmd.todoId);
+    yield* repo.remove(cmd.organizationId, cmd.todoId);
   });

--- a/packages/server/src/modules/todos/commands/update-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/update-todo-command.ts
@@ -7,10 +7,12 @@ import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 export const UpdateTodoCommand = Schema.TaggedStruct("UpdateTodoCommand", {
   todoId: TodoId,
+  organizationId: OrganizationId,
   title: Schema.String,
   completed: Schema.Boolean,
   userId: UserId,
@@ -19,7 +21,12 @@ export type UpdateTodoCommand = typeof UpdateTodoCommand.Type;
 
 export const updateTodoCommandSpanAttributes: SpanAttributesExtractor<UpdateTodoCommand> = (
   cmd,
-) => ({ "todo.id": cmd.todoId, "todo.completed": cmd.completed, "user.id": cmd.userId });
+) => ({
+  "todo.id": cmd.todoId,
+  "organization.id": cmd.organizationId,
+  "todo.completed": cmd.completed,
+  "user.id": cmd.userId,
+});
 
 // Raw handler effect — `TodosRepository` is discharged by the wrap in
 // `todo-command-handlers.ts`; the bus-registered output type lives there.

--- a/packages/server/src/modules/todos/commands/update-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.test.ts
@@ -9,6 +9,7 @@ import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { updateTodo } from "./update-todo.js";
@@ -16,11 +17,13 @@ import { UpdateTodoCommand } from "./update-todo-command.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const aliceUserId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const otherOrgId = OrganizationId.make("33333333-3333-3333-3333-333333333333");
 const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 
 const seed = Effect.gen(function* () {
   const repo = yield* TodosRepository;
-  const todo = Todo.create({ id: aliceId, title: "Buy milk", now });
+  const todo = Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now });
   yield* repo.insert(todo);
 });
 
@@ -31,6 +34,7 @@ describe("updateTodo", () => {
       const updated = yield* updateTodo(
         UpdateTodoCommand.make({
           todoId: aliceId,
+          organizationId: orgId,
           title: "Buy oat milk",
           completed: true,
           userId: aliceUserId,
@@ -40,7 +44,7 @@ describe("updateTodo", () => {
       deepStrictEqual(updated.completed, true);
 
       const repo = yield* TodosRepository;
-      const stored = yield* repo.findById(aliceId);
+      const stored = yield* repo.findById(orgId, aliceId);
       deepStrictEqual(stored.title, "Buy oat milk");
       deepStrictEqual(stored.completed, true);
     }).pipe(Effect.provide(TodosRepositoryFake)),
@@ -52,6 +56,29 @@ describe("updateTodo", () => {
         updateTodo(
           UpdateTodoCommand.make({
             todoId: aliceId,
+            organizationId: orgId,
+            title: "x",
+            completed: false,
+            userId: aliceUserId,
+          }),
+        ),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof TodoNotFound, true);
+      }
+    }).pipe(Effect.provide(TodosRepositoryFake)),
+  );
+
+  it.effect("fails TodoNotFound when the todo belongs to a different org (tenant isolation)", () =>
+    Effect.gen(function* () {
+      yield* seed;
+      const exit = yield* Effect.exit(
+        updateTodo(
+          UpdateTodoCommand.make({
+            todoId: aliceId,
+            organizationId: otherOrgId,
             title: "x",
             completed: false,
             userId: aliceUserId,

--- a/packages/server/src/modules/todos/commands/update-todo.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.ts
@@ -11,7 +11,7 @@ import * as Todo from "@/modules/todos/domain/todo.js";
 export const updateTodo = (cmd: UpdateTodoCommand): UpdateTodoOutput =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    const existing = yield* repo.findById(cmd.todoId);
+    const existing = yield* repo.findById(cmd.organizationId, cmd.todoId);
     const now = yield* DateTime.now;
     const updated = Todo.update(existing, {
       title: cmd.title,

--- a/packages/server/src/modules/todos/domain/ports/repositories/todo-repository.ts
+++ b/packages/server/src/modules/todos/domain/ports/repositories/todo-repository.ts
@@ -5,12 +5,24 @@ import { type Todo } from "@/modules/todos/domain/todo.js";
 import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { type TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
+// Every read/mutate is org-scoped (Phase 5). `findById` and `remove`
+// take the `organizationId` explicitly so a caller can't reach a todo
+// outside the org in the request path — a row in another org reads as
+// `TodoNotFound`, not a leak. `insert`/`update` carry the org on the
+// `Todo` itself; `update`'s SQL filters on it too.
 export type TodosRepositoryShape = {
   readonly insert: (todo: Todo) => Effect.Effect<void, PersistenceUnavailable>;
   readonly update: (todo: Todo) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
-  readonly remove: (id: TodoId) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
-  readonly findById: (id: TodoId) => Effect.Effect<Todo, TodoNotFound | PersistenceUnavailable>;
+  readonly remove: (
+    organizationId: OrganizationId,
+    id: TodoId,
+  ) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
+  readonly findById: (
+    organizationId: OrganizationId,
+    id: TodoId,
+  ) => Effect.Effect<Todo, TodoNotFound | PersistenceUnavailable>;
 };
 
 export class TodosRepository extends Context.Tag("TodosRepository")<

--- a/packages/server/src/modules/todos/domain/todo.ts
+++ b/packages/server/src/modules/todos/domain/todo.ts
@@ -1,10 +1,16 @@
 import type * as DateTime from "effect/DateTime";
 import * as Schema from "effect/Schema";
 
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+
 import { TodoId } from "./todo-id.js";
 
 export class Todo extends Schema.Class<Todo>("Todo")({
   id: TodoId,
+  // Owning organization. Every todo is scoped to exactly one org
+  // (Phase 5 multi-tenancy); the repository requires it on every
+  // read/mutate so cross-tenant access can't leak.
+  organizationId: OrganizationId,
   title: Schema.String,
   completed: Schema.Boolean,
   createdAt: Schema.DateTimeUtc,
@@ -13,6 +19,7 @@ export class Todo extends Schema.Class<Todo>("Todo")({
 
 export type CreateInput = {
   readonly id: TodoId;
+  readonly organizationId: OrganizationId;
   readonly title: string;
   readonly now: DateTime.Utc;
 };
@@ -20,6 +27,7 @@ export type CreateInput = {
 export const create = (input: CreateInput): Todo =>
   Todo.make({
     id: input.id,
+    organizationId: input.organizationId,
     title: input.title,
     completed: false,
     createdAt: input.now,
@@ -35,6 +43,7 @@ export type UpdateInput = {
 export const update = (todo: Todo, input: UpdateInput): Todo =>
   Todo.make({
     id: todo.id,
+    organizationId: todo.organizationId,
     title: input.title,
     completed: input.completed,
     createdAt: todo.createdAt,

--- a/packages/server/src/modules/todos/index.ts
+++ b/packages/server/src/modules/todos/index.ts
@@ -1,6 +1,13 @@
 export { CreateTodoCommand } from "./commands/create-todo-command.js";
 export { DeleteTodoCommand } from "./commands/delete-todo-command.js";
 export { UpdateTodoCommand } from "./commands/update-todo-command.js";
+export {
+  TodoCollectionResolverEntry,
+  TodoCollectionResolverEntryLive,
+  TodoResolverEntry,
+  TodoResolverEntryLive,
+} from "./policies/todo-resource-resolvers.js";
+export { TodoCollectionResource, TodoResource, todosPolicies } from "./policies/todos-policies.js";
 export { ListTodosQuery } from "./queries/list-todos-query.js";
 export { todoCommandHandlers } from "./todo-command-handlers.js";
 export { todoQueryHandlers } from "./todo-query-handlers.js";

--- a/packages/server/src/modules/todos/infrastructure/todo-mapper.ts
+++ b/packages/server/src/modules/todos/infrastructure/todo-mapper.ts
@@ -1,6 +1,8 @@
 import { type RowSchemas } from "@org/database/index";
 import * as DateTime from "effect/DateTime";
 
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+
 import { Todo } from "../domain/todo.js";
 import { TodoId } from "../domain/todo-id.js";
 
@@ -9,6 +11,7 @@ type Row = RowSchemas.TodoRow;
 export const toDomain = (row: Row): Todo =>
   new Todo({
     id: TodoId.make(row.id),
+    organizationId: OrganizationId.make(row.organization_id),
     title: row.title,
     completed: row.completed,
     createdAt: row.created_at,
@@ -17,6 +20,7 @@ export const toDomain = (row: Row): Todo =>
 
 export type PersistenceRow = {
   readonly id: string;
+  readonly organization_id: string;
   readonly title: string;
   readonly completed: boolean;
   readonly created_at: Date;
@@ -25,6 +29,7 @@ export type PersistenceRow = {
 
 export const toPersistence = (todo: Todo): PersistenceRow => ({
   id: todo.id,
+  organization_id: todo.organizationId,
   title: todo.title,
   completed: todo.completed,
   created_at: DateTime.toDate(todo.createdAt),

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 
 import { TodosRepository } from "../domain/ports/repositories/todo-repository.js";
 import * as Todo from "../domain/todo.js";
@@ -13,21 +14,24 @@ import { TodosRepositoryFake } from "./todos-repository-fake.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");
+const orgId = OrganizationId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const otherOrgId = OrganizationId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 const later = DateTime.unsafeMake(new Date("2025-02-01T00:00:00Z"));
 
-const buyMilk = Todo.create({ id: aliceId, title: "Buy milk", now });
+const buyMilk = Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now });
 
 const provide = Effect.provide(TodosRepositoryFake);
 
 describe("TodosRepositoryFake", () => {
   describe("insert", () => {
-    it.effect("stores the todo and makes it findable by id", () =>
+    it.effect("stores the todo and makes it findable by (org, id)", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
         yield* repo.insert(buyMilk);
-        const found = yield* repo.findById(buyMilk.id);
+        const found = yield* repo.findById(orgId, buyMilk.id);
         deepStrictEqual(found.id, buyMilk.id);
+        deepStrictEqual(found.organizationId, orgId);
         deepStrictEqual(found.title, buyMilk.title);
         deepStrictEqual(found.completed, false);
       }).pipe(provide),
@@ -38,7 +42,20 @@ describe("TodosRepositoryFake", () => {
     it.effect("fails TodoNotFound for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.findById(bobId));
+        const exit = yield* Effect.exit(repo.findById(orgId, bobId));
+        deepStrictEqual(Exit.isFailure(exit), true);
+        if (Exit.isFailure(exit)) {
+          const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+          deepStrictEqual(error instanceof TodoNotFound, true);
+        }
+      }).pipe(provide),
+    );
+
+    it.effect("fails TodoNotFound when the id exists but in another org (isolation)", () =>
+      Effect.gen(function* () {
+        const repo = yield* TodosRepository;
+        yield* repo.insert(buyMilk);
+        const exit = yield* Effect.exit(repo.findById(otherOrgId, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -59,7 +76,7 @@ describe("TodosRepositoryFake", () => {
           now: later,
         });
         yield* repo.update(completed);
-        const found = yield* repo.findById(buyMilk.id);
+        const found = yield* repo.findById(orgId, buyMilk.id);
         deepStrictEqual(found.completed, true);
         deepStrictEqual(found.updatedAt, later);
       }).pipe(provide),
@@ -83,8 +100,8 @@ describe("TodosRepositoryFake", () => {
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
         yield* repo.insert(buyMilk);
-        yield* repo.remove(buyMilk.id);
-        const exit = yield* Effect.exit(repo.findById(buyMilk.id));
+        yield* repo.remove(orgId, buyMilk.id);
+        const exit = yield* Effect.exit(repo.findById(orgId, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
       }).pipe(provide),
     );
@@ -92,12 +109,24 @@ describe("TodosRepositoryFake", () => {
     it.effect("fails TodoNotFound when the todo isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.remove(bobId));
+        const exit = yield* Effect.exit(repo.remove(orgId, bobId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
           deepStrictEqual(error instanceof TodoNotFound, true);
         }
+      }).pipe(provide),
+    );
+
+    it.effect("fails TodoNotFound when removing from the wrong org (isolation)", () =>
+      Effect.gen(function* () {
+        const repo = yield* TodosRepository;
+        yield* repo.insert(buyMilk);
+        const exit = yield* Effect.exit(repo.remove(otherOrgId, buyMilk.id));
+        deepStrictEqual(Exit.isFailure(exit), true);
+        // Row still present under its real org.
+        const found = yield* repo.findById(orgId, buyMilk.id);
+        deepStrictEqual(found.id, buyMilk.id);
       }).pipe(provide),
     );
   });

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
@@ -4,11 +4,17 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
 import { TodosRepository } from "../domain/ports/repositories/todo-repository.js";
 import { type Todo } from "../domain/todo.js";
 import { TodoNotFound } from "../domain/todo-errors.js";
 import { type TodoId } from "../domain/todo-id.js";
 
+// Keyed by TodoId; org scoping is enforced by guarding on the stored
+// todo's organizationId — a read/mutate for the wrong org behaves like
+// a missing row (TodoNotFound), mirroring the live repo's
+// `WHERE id AND organization_id` filter.
 export const TodosRepositoryFake = Layer.effect(
   TodosRepository,
   Effect.gen(function* () {
@@ -18,24 +24,35 @@ export const TodosRepositoryFake = Layer.effect(
       Ref.update(store, HashMap.set(todo.id, todo));
 
     const update = (todo: Todo): Effect.Effect<void, TodoNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        HashMap.has(m, todo.id)
+      Effect.flatMap(Ref.get(store), (m) => {
+        const found = HashMap.get(m, todo.id);
+        return found._tag === "Some" && found.value.organizationId === todo.organizationId
           ? Ref.update(store, HashMap.set(todo.id, todo))
-          : Effect.fail(new TodoNotFound({ todoId: todo.id })),
-      );
+          : Effect.fail(new TodoNotFound({ todoId: todo.id }));
+      });
 
-    const remove = (id: TodoId): Effect.Effect<void, TodoNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        HashMap.has(m, id)
+    const remove = (
+      organizationId: OrganizationId,
+      id: TodoId,
+    ): Effect.Effect<void, TodoNotFound> =>
+      Effect.flatMap(Ref.get(store), (m) => {
+        const found = HashMap.get(m, id);
+        return found._tag === "Some" && found.value.organizationId === organizationId
           ? Ref.update(store, HashMap.remove(id))
-          : Effect.fail(new TodoNotFound({ todoId: id })),
-      );
+          : Effect.fail(new TodoNotFound({ todoId: id }));
+      });
 
-    const findById = (id: TodoId): Effect.Effect<Todo, TodoNotFound> =>
+    const findById = (
+      organizationId: OrganizationId,
+      id: TodoId,
+    ): Effect.Effect<Todo, TodoNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         Option.match(HashMap.get(m, id), {
           onNone: () => Effect.fail(new TodoNotFound({ todoId: id })),
-          onSome: Effect.succeed,
+          onSome: (todo) =>
+            todo.organizationId === organizationId
+              ? Effect.succeed(todo)
+              : Effect.fail(new TodoNotFound({ todoId: id })),
         }),
       );
 

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest";
-import { Database } from "@org/database/index";
+import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -12,14 +12,37 @@ import * as Todo from "@/modules/todos/domain/todo.js";
 import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
 import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");
+const orgA = OrganizationId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const orgB = OrganizationId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 const later = DateTime.unsafeMake(new Date("2025-02-01T00:00:00Z"));
 
-const buyMilk = Todo.create({ id: aliceId, title: "Buy milk", now });
+const buyMilk = Todo.create({ id: aliceId, organizationId: orgA, title: "Buy milk", now });
+
+// todos.todos.organization_id FKs to organization.organizations(id);
+// seed both orgs via raw SQL since the todos repo can't (and shouldn't)
+// reach the org module's internals.
+const seedOrgs = Effect.gen(function* () {
+  const db = yield* Database.Database;
+  for (const [id, name] of [
+    [orgA, "Acme"],
+    [orgB, "Beta"],
+  ] as const) {
+    yield* db
+      .execute((client) =>
+        client.query(sql.unsafe`
+          INSERT INTO "organization".organizations (id, name, created_at, updated_at, deleted_at)
+          VALUES (${id}, ${name}, now(), now(), null)
+        `),
+      )
+      .pipe(Effect.orDie);
+  }
+});
 
 const TestLayer = TodosRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
@@ -27,16 +50,20 @@ const suite = hasTestDatabase ? describe.sequential : describe.skip;
 
 suite("TodosRepositoryLive (integration)", () => {
   beforeEach(async () => {
-    await Effect.runPromise(truncate("todos.todos").pipe(Effect.provide(TestDatabaseLive)));
+    await Effect.runPromise(
+      truncate("todos.todos", "organization.organizations").pipe(Effect.provide(TestDatabaseLive)),
+    );
   });
 
   describe("insert", () => {
-    it.effect("persists the todo and decodes it back via findById", () =>
+    it.effect("persists the todo with its org and decodes it back via findById", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
         yield* repo.insert(buyMilk);
-        const found = yield* repo.findById(buyMilk.id);
+        const found = yield* repo.findById(orgA, buyMilk.id);
         deepStrictEqual(found.id, buyMilk.id);
+        deepStrictEqual(found.organizationId, orgA);
         deepStrictEqual(found.title, buyMilk.title);
         deepStrictEqual(found.completed, false);
       }).pipe(Effect.provide(TestLayer)),
@@ -46,8 +73,23 @@ suite("TodosRepositoryLive (integration)", () => {
   describe("findById", () => {
     it.effect("fails TodoNotFound for an unknown id", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.findById(bobId));
+        const exit = yield* Effect.exit(repo.findById(orgA, bobId));
+        deepStrictEqual(Exit.isFailure(exit), true);
+        if (Exit.isFailure(exit)) {
+          const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+          deepStrictEqual(error instanceof TodoNotFound, true);
+        }
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("fails TodoNotFound when the todo belongs to another org (tenant isolation)", () =>
+      Effect.gen(function* () {
+        yield* seedOrgs;
+        const repo = yield* TodosRepository;
+        yield* repo.insert(buyMilk);
+        const exit = yield* Effect.exit(repo.findById(orgB, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -60,6 +102,7 @@ suite("TodosRepositoryLive (integration)", () => {
   describe("update", () => {
     it.effect("overwrites title/completed and updatedAt", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
         yield* repo.insert(buyMilk);
         const completed = Todo.update(buyMilk, {
@@ -68,7 +111,7 @@ suite("TodosRepositoryLive (integration)", () => {
           now: later,
         });
         yield* repo.update(completed);
-        const found = yield* repo.findById(buyMilk.id);
+        const found = yield* repo.findById(orgA, buyMilk.id);
         deepStrictEqual(found.title, "Buy oat milk");
         deepStrictEqual(found.completed, true);
         deepStrictEqual(
@@ -80,6 +123,7 @@ suite("TodosRepositoryLive (integration)", () => {
 
     it.effect("fails TodoNotFound when the todo isn't stored", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
         const exit = yield* Effect.exit(repo.update(buyMilk));
         deepStrictEqual(Exit.isFailure(exit), true);
@@ -94,18 +138,36 @@ suite("TodosRepositoryLive (integration)", () => {
   describe("remove", () => {
     it.effect("deletes the row", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
         yield* repo.insert(buyMilk);
-        yield* repo.remove(buyMilk.id);
-        const exit = yield* Effect.exit(repo.findById(buyMilk.id));
+        yield* repo.remove(orgA, buyMilk.id);
+        const exit = yield* Effect.exit(repo.findById(orgA, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("fails TodoNotFound (and leaves the row) when removing from the wrong org", () =>
+      Effect.gen(function* () {
+        yield* seedOrgs;
+        const repo = yield* TodosRepository;
+        yield* repo.insert(buyMilk);
+        const exit = yield* Effect.exit(repo.remove(orgB, buyMilk.id));
+        deepStrictEqual(Exit.isFailure(exit), true);
+        if (Exit.isFailure(exit)) {
+          const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+          deepStrictEqual(error instanceof TodoNotFound, true);
+        }
+        const found = yield* repo.findById(orgA, buyMilk.id);
+        deepStrictEqual(found.id, buyMilk.id);
       }).pipe(Effect.provide(TestLayer)),
     );
 
     it.effect("fails TodoNotFound when the todo isn't stored", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.remove(bobId));
+        const exit = yield* Effect.exit(repo.remove(orgA, bobId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -118,6 +180,7 @@ suite("TodosRepositoryLive (integration)", () => {
   describe("transaction", () => {
     it.effect("rolls back inserts when the body fails (surfaces typed error)", () =>
       Effect.gen(function* () {
+        yield* seedOrgs;
         const repo = yield* TodosRepository;
         const db = yield* Database.Database;
         const exit = yield* Effect.exit(
@@ -129,7 +192,7 @@ suite("TodosRepositoryLive (integration)", () => {
           ),
         );
         deepStrictEqual(Exit.isFailure(exit), true);
-        const after = yield* Effect.exit(repo.findById(buyMilk.id));
+        const after = yield* Effect.exit(repo.findById(orgA, buyMilk.id));
         deepStrictEqual(Exit.isFailure(after), true);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
@@ -2,6 +2,7 @@ import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import { TodosRepository } from "../domain/ports/repositories/todo-repository.js";
@@ -19,9 +20,10 @@ export const TodosRepositoryLive = Layer.effect(
       const row = TodoMapper.toPersistence(todo);
       return execute((client) =>
         client.query(sql.unsafe`
-          INSERT INTO todos.todos (id, title, completed, created_at, updated_at)
+          INSERT INTO todos.todos (id, organization_id, title, completed, created_at, updated_at)
           VALUES (
             ${row.id},
+            ${row.organization_id},
             ${row.title},
             ${row.completed},
             ${sql.timestamp(row.created_at)},
@@ -36,6 +38,8 @@ export const TodosRepositoryLive = Layer.effect(
       );
     });
 
+    // Scoped on organization_id as well as id: an update aimed at a todo
+    // in another org matches no row and surfaces as TodoNotFound.
     const update = db.makeQuery((execute, todo: Todo) => {
       const row = TodoMapper.toPersistence(todo);
       return execute((client) =>
@@ -44,7 +48,7 @@ export const TodosRepositoryLive = Layer.effect(
             title = ${row.title},
             completed = ${row.completed},
             updated_at = ${sql.timestamp(row.updated_at)}
-          WHERE id = ${row.id}
+          WHERE id = ${row.id} AND organization_id = ${row.organization_id}
           RETURNING *
         `),
       ).pipe(
@@ -56,13 +60,15 @@ export const TodosRepositoryLive = Layer.effect(
       );
     });
 
-    const remove = db.makeQuery((execute, id: TodoId) =>
+    const remove = db.makeQuery((execute, args: { organizationId: OrganizationId; id: TodoId }) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
-          DELETE FROM todos.todos WHERE id = ${id} RETURNING *
-        `),
+            DELETE FROM todos.todos
+            WHERE id = ${args.id} AND organization_id = ${args.organizationId}
+            RETURNING *
+          `),
       ).pipe(
-        orFail(() => new TodoNotFound({ todoId: id })),
+        orFail(() => new TodoNotFound({ todoId: args.id })),
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
@@ -70,13 +76,14 @@ export const TodosRepositoryLive = Layer.effect(
       ),
     );
 
-    const findById = db.makeQuery((execute, id: TodoId) =>
+    const findById = db.makeQuery((execute, args: { organizationId: OrganizationId; id: TodoId }) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
-          SELECT * FROM todos.todos WHERE id = ${id}
-        `),
+            SELECT * FROM todos.todos
+            WHERE id = ${args.id} AND organization_id = ${args.organizationId}
+          `),
       ).pipe(
-        orFail(() => new TodoNotFound({ todoId: id })),
+        orFail(() => new TodoNotFound({ todoId: args.id })),
         Effect.map(TodoMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
@@ -84,6 +91,11 @@ export const TodosRepositoryLive = Layer.effect(
       ),
     );
 
-    return TodosRepository.of({ insert, update, remove, findById });
+    return TodosRepository.of({
+      insert,
+      update,
+      remove: (organizationId, id) => remove({ organizationId, id }),
+      findById: (organizationId, id) => findById({ organizationId, id }),
+    });
   }),
 );

--- a/packages/server/src/modules/todos/interface/http/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/create.endpoint.integration.test.ts
@@ -1,30 +1,76 @@
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { Database, sql } from "@org/database/index";
 import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
 import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 
-suite("POST /todos (integration)", () => {
-  const { run } = useServerTestRuntime(["todos.todos"]);
+suite("POST /orgs/:orgId/todos (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, { seedSuperAdminCaller: true });
 
-  it("creates a todo and returns the persisted shape", async () => {
+  it("creates a todo in the org and returns the persisted shape", async () => {
     await run(
       Effect.gen(function* () {
         const client = yield* HttpApiClient.make(Api);
-        const res = yield* client.todos.create({ payload: { title: "Buy milk" } });
-        // The HTTP response is the persisted Todo per the contract. The repo
-        // integration test (`todos-repository-live.integration.test.ts`)
-        // covers actual persistence; asserting it again here would be
-        // redundant. The GET endpoint integration test covers read-side
-        // visibility.
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const res = yield* client.todos.create({ path: { orgId }, payload: { title: "Buy milk" } });
         ok(typeof res.id === "string" && res.id.length > 0);
         deepStrictEqual(res.title, "Buy milk");
         deepStrictEqual(res.completed, false);
+      }),
+    );
+  });
+});
+
+const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+
+memberSuite("POST /orgs/:orgId/todos (integration, non-member caller)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("returns 403 Forbidden for a caller who isn't a member of the org", async () => {
+    await run(
+      Effect.gen(function* () {
+        const orgId = "11111111-1111-1111-1111-111111111111" as never;
+        const db = yield* Database.Database;
+        yield* db
+          .execute((c) =>
+            c.query(sql.unsafe`
+              INSERT INTO "organization".organizations (id, name, created_at, updated_at, deleted_at)
+              VALUES (${orgId}, 'Acme', now(), now(), null)
+            `),
+          )
+          .pipe(Effect.orDie);
+
+        const client = yield* HttpApiClient.make(Api);
+        const exit = yield* Effect.exit(
+          client.todos.create({ path: { orgId }, payload: { title: "Buy milk" } }),
+        );
+        ok(Exit.isFailure(exit));
+        if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
+          ok(exit.cause.error instanceof CustomHttpApiError.Forbidden);
+        } else {
+          throw new Error("expected a typed Fail, got " + JSON.stringify(exit));
+        }
       }),
     );
   });

--- a/packages/server/src/modules/todos/interface/http/create.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/create.endpoint.ts
@@ -1,18 +1,33 @@
 import { TodosContract } from "@org/contracts/api/Contracts";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
 import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
 
 import { CreateTodoCommand } from "@/modules/todos/commands/create-todo-command.js";
+import { todoMemberCheck } from "@/modules/todos/policies/todos-policies.js";
 import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
 import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
 
 export const createEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "create">) =>
   Effect.gen(function* () {
-    const commandBus = yield* CommandBus;
     const currentUser = yield* CurrentUser;
+    // Create is a flat action — the Authz DSL forbids an id on Create,
+    // and a flat check can't see the orgId — so run the same composed
+    // membership gate directly against the path orgId (defined once in
+    // `todos-policies.ts` as `todoMemberCheck`).
+    const allowed = yield* todoMemberCheck(currentUser, {
+      organizationId: request.path.orgId,
+    });
+    if (!allowed) {
+      return yield* Effect.fail(
+        new CustomHttpApiError.Forbidden({ message: "Not permitted: todoCollection.create" }),
+      );
+    }
+    const commandBus = yield* CommandBus;
     const todo = yield* commandBus.execute(
       CreateTodoCommand.make({
         title: request.payload.title,
+        organizationId: request.path.orgId,
         userId: currentUser.userId,
       }),
     );

--- a/packages/server/src/modules/todos/interface/http/delete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/delete.endpoint.integration.test.ts
@@ -10,18 +10,31 @@ import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
 import { hasTestDatabase } from "@/test-utils/test-database.js";
 
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 
-suite("DELETE /todos/:id (integration)", () => {
-  const { run } = useServerTestRuntime(["todos.todos"]);
+suite("DELETE /orgs/:orgId/todos/:id (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, { seedSuperAdminCaller: true });
 
   it("removes the todo", async () => {
     await run(
       Effect.gen(function* () {
         const client = yield* HttpApiClient.make(Api);
-        const created = yield* client.todos.create({ payload: { title: "Buy milk" } });
-        yield* client.todos.delete({ payload: created.id });
-        const todos = yield* client.todos.get();
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const created = yield* client.todos.create({
+          path: { orgId },
+          payload: { title: "Buy milk" },
+        });
+        yield* client.todos.delete({ path: { orgId, id: created.id } });
+        const todos = yield* client.todos.get({ path: { orgId } });
         deepStrictEqual(todos.length, 0);
       }),
     );
@@ -31,14 +44,41 @@ suite("DELETE /todos/:id (integration)", () => {
     await run(
       Effect.gen(function* () {
         const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
         const ghostId = TodoId.make("00000000-0000-0000-0000-000000000000");
-        const exit = yield* Effect.exit(client.todos.delete({ payload: ghostId }));
+        const exit = yield* Effect.exit(client.todos.delete({ path: { orgId, id: ghostId } }));
         ok(Exit.isFailure(exit));
         if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
           ok(exit.cause.error instanceof TodosContract.TodoNotFoundError);
         } else {
           throw new Error("expected a typed Fail, got " + JSON.stringify(exit));
         }
+      }),
+    );
+  });
+
+  it("returns 404 when deleting via a different org's path (tenant isolation)", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgA } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const { id: orgB } = yield* client.organization.create({ payload: { name: "Beta" } });
+        const created = yield* client.todos.create({
+          path: { orgId: orgA },
+          payload: { title: "Buy milk" },
+        });
+        const exit = yield* Effect.exit(
+          client.todos.delete({ path: { orgId: orgB, id: created.id } }),
+        );
+        ok(Exit.isFailure(exit));
+        if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
+          ok(exit.cause.error instanceof TodosContract.TodoNotFoundError);
+        } else {
+          throw new Error("expected a typed Fail, got " + JSON.stringify(exit));
+        }
+        // The todo is still present under its real org.
+        const todos = yield* client.todos.get({ path: { orgId: orgA } });
+        deepStrictEqual(todos.length, 1);
       }),
     );
   });

--- a/packages/server/src/modules/todos/interface/http/delete.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/delete.endpoint.ts
@@ -3,16 +3,36 @@ import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
 
 import { DeleteTodoCommand } from "@/modules/todos/commands/delete-todo-command.js";
+import { TodoResource } from "@/modules/todos/policies/todos-policies.js";
+import { Actions } from "@/platform/auth/actions.js";
+import * as Authz from "@/platform/auth/authz.js";
 import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
 import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
 
 export const deleteEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "delete">) =>
   Effect.gen(function* () {
+    // The `todo` resolver loads the row scoped to (orgId, id); a missing
+    // or cross-tenant todo surfaces as NotFound, mapped to the contract's
+    // TodoNotFoundError. Membership against the todo's real org is then
+    // checked before the command runs.
+    yield* Authz.hasPermissions(TodoResource, Actions.Delete, {
+      organizationId: request.path.orgId,
+      todoId: request.path.id,
+    }).pipe(
+      Effect.catchTag("NotFound", () =>
+        Effect.fail(
+          new TodosContract.TodoNotFoundError({
+            message: `Todo with id ${request.path.id} not found`,
+          }),
+        ),
+      ),
+    );
     const commandBus = yield* CommandBus;
     const currentUser = yield* CurrentUser;
     yield* commandBus.execute(
       DeleteTodoCommand.make({
-        todoId: request.payload,
+        todoId: request.path.id,
+        organizationId: request.path.orgId,
         userId: currentUser.userId,
       }),
     );

--- a/packages/server/src/modules/todos/interface/http/get.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/get.endpoint.integration.test.ts
@@ -1,39 +1,85 @@
 import * as HttpApiClient from "@effect/platform/HttpApiClient";
 import { describe, it } from "@effect/vitest";
-import { deepStrictEqual } from "assert";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { Database, sql } from "@org/database/index";
+import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
 import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 
-suite("GET /todos (integration)", () => {
-  const { run } = useServerTestRuntime(["todos.todos"]);
+suite("GET /orgs/:orgId/todos (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, { seedSuperAdminCaller: true });
 
-  it("returns an empty list initially", async () => {
+  it("lists only the org's todos, created_at desc", async () => {
     await run(
       Effect.gen(function* () {
         const client = yield* HttpApiClient.make(Api);
-        const todos = yield* client.todos.get();
-        deepStrictEqual(todos.length, 0);
-      }),
-    );
-  });
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
 
-  it("returns todos in created_at desc order", async () => {
-    await run(
-      Effect.gen(function* () {
-        const client = yield* HttpApiClient.make(Api);
-        yield* client.todos.create({ payload: { title: "first" } });
-        yield* client.todos.create({ payload: { title: "second" } });
-        yield* client.todos.create({ payload: { title: "third" } });
-        const todos = yield* client.todos.get();
+        const empty = yield* client.todos.get({ path: { orgId } });
+        deepStrictEqual(empty.length, 0);
+
+        yield* client.todos.create({ path: { orgId }, payload: { title: "first" } });
+        yield* client.todos.create({ path: { orgId }, payload: { title: "second" } });
+        yield* client.todos.create({ path: { orgId }, payload: { title: "third" } });
+
+        const todos = yield* client.todos.get({ path: { orgId } });
         deepStrictEqual(
           todos.map((t) => t.title),
           ["third", "second", "first"],
         );
+      }),
+    );
+  });
+});
+
+// Non-member caller (not super-admin) is rejected before any query.
+const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+
+memberSuite("GET /orgs/:orgId/todos (integration, non-member caller)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("returns 403 Forbidden for a caller who isn't a member of the org", async () => {
+    await run(
+      Effect.gen(function* () {
+        // Seed an org directly so the member-caller is NOT a member of it.
+        const orgId = "11111111-1111-1111-1111-111111111111" as never;
+        const db = yield* Database.Database;
+        yield* db
+          .execute((c) =>
+            c.query(sql.unsafe`
+              INSERT INTO "organization".organizations (id, name, created_at, updated_at, deleted_at)
+              VALUES (${orgId}, 'Acme', now(), now(), null)
+            `),
+          )
+          .pipe(Effect.orDie);
+
+        const client = yield* HttpApiClient.make(Api);
+        const exit = yield* Effect.exit(client.todos.get({ path: { orgId } }));
+        ok(Exit.isFailure(exit));
+        if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
+          ok(exit.cause.error instanceof CustomHttpApiError.Forbidden);
+        } else {
+          throw new Error("expected a typed Fail, got " + JSON.stringify(exit));
+        }
       }),
     );
   });

--- a/packages/server/src/modules/todos/interface/http/get.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/get.endpoint.ts
@@ -1,11 +1,14 @@
 import { TodosContract } from "@org/contracts/api/Contracts";
 import * as Effect from "effect/Effect";
 
+import { TodoCollectionResource } from "@/modules/todos/policies/todos-policies.js";
 import {
   ListTodosQuery,
   type ListTodosResult,
   type ListTodosTodoView,
 } from "@/modules/todos/queries/list-todos-query.js";
+import { Actions } from "@/platform/auth/actions.js";
+import * as Authz from "@/platform/auth/authz.js";
 import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
 import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
 
@@ -19,9 +22,21 @@ const toContract = (view: ListTodosTodoView): TodosContract.Todo =>
 const toResponse = (result: ListTodosResult): ReadonlyArray<TodosContract.Todo> =>
   result.todos.map(toContract);
 
-export const getEndpoint = (_request: EndpointRequest<typeof TodosContract.Group, "get">) =>
+export const getEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "get">) =>
   Effect.gen(function* () {
+    // The `todoCollection` resolver is a deliberate echo of the orgId
+    // and never fails NotFound (the collection's identity *is* the org;
+    // we don't leak org existence to non-members). `hasPermissions`
+    // declares NotFound for resource-scoped calls, so collapse the
+    // unreachable case to a defect.
+    yield* Authz.hasPermissions(TodoCollectionResource, Actions.Read, request.path.orgId).pipe(
+      Effect.catchTag("NotFound", () =>
+        Effect.die("Unreachable: todoCollection resolver cannot surface NotFound"),
+      ),
+    );
     const queryBus = yield* QueryBus;
-    const result = yield* queryBus.execute(ListTodosQuery.make({}));
+    const result = yield* queryBus.execute(
+      ListTodosQuery.make({ organizationId: request.path.orgId }),
+    );
     return toResponse(result);
   }).pipe(recoverPersistenceUnavailable, Effect.withSpan("TodosLive.get"));

--- a/packages/server/src/modules/todos/interface/http/update.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/update.endpoint.integration.test.ts
@@ -10,18 +10,32 @@ import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
 import { hasTestDatabase } from "@/test-utils/test-database.js";
 
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 
-suite("PUT /todos/:id (integration)", () => {
-  const { run } = useServerTestRuntime(["todos.todos"]);
+suite("PUT /orgs/:orgId/todos/:id (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, { seedSuperAdminCaller: true });
 
   it("updates title and completed", async () => {
     await run(
       Effect.gen(function* () {
         const client = yield* HttpApiClient.make(Api);
-        const created = yield* client.todos.create({ payload: { title: "Buy milk" } });
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const created = yield* client.todos.create({
+          path: { orgId },
+          payload: { title: "Buy milk" },
+        });
         const updated = yield* client.todos.update({
-          payload: { id: created.id, title: "Buy oat milk", completed: true },
+          path: { orgId, id: created.id },
+          payload: { title: "Buy oat milk", completed: true },
         });
         deepStrictEqual(updated.title, "Buy oat milk");
         deepStrictEqual(updated.completed, true);
@@ -33,10 +47,41 @@ suite("PUT /todos/:id (integration)", () => {
     await run(
       Effect.gen(function* () {
         const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
         const ghostId = TodoId.make("00000000-0000-0000-0000-000000000000");
         const exit = yield* Effect.exit(
           client.todos.update({
-            payload: { id: ghostId, title: "x", completed: false },
+            path: { orgId, id: ghostId },
+            payload: { title: "x", completed: false },
+          }),
+        );
+        ok(Exit.isFailure(exit));
+        if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
+          ok(exit.cause.error instanceof TodosContract.TodoNotFoundError);
+        } else {
+          throw new Error("expected a typed Fail, got " + JSON.stringify(exit));
+        }
+      }),
+    );
+  });
+
+  it("returns 404 when updating via a different org's path (tenant isolation)", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgA } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const { id: orgB } = yield* client.organization.create({ payload: { name: "Beta" } });
+        const created = yield* client.todos.create({
+          path: { orgId: orgA },
+          payload: { title: "Buy milk" },
+        });
+        // Super-admin bypasses the membership gate for orgB, but the
+        // repository is scoped by (orgId, todoId), so the todo created in
+        // orgA can't be reached through orgB's path.
+        const exit = yield* Effect.exit(
+          client.todos.update({
+            path: { orgId: orgB, id: created.id },
+            payload: { title: "hijack", completed: true },
           }),
         );
         ok(Exit.isFailure(exit));

--- a/packages/server/src/modules/todos/interface/http/update.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/http/update.endpoint.ts
@@ -3,16 +3,36 @@ import { CurrentUser } from "@org/contracts/Policy";
 import * as Effect from "effect/Effect";
 
 import { UpdateTodoCommand } from "@/modules/todos/commands/update-todo-command.js";
+import { TodoResource } from "@/modules/todos/policies/todos-policies.js";
+import { Actions } from "@/platform/auth/actions.js";
+import * as Authz from "@/platform/auth/authz.js";
 import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
 import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
 
 export const updateEndpoint = (request: EndpointRequest<typeof TodosContract.Group, "update">) =>
   Effect.gen(function* () {
+    // The `todo` resolver loads the row scoped to (orgId, id); a missing
+    // or cross-tenant todo surfaces as NotFound, mapped to the contract's
+    // TodoNotFoundError. Membership against the todo's real org is then
+    // checked before the command runs.
+    yield* Authz.hasPermissions(TodoResource, Actions.Update, {
+      organizationId: request.path.orgId,
+      todoId: request.path.id,
+    }).pipe(
+      Effect.catchTag("NotFound", () =>
+        Effect.fail(
+          new TodosContract.TodoNotFoundError({
+            message: `Todo with id ${request.path.id} not found`,
+          }),
+        ),
+      ),
+    );
     const commandBus = yield* CommandBus;
     const currentUser = yield* CurrentUser;
     const todo = yield* commandBus.execute(
       UpdateTodoCommand.make({
-        todoId: request.payload.id,
+        todoId: request.path.id,
+        organizationId: request.path.orgId,
         title: request.payload.title,
         completed: request.payload.completed,
         userId: currentUser.userId,

--- a/packages/server/src/modules/todos/policies/is-todo-org-member.test.ts
+++ b/packages/server/src/modules/todos/policies/is-todo-org-member.test.ts
@@ -1,0 +1,63 @@
+// Side-effect imports: these modules carry the `declare module`
+// augmentations that register the `todoCollection` / `todo` resources in
+// `PolicyMap` / `ResourceResolverMap`, which `ResourceCheck<TodoOrgContext>`
+// composes against.
+import "@/modules/todos/policies/todos-policies.js";
+import "@/modules/todos/policies/todo-resource-resolvers.js";
+
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { IsTodoOrgMember } from "@/modules/todos/policies/is-todo-org-member.js";
+import { MembershipService } from "@/platform/ddd/ports/membership-service.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { makeOrganizationRoleServiceFake } from "@/test-utils/organization-role-service-fake.js";
+import { makeRoleServiceFake } from "@/test-utils/role-service-fake.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const caller = { sessionId: "s", userId };
+const resource = { organizationId: orgId };
+
+// `IsTodoOrgMember` only reads `MembershipService`, but its registry
+// type (`CheckFor`) declares the full `PolicyDeps` set in R, so the
+// other two ACLs are provided as empty fakes to satisfy the channel.
+const membershipFake = (isMember: boolean) =>
+  Layer.succeed(
+    MembershipService,
+    MembershipService.of({ isMember: () => Effect.succeed(isMember) }),
+  );
+
+const PolicyDepsFake = (isMember: boolean) =>
+  Layer.mergeAll(
+    membershipFake(isMember),
+    makeRoleServiceFake(new Map()),
+    makeOrganizationRoleServiceFake(),
+  );
+
+describe("IsTodoOrgMember", () => {
+  it.effect("returns true when MembershipService reports the caller is a member", () =>
+    IsTodoOrgMember(caller, resource).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          deepStrictEqual(result, true);
+        }),
+      ),
+      Effect.provide(PolicyDepsFake(true)),
+    ),
+  );
+
+  it.effect("returns false when the caller is not a member of the todo's org", () =>
+    IsTodoOrgMember(caller, resource).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          deepStrictEqual(result, false);
+        }),
+      ),
+      Effect.provide(PolicyDepsFake(false)),
+    ),
+  );
+});

--- a/packages/server/src/modules/todos/policies/is-todo-org-member.ts
+++ b/packages/server/src/modules/todos/policies/is-todo-org-member.ts
@@ -1,0 +1,13 @@
+import { makeIsOrgMember } from "@/platform/auth/policies/is-org-member.js";
+
+import { type TodoOrgContext } from "./todo-resource-resolvers.js";
+
+// "Is this caller a member of the todo's org?" — shared by both todo
+// policy resources (`todoCollection.read` and `todo.update`/`delete`),
+// which both resolve to `{ organizationId }`. The membership lookup
+// lives in the shared `makeIsOrgMember` factory (platform), over the
+// `MembershipService` ACL; this module supplies only the resource→orgId
+// extractor. Same pattern as the organization module's `IsMember`.
+export const IsTodoOrgMember = makeIsOrgMember(
+  (resource: TodoOrgContext) => resource.organizationId,
+);

--- a/packages/server/src/modules/todos/policies/todo-resource-resolvers.ts
+++ b/packages/server/src/modules/todos/policies/todo-resource-resolvers.ts
@@ -1,0 +1,75 @@
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-repository.js";
+import { type TodoId } from "@/modules/todos/domain/todo-id.js";
+import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
+import { type Resolver } from "@/platform/auth/resource-resolver-registry.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
+// Todos expose two policy resources, split by what is actually being
+// acted on:
+//
+//   - `todoCollection` (keyed by OrganizationId) gates the list read
+//     (and, via a direct check, create). Its identity genuinely *is*
+//     the org, so the resolver is a deliberate echo: there is nothing
+//     to load, and a non-member must not learn whether the org exists.
+//
+//   - `todo` (keyed by the (orgId, todoId) pair) gates per-item
+//     update/delete. Its resolver *loads* the todo scoped to the org —
+//     a missing row, or one living in a different org, surfaces as
+//     NotFound (→ TodoNotFoundError at the endpoint), folding tenant
+//     isolation into authorization. The resolved resource carries the
+//     todo's real `organizationId`, which the membership check reads.
+//
+// Both resources resolve to the same org-membership context, so a
+// single `IsTodoOrgMember` check serves both (see is-todo-org-member.ts).
+export type TodoOrgContext = { readonly organizationId: OrganizationId };
+export type TodoResourceId = {
+  readonly organizationId: OrganizationId;
+  readonly todoId: TodoId;
+};
+
+declare module "@/platform/auth/resource-resolver-registry.js" {
+  interface ResourceResolverMap {
+    todoCollection: { resourceType: TodoOrgContext; idType: OrganizationId };
+    todo: { resourceType: TodoOrgContext; idType: TodoResourceId };
+  }
+}
+
+export class TodoCollectionResolverEntry extends Context.Tag("TodoCollectionResolverEntry")<
+  TodoCollectionResolverEntry,
+  Resolver<"todoCollection">
+>() {}
+
+// Echo: the collection's identity is the org id. No cross-module load —
+// non-members get 403 without learning whether the org exists.
+export const TodoCollectionResolverEntryLive = Layer.succeed(
+  TodoCollectionResolverEntry,
+  (organizationId) => Effect.succeed({ organizationId }),
+);
+
+export class TodoResolverEntry extends Context.Tag("TodoResolverEntry")<
+  TodoResolverEntry,
+  Resolver<"todo">
+>() {}
+
+// Loads the todo scoped to its org. `TodoNotFound` (missing OR
+// cross-tenant) → `NotFound`, which the endpoint maps to
+// `TodoNotFoundError`. `PersistenceUnavailable` dies inside the resolver
+// — the endpoint's `recoverPersistenceUnavailable` converts it to 503,
+// same shape as the organization resolver.
+export const TodoResolverEntryLive = Layer.effect(
+  TodoResolverEntry,
+  Effect.gen(function* () {
+    const repo = yield* TodosRepository;
+    return ({ organizationId, todoId }) =>
+      repo.findById(organizationId, todoId).pipe(
+        Effect.map((todo) => ({ organizationId: todo.organizationId })),
+        Effect.catchTag("TodoNotFound", () => Effect.fail(new CustomHttpApiError.NotFound())),
+        Effect.catchTag("PersistenceUnavailable", Effect.die),
+      );
+  }),
+).pipe(Layer.provide(TodosRepositoryLive));

--- a/packages/server/src/modules/todos/policies/todos-policies.ts
+++ b/packages/server/src/modules/todos/policies/todos-policies.ts
@@ -1,0 +1,42 @@
+import * as Check from "@/platform/auth/check.js";
+import { SuperAdminOnly } from "@/platform/auth/policies/super-admin.js";
+import type * as PolicyRegistry from "@/platform/auth/policy-registry.js";
+
+import { IsTodoOrgMember } from "./is-todo-org-member.js";
+
+// Two todo policy resources (see todo-resource-resolvers.ts):
+//   - `todoCollection.read`        — list the todos in an org
+//   - `todo.update` / `todo.delete` — act on a single todo
+// All gate on org membership (super-admin bypasses). `create` is a flat
+// action — the DSL forbids an id on Create, and a flat check can't see
+// the orgId — so its endpoint runs `todoMemberCheck` directly against
+// the path orgId, the same composed gate registered here.
+
+declare module "@/platform/auth/policy-registry.js" {
+  interface PolicyMap {
+    todoCollection: {
+      read: PolicyRegistry.CheckFor<"todoCollection", "read">;
+    };
+    todo: {
+      update: PolicyRegistry.CheckFor<"todo", "update">;
+      delete: PolicyRegistry.CheckFor<"todo", "delete">;
+    };
+  }
+}
+
+export const TodoCollectionResource = "todoCollection" as const;
+export const TodoResource = "todo" as const;
+
+// One composed gate reused across every todo operation, including the
+// create endpoint's direct call — so the membership rule is defined once.
+export const todoMemberCheck = Check.any(SuperAdminOnly, IsTodoOrgMember);
+
+export const todosPolicies: PolicyRegistry.PolicyContribution = {
+  todoCollection: {
+    read: todoMemberCheck,
+  },
+  todo: {
+    update: todoMemberCheck,
+    delete: todoMemberCheck,
+  },
+};

--- a/packages/server/src/modules/todos/queries/list-todos-query.ts
+++ b/packages/server/src/modules/todos/queries/list-todos-query.ts
@@ -5,11 +5,16 @@ import * as Schema from "effect/Schema";
 import { type TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 
-export const ListTodosQuery = Schema.TaggedStruct("ListTodosQuery", {});
+export const ListTodosQuery = Schema.TaggedStruct("ListTodosQuery", {
+  organizationId: OrganizationId,
+});
 export type ListTodosQuery = typeof ListTodosQuery.Type;
 
-export const listTodosQuerySpanAttributes: SpanAttributesExtractor<ListTodosQuery> = () => ({});
+export const listTodosQuerySpanAttributes: SpanAttributesExtractor<ListTodosQuery> = (query) => ({
+  "organization.id": query.organizationId,
+});
 
 export type ListTodosTodoView = {
   readonly id: TodoId;

--- a/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@effect/vitest";
+import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -11,11 +12,14 @@ import { TodoId } from "@/modules/todos/domain/todo-id.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/todos-repository-live.js";
 import { listTodos } from "@/modules/todos/queries/list-todos.js";
 import { ListTodosQuery } from "@/modules/todos/queries/list-todos-query.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");
 const carolId = TodoId.make("33333333-3333-3333-3333-333333333333");
+const orgA = OrganizationId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const orgB = OrganizationId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 
 const aliceTime = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 const bobTime = DateTime.unsafeMake(new Date("2025-02-01T00:00:00Z"));
@@ -23,36 +27,58 @@ const carolTime = DateTime.unsafeMake(new Date("2025-03-01T00:00:00Z"));
 
 const TestLayer = TodosRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const seed = (id: TodoId, title: string, now: DateTime.Utc) =>
+const seedOrgs = Effect.gen(function* () {
+  const db = yield* Database.Database;
+  for (const [id, name] of [
+    [orgA, "Acme"],
+    [orgB, "Beta"],
+  ] as const) {
+    yield* db
+      .execute((client) =>
+        client.query(sql.unsafe`
+          INSERT INTO "organization".organizations (id, name, created_at, updated_at, deleted_at)
+          VALUES (${id}, ${name}, now(), now(), null)
+        `),
+      )
+      .pipe(Effect.orDie);
+  }
+});
+
+const seed = (id: TodoId, organizationId: OrganizationId, title: string, now: DateTime.Utc) =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    yield* repo.insert(Todo.create({ id, title, now }));
+    yield* repo.insert(Todo.create({ id, organizationId, title, now }));
   });
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;
 
 suite("listTodos (integration)", () => {
   beforeEach(async () => {
-    await Effect.runPromise(truncate("todos.todos").pipe(Effect.provide(TestDatabaseLive)));
+    await Effect.runPromise(
+      truncate("todos.todos", "organization.organizations").pipe(Effect.provide(TestDatabaseLive)),
+    );
   });
 
-  it.effect("returns rows ordered by created_at desc", () =>
+  it.effect("returns only the requested org's rows, ordered by created_at desc", () =>
     Effect.gen(function* () {
-      yield* seed(aliceId, "alice", aliceTime);
-      yield* seed(bobId, "bob", bobTime);
-      yield* seed(carolId, "carol", carolTime);
+      yield* seedOrgs;
+      yield* seed(aliceId, orgA, "alice", aliceTime);
+      yield* seed(bobId, orgA, "bob", bobTime);
+      yield* seed(carolId, orgB, "carol-in-org-b", carolTime);
 
-      const result = yield* listTodos(ListTodosQuery.make({}));
+      const result = yield* listTodos(ListTodosQuery.make({ organizationId: orgA }));
       deepStrictEqual(
         result.todos.map((t) => t.title),
-        ["carol", "bob", "alice"],
+        ["bob", "alice"],
       );
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("returns empty when the table is empty", () =>
+  it.effect("returns empty for an org with no todos", () =>
     Effect.gen(function* () {
-      const result = yield* listTodos(ListTodosQuery.make({}));
+      yield* seedOrgs;
+      yield* seed(aliceId, orgA, "alice", aliceTime);
+      const result = yield* listTodos(ListTodosQuery.make({ organizationId: orgB }));
       deepStrictEqual(result.todos, []);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/todos/queries/list-todos.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.ts
@@ -15,13 +15,15 @@ const toView = (row: RowSchemas.TodoRow): ListTodosTodoView => ({
   completed: row.completed,
 });
 
-export const listTodos = (_query: ListTodosQuery): ListTodosOutput =>
+export const listTodos = (query: ListTodosQuery): ListTodosOutput =>
   Effect.gen(function* () {
     const db = yield* Database.Database;
     const rows = yield* db
       .execute((client) =>
         client.any(sql.type(RowSchemas.TodoRowStd)`
-          SELECT * FROM todos.todos ORDER BY created_at DESC
+          SELECT * FROM todos.todos
+          WHERE organization_id = ${query.organizationId}
+          ORDER BY created_at DESC
         `),
       )
       .pipe(

--- a/packages/server/src/platform/auth/policies/is-org-member.ts
+++ b/packages/server/src/platform/auth/policies/is-org-member.ts
@@ -1,0 +1,28 @@
+import * as Effect from "effect/Effect";
+
+import { type ResourceCheck } from "@/platform/auth/policy-registry.js";
+import { MembershipService } from "@/platform/ddd/ports/membership-service.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
+// Reusable "is this caller a member of the resource's org?" check,
+// parameterized by how *this* resource yields its org id.
+//
+// The membership lookup is the uniform, cross-cutting part — every
+// consumer asks the identical `isMember(userId, orgId)` — so it stays
+// centralized behind the platform `MembershipService` ACL. The only
+// module-specific part is extracting the org id from the resource
+// (`organization.id`, `todo.organizationId`, …), so each module supplies
+// that one-liner. Platform never learns the consumer's resource shape;
+// it only receives the extractor.
+//
+// Mirrors `SuperAdminOnly` (a platform check over a platform ACL),
+// composed as `Authz.any(SuperAdminOnly, makeIsOrgMember(...))`. A module
+// needing bespoke membership semantics (e.g. "member OR pending
+// invitation") still authors its own check by hand.
+export const makeIsOrgMember =
+  <R>(getOrganizationId: (resource: R) => OrganizationId): ResourceCheck<R> =>
+  (caller, resource) =>
+    Effect.gen(function* () {
+      const memberships = yield* MembershipService;
+      return yield* memberships.isMember(caller.userId, getOrganizationId(resource));
+    });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -40,7 +40,16 @@ import {
   roleQueryHandlers,
   RoleServiceLive,
 } from "./modules/role/index.js";
-import { todoCommandHandlers, todoQueryHandlers, TodosModuleLive } from "./modules/todos/index.js";
+import {
+  TodoCollectionResolverEntry,
+  TodoCollectionResolverEntryLive,
+  todoCommandHandlers,
+  todoQueryHandlers,
+  TodoResolverEntry,
+  TodoResolverEntryLive,
+  TodosModuleLive,
+  todosPolicies,
+} from "./modules/todos/index.js";
 import {
   userCommandHandlers,
   userEventSpanAttributes,
@@ -95,7 +104,7 @@ const DomainEventBusLive = makeDomainEventBusLive({
   },
 });
 
-const PolicyRegistryLive = makePolicyRegistry([userPolicies, organizationPolicies]);
+const PolicyRegistryLive = makePolicyRegistry([userPolicies, organizationPolicies, todosPolicies]);
 
 // Resource resolvers are owned by each module: the module exports a
 // `*ResolverEntryLive` layer that internally satisfies its repository
@@ -107,12 +116,23 @@ const ResourceResolverRegistryLive = Layer.unwrapEffect(
   Effect.gen(function* () {
     const userResolver = yield* UserResolverEntry;
     const organizationResolver = yield* OrganizationResolverEntry;
+    const todoCollectionResolver = yield* TodoCollectionResolverEntry;
+    const todoResolver = yield* TodoResolverEntry;
     return makeResourceResolverRegistry({
       user: userResolver,
       organization: organizationResolver,
+      todoCollection: todoCollectionResolver,
+      todo: todoResolver,
     });
   }),
-).pipe(Layer.provide([UserResolverEntryLive, OrganizationResolverEntryLive]));
+).pipe(
+  Layer.provide([
+    UserResolverEntryLive,
+    OrganizationResolverEntryLive,
+    TodoCollectionResolverEntryLive,
+    TodoResolverEntryLive,
+  ]),
+);
 
 const ApiLive = HttpApiBuilder.api(Api).pipe(
   Layer.provide([

--- a/packages/server/src/test-utils/test-server.ts
+++ b/packages/server/src/test-utils/test-server.ts
@@ -29,7 +29,16 @@ import {
   roleQueryHandlers,
   RoleServiceLive,
 } from "@/modules/role/index.js";
-import { todoCommandHandlers, todoQueryHandlers, TodosModuleLive } from "@/modules/todos/index.js";
+import {
+  TodoCollectionResolverEntry,
+  TodoCollectionResolverEntryLive,
+  todoCommandHandlers,
+  todoQueryHandlers,
+  TodoResolverEntry,
+  TodoResolverEntryLive,
+  TodosModuleLive,
+  todosPolicies,
+} from "@/modules/todos/index.js";
 import {
   userCommandHandlers,
   userEventSpanAttributes,
@@ -83,18 +92,29 @@ const DomainEventBusLive = makeDomainEventBusLive({
   },
 });
 
-const PolicyRegistryLive = makePolicyRegistry([userPolicies, organizationPolicies]);
+const PolicyRegistryLive = makePolicyRegistry([userPolicies, organizationPolicies, todosPolicies]);
 
 const ResourceResolverRegistryLive = Layer.unwrapEffect(
   Effect.gen(function* () {
     const userResolver = yield* UserResolverEntry;
     const organizationResolver = yield* OrganizationResolverEntry;
+    const todoCollectionResolver = yield* TodoCollectionResolverEntry;
+    const todoResolver = yield* TodoResolverEntry;
     return makeResourceResolverRegistry({
       user: userResolver,
       organization: organizationResolver,
+      todoCollection: todoCollectionResolver,
+      todo: todoResolver,
     });
   }),
-).pipe(Layer.provide([UserResolverEntryLive, OrganizationResolverEntryLive]));
+).pipe(
+  Layer.provide([
+    UserResolverEntryLive,
+    OrganizationResolverEntryLive,
+    TodoCollectionResolverEntryLive,
+    TodoResolverEntryLive,
+  ]),
+);
 
 // `CommandBus` and `QueryBus` are cross-cutting public production APIs
 // (ADR-0006) — the same dispatch surface every HTTP handler uses. Exposing

--- a/packages/web/app/(authed)/page.tsx
+++ b/packages/web/app/(authed)/page.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { AddTodo } from "@/features/index/add-todo/add-todo";
 import { TodoList } from "@/features/index/todo-list";
 import { ServerHydrationBoundary } from "@/lib/tanstack-query/server-hydration-boundary";
+import { ensurePrimaryOrgId } from "@/services/data-access/primary-org.server";
 import { prefetchTodos } from "@/services/data-access/todos-queries.server";
 
 const SKELETON_COUNT = 3;
@@ -17,16 +18,24 @@ const Fallback: React.FC = () => (
   </div>
 );
 
-export default function TasksPage() {
+// Phase 5 bridge: contract paths are now `/orgs/:orgId/todos`, but the
+// route surface still lives at `/`. Resolve the caller's primary org
+// server-side (auto-creating "My Workspace" on first sign-in) and
+// thread the id down through prefetch + the two client features.
+// Phase 8 will replace this with `/orgs/[orgId]/todos` and read orgId
+// from the URL segment.
+export default async function TasksPage() {
+  const orgId = await ensurePrimaryOrgId();
+
   return (
     <Card className="mx-auto w-full max-w-lg shadow-md">
       <Card.Header className="pb-2">
         <Card.Title className="text-center text-2xl font-semibold">My Tasks</Card.Title>
       </Card.Header>
       <Card.Content className="space-y-4">
-        <AddTodo />
-        <ServerHydrationBoundary prefetch={[prefetchTodos()]} fallback={<Fallback />}>
-          <TodoList />
+        <AddTodo orgId={orgId} />
+        <ServerHydrationBoundary prefetch={[prefetchTodos(orgId)]} fallback={<Fallback />}>
+          <TodoList orgId={orgId} />
         </ServerHydrationBoundary>
       </Card.Content>
     </Card>

--- a/packages/web/features/index/add-todo/add-todo.presenter.test.ts
+++ b/packages/web/features/index/add-todo/add-todo.presenter.test.ts
@@ -1,5 +1,5 @@
 import { TodosContract } from "@org/contracts/api/Contracts";
-import { TodoId } from "@org/contracts/EntityIds";
+import { OrganizationId, TodoId } from "@org/contracts/EntityIds";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as Effect from "effect/Effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makePresenterHarness } from "@/test/presenter-harness";
 
 import { useAddTodoPresenter } from "./add-todo.presenter";
+
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 
 type CreateCalls = ReadonlyArray<TodosContract.CreateTodoPayload>;
 
@@ -53,7 +55,7 @@ describe("useAddTodoPresenter", () => {
     const recorded: { current: CreateCalls } = { current: [] };
     harness = makePresenterHarness({ apiClient: makeApiClient({ recordedCalls: recorded }) });
 
-    const { result } = renderHook(() => useAddTodoPresenter(), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useAddTodoPresenter(orgId), { wrapper: harness.wrapper });
 
     act(() => {
       result.current.form.setFieldValue("title", "Buy milk");
@@ -78,7 +80,7 @@ describe("useAddTodoPresenter", () => {
     const recorded: { current: CreateCalls } = { current: [] };
     harness = makePresenterHarness({ apiClient: makeApiClient({ recordedCalls: recorded }) });
 
-    const { result } = renderHook(() => useAddTodoPresenter(), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useAddTodoPresenter(orgId), { wrapper: harness.wrapper });
 
     await act(async () => {
       await result.current.form.handleSubmit();
@@ -94,7 +96,7 @@ describe("useAddTodoPresenter", () => {
     });
     harness = makePresenterHarness({ apiClient: failingApi });
 
-    const { result } = renderHook(() => useAddTodoPresenter(), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useAddTodoPresenter(orgId), { wrapper: harness.wrapper });
 
     act(() => {
       result.current.form.setFieldValue("title", "Buy milk");

--- a/packages/web/features/index/add-todo/add-todo.presenter.ts
+++ b/packages/web/features/index/add-todo/add-todo.presenter.ts
@@ -5,13 +5,14 @@
 // the component is pure JSX over the returned form instance.
 
 import { TodosContract } from "@org/contracts/api/Contracts";
+import type { OrganizationId } from "@org/contracts/EntityIds";
 import { useForm } from "@tanstack/react-form";
 import * as Schema from "effect/Schema";
 
 import { makeFormOptions } from "@/lib/tanstack-query/make-form-options";
 import { useCreateTodoMutation } from "@/services/data-access/use-todos-queries";
 
-export const useAddTodoPresenter = () => {
+export const useAddTodoPresenter = (orgId: OrganizationId) => {
   const createTodoMutation = useCreateTodoMutation();
 
   const form = useForm({
@@ -24,7 +25,7 @@ export const useAddTodoPresenter = () => {
     }),
     onSubmit: async ({ formApi, value }) => {
       const payload = Schema.decodeSync(TodosContract.CreateTodoPayload)(value);
-      await createTodoMutation.mutateAsync(payload);
+      await createTodoMutation.mutateAsync({ orgId, payload });
       formApi.reset();
     },
   });

--- a/packages/web/features/index/add-todo/add-todo.tsx
+++ b/packages/web/features/index/add-todo/add-todo.tsx
@@ -4,11 +4,12 @@ import { Button } from "@org/components/primitives/button";
 import { Form } from "@org/components/primitives/form";
 import { PlusIcon } from "@org/components/primitives/icon";
 import { Input } from "@org/components/primitives/input";
+import type { OrganizationId } from "@org/contracts/EntityIds";
 
 import { useAddTodoPresenter } from "./add-todo.presenter";
 
-export const AddTodo: React.FC = () => {
-  const { form } = useAddTodoPresenter();
+export const AddTodo: React.FC<{ orgId: OrganizationId }> = ({ orgId }) => {
+  const { form } = useAddTodoPresenter(orgId);
 
   return (
     <Form onSubmit={form.handleSubmit}>

--- a/packages/web/features/index/todo-item/todo-item.presenter.test.tsx
+++ b/packages/web/features/index/todo-item/todo-item.presenter.test.tsx
@@ -1,5 +1,5 @@
 import { TodosContract } from "@org/contracts/api/Contracts";
-import { TodoId } from "@org/contracts/EntityIds";
+import { OrganizationId, TodoId } from "@org/contracts/EntityIds";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -8,6 +8,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { makePresenterHarness } from "@/test/presenter-harness";
 
 import { useTodoItemPresenter } from "./todo-item.presenter";
+
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 
 class TodoNotFoundError extends Data.TaggedError("TodoNotFoundError")<{
   readonly todoId: string;
@@ -34,17 +36,29 @@ const makeApiClient = (opts?: {
   todos: {
     get: () => Effect.succeed([] as ReadonlyArray<TodosContract.Todo>),
     create: () => Effect.die("not used"),
-    update: (args: { payload: TodosContract.Todo }) => {
+    // Phase 5: the path now carries orgId + id, payload only the
+    // updatable fields. Stamp the id back on so existing assertions
+    // (`.id` / `.completed`) continue to work without each test having
+    // to know the path shape.
+    update: (args: {
+      path: { orgId: OrganizationId; id: TodoId };
+      payload: { title: string; completed: boolean };
+    }) => {
+      const stamped = new TodosContract.Todo({
+        id: args.path.id,
+        title: args.payload.title,
+        completed: args.payload.completed,
+      });
       if (opts?.updateCalls !== undefined) {
-        opts.updateCalls.current = [...opts.updateCalls.current, args.payload];
+        opts.updateCalls.current = [...opts.updateCalls.current, stamped];
       }
-      return opts?.update?.(args.payload) ?? Effect.succeed(args.payload);
+      return opts?.update?.(stamped) ?? Effect.succeed(stamped);
     },
-    delete: (args: { payload: TodoId }) => {
+    delete: (args: { path: { orgId: OrganizationId; id: TodoId } }) => {
       if (opts?.deleteCalls !== undefined) {
-        opts.deleteCalls.current = [...opts.deleteCalls.current, args.payload];
+        opts.deleteCalls.current = [...opts.deleteCalls.current, args.path.id];
       }
-      return opts?.delete?.(args.payload) ?? Effect.void;
+      return opts?.delete?.(args.path.id) ?? Effect.void;
     },
   },
 });
@@ -61,7 +75,9 @@ describe("useTodoItemPresenter — toggleCompleted", () => {
     harness = makePresenterHarness({ apiClient: makeApiClient({ updateCalls }) });
     const todo = mkTodo({ completed: false });
 
-    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useTodoItemPresenter(todo, orgId), {
+      wrapper: harness.wrapper,
+    });
 
     act(() => {
       result.current.toggleCompleted();
@@ -78,7 +94,9 @@ describe("useTodoItemPresenter — toggleCompleted", () => {
     harness = makePresenterHarness({ apiClient: makeApiClient({ updateCalls }) });
     const todo = mkTodo({ completed: true });
 
-    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useTodoItemPresenter(todo, orgId), {
+      wrapper: harness.wrapper,
+    });
 
     act(() => {
       result.current.toggleCompleted();
@@ -97,7 +115,9 @@ describe("useTodoItemPresenter — deleteThis", () => {
     harness = makePresenterHarness({ apiClient: makeApiClient({ deleteCalls }) });
     const todo = mkTodo();
 
-    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useTodoItemPresenter(todo, orgId), {
+      wrapper: harness.wrapper,
+    });
 
     act(() => {
       result.current.deleteThis();
@@ -116,7 +136,9 @@ describe("useTodoItemPresenter — deleteThis", () => {
     });
     const todo = mkTodo();
 
-    const { result } = renderHook(() => useTodoItemPresenter(todo), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useTodoItemPresenter(todo, orgId), {
+      wrapper: harness.wrapper,
+    });
 
     act(() => {
       result.current.deleteThis();

--- a/packages/web/features/index/todo-item/todo-item.presenter.ts
+++ b/packages/web/features/index/todo-item/todo-item.presenter.ts
@@ -7,6 +7,7 @@
 // is testable via the presenter without rendering JSX.
 
 import type { TodosContract } from "@org/contracts/api/Contracts";
+import type { OrganizationId } from "@org/contracts/EntityIds";
 import * as React from "react";
 
 import {
@@ -14,17 +15,21 @@ import {
   useUpdateTodoMutation,
 } from "@/services/data-access/use-todos-queries";
 
-export const useTodoItemPresenter = (todo: TodosContract.Todo) => {
+export const useTodoItemPresenter = (todo: TodosContract.Todo, orgId: OrganizationId) => {
   const updateTodo = useUpdateTodoMutation();
   const deleteTodo = useDeleteTodoMutation();
 
   const toggleCompleted = React.useCallback(() => {
-    updateTodo.mutate({ ...todo, completed: !todo.completed });
-  }, [updateTodo, todo]);
+    updateTodo.mutate({
+      orgId,
+      id: todo.id,
+      payload: { title: todo.title, completed: !todo.completed },
+    });
+  }, [updateTodo, todo, orgId]);
 
   const deleteThis = React.useCallback(() => {
-    deleteTodo.mutate(todo.id);
-  }, [deleteTodo, todo.id]);
+    deleteTodo.mutate({ orgId, id: todo.id });
+  }, [deleteTodo, todo.id, orgId]);
 
   return {
     todo,

--- a/packages/web/features/index/todo-item/todo-item.tsx
+++ b/packages/web/features/index/todo-item/todo-item.tsx
@@ -5,11 +5,15 @@ import { Checkbox } from "@org/components/primitives/checkbox";
 import { TrashIcon } from "@org/components/primitives/icon";
 import { Label } from "@org/components/primitives/label";
 import type { TodosContract } from "@org/contracts/api/Contracts";
+import type { OrganizationId } from "@org/contracts/EntityIds";
 
 import { useTodoItemPresenter } from "./todo-item.presenter";
 
-export const TodoItem: React.FC<{ todo: TodosContract.Todo }> = ({ todo }) => {
-  const { deleteThis, toggleCompleted } = useTodoItemPresenter(todo);
+export const TodoItem: React.FC<{ todo: TodosContract.Todo; orgId: OrganizationId }> = ({
+  orgId,
+  todo,
+}) => {
+  const { deleteThis, toggleCompleted } = useTodoItemPresenter(todo, orgId);
 
   return (
     <li

--- a/packages/web/features/index/todo-list.presenter.test.tsx
+++ b/packages/web/features/index/todo-list.presenter.test.tsx
@@ -1,5 +1,5 @@
 import { TodosContract } from "@org/contracts/api/Contracts";
-import { TodoId } from "@org/contracts/EntityIds";
+import { OrganizationId, TodoId } from "@org/contracts/EntityIds";
 import { renderHook, waitFor } from "@testing-library/react";
 import * as Effect from "effect/Effect";
 import { afterEach, describe, expect, it } from "vitest";
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { makePresenterHarness } from "@/test/presenter-harness";
 
 import { useTodoListPresenter } from "./todo-list.presenter";
+
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 
 const mkTodo = (i: number): TodosContract.Todo =>
   new TodosContract.Todo({
@@ -33,7 +35,7 @@ afterEach(async () => {
 describe("useTodoListPresenter", () => {
   it("reports isEmpty=true when no todos are returned", async () => {
     harness = makePresenterHarness({ apiClient: makeApiClient([]) });
-    const { result } = renderHook(() => useTodoListPresenter(), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useTodoListPresenter(orgId), { wrapper: harness.wrapper });
     await waitFor(() => {
       expect(result.current.todos).toEqual([]);
     });
@@ -43,7 +45,7 @@ describe("useTodoListPresenter", () => {
   it("exposes the loaded todos and isEmpty=false when populated", async () => {
     const todos = [mkTodo(1), mkTodo(2)];
     harness = makePresenterHarness({ apiClient: makeApiClient(todos) });
-    const { result } = renderHook(() => useTodoListPresenter(), { wrapper: harness.wrapper });
+    const { result } = renderHook(() => useTodoListPresenter(orgId), { wrapper: harness.wrapper });
     await waitFor(() => {
       expect(result.current.todos.length).toBe(2);
     });

--- a/packages/web/features/index/todo-list.presenter.ts
+++ b/packages/web/features/index/todo-list.presenter.ts
@@ -3,9 +3,11 @@
 // Presenter for TodoList (ADR-0014 Tier 2). Owns the suspense-query
 // call and the empty-vs-populated split so the view file is pure JSX.
 
+import type { OrganizationId } from "@org/contracts/EntityIds";
+
 import { useTodosSuspenseQuery } from "@/services/data-access/use-todos-queries";
 
-export const useTodoListPresenter = () => {
-  const { data: todos } = useTodosSuspenseQuery();
-  return { todos, isEmpty: todos.length === 0 };
+export const useTodoListPresenter = (orgId: OrganizationId) => {
+  const { data: todos } = useTodosSuspenseQuery(orgId);
+  return { todos, isEmpty: todos.length === 0, orgId };
 };

--- a/packages/web/features/index/todo-list.tsx
+++ b/packages/web/features/index/todo-list.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import type { OrganizationId } from "@org/contracts/EntityIds";
 import * as Array from "effect/Array";
 
 import { TodoItem } from "./todo-item/todo-item";
 import { useTodoListPresenter } from "./todo-list.presenter";
 
-export const TodoList: React.FC = () => {
-  const { isEmpty, todos } = useTodoListPresenter();
+export const TodoList: React.FC<{ orgId: OrganizationId }> = ({ orgId }) => {
+  const { isEmpty, todos } = useTodoListPresenter(orgId);
 
   if (isEmpty) {
     return (
@@ -19,7 +20,7 @@ export const TodoList: React.FC = () => {
   return (
     <ul className="space-y-2" data-testid="todo-list">
       {Array.map(todos, (todo) => (
-        <TodoItem key={todo.id} todo={todo} />
+        <TodoItem key={todo.id} todo={todo} orgId={orgId} />
       ))}
     </ul>
   );

--- a/packages/web/services/data-access/primary-org.server.ts
+++ b/packages/web/services/data-access/primary-org.server.ts
@@ -1,0 +1,35 @@
+// Server-only: resolve the caller's primary organization id, creating
+// a default org if they have none yet.
+//
+// Bridge for Phase 5. The contract is now org-scoped (`/orgs/:orgId/todos`)
+// but the frontend doesn't have an org-aware route surface yet —
+// that's Phase 8. Until then, the (authed) page treats the caller's
+// first organization as the implicit working org; on first sign-in
+// the server creates "My Workspace" so the todos UI has somewhere to
+// land. When Phase 8 introduces `/orgs/[orgId]/todos`, this helper
+// goes away and orgId comes from the URL segment instead.
+
+import "server-only";
+
+import type { OrganizationId } from "@org/contracts/EntityIds";
+import * as Effect from "effect/Effect";
+
+import { ApiClient } from "@/services/api-client.shared";
+import { getServerRuntime } from "@/services/runtime.server";
+
+const DEFAULT_ORG_NAME = "My Workspace";
+
+export const ensurePrimaryOrgId = async (): Promise<OrganizationId> => {
+  const runtime = await getServerRuntime();
+  return runtime.runPromise(
+    Effect.gen(function* () {
+      const { client } = yield* ApiClient;
+      const mine = yield* client.organization.findMine();
+      if (mine.length > 0) return mine[0].id;
+      const created = yield* client.organization.create({
+        payload: { name: DEFAULT_ORG_NAME },
+      });
+      return created.id;
+    }),
+  );
+};

--- a/packages/web/services/data-access/todos-queries.server.ts
+++ b/packages/web/services/data-access/todos-queries.server.ts
@@ -6,9 +6,11 @@
 
 import "server-only";
 
+import type { OrganizationId } from "@org/contracts/EntityIds";
+
 import { prefetchEffectQuery } from "@/lib/tanstack-query/effect-prefetch.server";
 
 import { todosQuery, todosQueryKey } from "./todos-queries";
 
-export const prefetchTodos = (): Promise<void> =>
-  prefetchEffectQuery({ queryKey: todosQueryKey(), queryFn: todosQuery });
+export const prefetchTodos = (orgId: OrganizationId): Promise<void> =>
+  prefetchEffectQuery({ queryKey: todosQueryKey({ orgId }), queryFn: todosQuery(orgId) });

--- a/packages/web/services/data-access/todos-queries.ts
+++ b/packages/web/services/data-access/todos-queries.ts
@@ -4,36 +4,51 @@
 // and client components (transitively, via use-todos-queries.ts
 // which adds the suspense + mutation hooks).
 //
+// Every operation is org-scoped (Phase 5): the contract paths are
+// `/orgs/:orgId/todos[/:id]`, so `orgId` is required up front. The
+// query key includes it so two orgs don't share a cache slot.
+//
 // Mutations chain `todosHelpers.invalidateAllQueries()` so the read
-// cache refreshes after writes. The helper depends on `QueryClient`
-// (provided by the client runtime); on the server we don't run
-// mutations, so the helper's R is satisfied only client-side.
+// cache refreshes after writes (across all per-org keys in the
+// namespace). The helper depends on `QueryClient` (provided by the
+// client runtime); on the server we don't run mutations, so the
+// helper's R is satisfied only client-side.
 
 import type { TodosContract } from "@org/contracts/api/Contracts";
-import type { TodoId } from "@org/contracts/EntityIds";
+import type { OrganizationId, TodoId } from "@org/contracts/EntityIds";
 import * as Effect from "effect/Effect";
 
 import { QueryData } from "@/lib/tanstack-query";
 import { ApiClient } from "@/services/api-client.shared";
 
-const todosKey = QueryData.makeQueryKey("todos");
-const todosHelpers = QueryData.makeHelpers<Array<TodosContract.Todo>>(todosKey);
+type TodosKeyVars = { readonly orgId: OrganizationId };
+
+const todosKey = QueryData.makeQueryKey<"todos", TodosKeyVars>("todos");
+const todosHelpers = QueryData.makeHelpers<Array<TodosContract.Todo>, TodosKeyVars>(todosKey);
 
 export const todosQueryKey = todosKey;
 
-export const todosQuery = Effect.flatMap(ApiClient, ({ client }) => client.todos.get());
+export const todosQuery = (orgId: OrganizationId) =>
+  Effect.flatMap(ApiClient, ({ client }) => client.todos.get({ path: { orgId } }));
 
-export const createTodo = (todo: TodosContract.CreateTodoPayload) =>
-  Effect.flatMap(ApiClient, ({ client }) => client.todos.create({ payload: todo })).pipe(
-    Effect.tap(() => todosHelpers.invalidateAllQueries()),
-  );
+export const createTodo = (args: {
+  readonly orgId: OrganizationId;
+  readonly payload: TodosContract.CreateTodoPayload;
+}) =>
+  Effect.flatMap(ApiClient, ({ client }) =>
+    client.todos.create({ path: { orgId: args.orgId }, payload: args.payload }),
+  ).pipe(Effect.tap(() => todosHelpers.invalidateAllQueries()));
 
-export const updateTodo = (todo: TodosContract.Todo) =>
-  Effect.flatMap(ApiClient, ({ client }) => client.todos.update({ payload: todo })).pipe(
-    Effect.tap(() => todosHelpers.invalidateAllQueries()),
-  );
+export const updateTodo = (args: {
+  readonly orgId: OrganizationId;
+  readonly id: TodoId;
+  readonly payload: TodosContract.UpdateTodoPayload;
+}) =>
+  Effect.flatMap(ApiClient, ({ client }) =>
+    client.todos.update({ path: { orgId: args.orgId, id: args.id }, payload: args.payload }),
+  ).pipe(Effect.tap(() => todosHelpers.invalidateAllQueries()));
 
-export const deleteTodo = (id: TodoId) =>
-  Effect.flatMap(ApiClient, ({ client }) => client.todos.delete({ payload: id })).pipe(
-    Effect.tap(() => todosHelpers.invalidateAllQueries()),
-  );
+export const deleteTodo = (args: { readonly orgId: OrganizationId; readonly id: TodoId }) =>
+  Effect.flatMap(ApiClient, ({ client }) =>
+    client.todos.delete({ path: { orgId: args.orgId, id: args.id } }),
+  ).pipe(Effect.tap(() => todosHelpers.invalidateAllQueries()));

--- a/packages/web/services/data-access/use-todos-queries.ts
+++ b/packages/web/services/data-access/use-todos-queries.ts
@@ -4,15 +4,23 @@
 // todos-queries.ts with `useEffectSuspenseQuery` (read) and
 // `useEffectMutation` (writes). Mutations toast on success and use
 // the same in-flight feedback the existing SPA used.
+//
+// The read hook takes `orgId` to key the cache per org and to pass
+// through to the underlying contract path. Mutations stay
+// orgId-agnostic at the hook level — the caller hands the orgId in
+// at `mutate({ orgId, … })` time, the same shape the underlying
+// Effect functions accept.
+
+import type { OrganizationId } from "@org/contracts/EntityIds";
 
 import { useEffectMutation, useEffectSuspenseQuery } from "@/lib/tanstack-query";
 
 import { createTodo, deleteTodo, todosQuery, todosQueryKey, updateTodo } from "./todos-queries";
 
-export const useTodosSuspenseQuery = () =>
+export const useTodosSuspenseQuery = (orgId: OrganizationId) =>
   useEffectSuspenseQuery({
-    queryKey: todosQueryKey(),
-    queryFn: () => todosQuery,
+    queryKey: todosQueryKey({ orgId }),
+    queryFn: () => todosQuery(orgId),
   });
 
 export const useCreateTodoMutation = () =>


### PR DESCRIPTION
Phase 5 of the organizations/subscriptions arc. Todos become multi-tenant: every todo belongs to an organization, endpoints move under `/orgs/:orgId/todos`, and a caller may touch a todo only if they're a member of that org (super-admin bypasses).

## Schema + domain
- Migration `V017` adds `todos.organization_id` with a cross-schema FK to `organization.organizations` (ADR-0021 wallet→user precedent) and an index. `TodoRow` gains the column.
- The `Todo` aggregate, repository port, mapper, live + fake repo all org-scope every read/mutate: `findById` / `update` / `remove` key on `(orgId, todoId)`, so a cross-tenant row reads as `TodoNotFound` rather than leaking.
- Commands (`create`/`update`/`delete`) and the list query carry `organizationId`.

## Contract + endpoints
- `TodosContract` moves to `/orgs/:orgId/todos[/:id]`; each endpoint adds `CustomHttpApiError.Forbidden` to its channel.
- Cross-tenant update/delete surfaces `TodoNotFoundError`; a non-member surfaces `403 Forbidden`.

## Authz model — two resources
Picked Path Q from planning and split the todo resource by what's being acted on:
- **`todoCollection`** (keyed by `OrganizationId`, *echo* resolver) gates `list` and the flat `create` check. The collection's identity *is* the org, so the echo resolver is honest — there's nothing to load, and a non-member must not learn whether the org exists.
- **`todo`** (keyed by `(orgId, todoId)`, *loading* resolver) gates `update` and `delete`. The resolver loads the row scoped to the org and surfaces a real `NotFound` → `TodoNotFoundError`. Tenant isolation is folded into authz, not just at the repo.

## Membership delegation
`MembershipServiceLive` (org module) is rerouted through the **query bus** via a new org-module `FindMembershipQuery` — mirrors `RoleServiceLive`. The cross-module membership lookup is now an explicit query against the org module (the single source of truth), and the platform ACL stays the only surface consuming policies see.

## Reusable membership check (platform factory)
`platform/auth/policies/is-org-member.ts` exposes `makeIsOrgMember<R>(getOrgId): ResourceCheck<R>`. The lookup is uniform across consumers (every module asks the identical `isMember` question), so it stays centralized over the platform `MembershipService` ACL. The only module-specific bit is the resource→orgId extraction, supplied by the consumer. Mirrors `SuperAdminOnly` (a platform check over a platform ACL, reused across modules).

`organization/policies/is-member.ts` and `todos/policies/is-todo-org-member.ts` collapse to one-liners that just hand the factory their extractor — no duplicated lookup logic.

## Tests
- Repo + query integration tests seed two orgs, assert cross-tenant `findById`/`update`/`remove` return `TodoNotFound`, and the list query only returns the requested org's rows.
- Endpoint integration tests use `useServerTestRuntime` + `seedSuperAdminCaller` for happy-path CRUD, and `TestServerLiveAsMember` for the 403 non-member case. Update/delete also assert cross-tenant 404.
- `find-membership` query has a sibling unit test (query parity); `is-todo-org-member` check has a unit test exercising the membership branch.

## Verification
- `pnpm check`, `pnpm lint`, `pnpm lint:deps`, `pnpm lint:tests` — all clean.
- `DATABASE_URL_TEST=… pnpm test` — **437 / 437 pass**, including all new cross-tenant isolation assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)