### PR TITLE
feat(cli/mcp): CLI + MCP clients with app-native device auth & API tokens

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@org/api-client",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Shared typed client (over CliApi) + credential store for the CLI and MCP server.",
+  "scripts": {
+    "check": "tsc -b tsconfig.json",
+    "clean": "rm -rf build .tsbuildinfo",
+    "build": "tsc -b tsconfig.build.json",
+    "lint": "eslint . --quiet",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@effect/platform": "*",
+    "@org/contracts": "workspace:^",
+    "effect": "^3.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  }
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,0 +1,24 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import { CliApi } from "@org/contracts/CliApi";
+
+// Builds the typed client over `CliApi` (ADR-0024). When a token is present
+// it's injected as `Authorization: Bearer …`; the device-auth endpoints are
+// public, so a tokenless client is valid for `auth login`.
+//
+// Returns an Effect requiring `HttpClient` — the caller provides the
+// transport (the CLI/MCP wire `FetchHttpClient.layer`).
+export const makeCliClient = (opts: { readonly baseUrl: string; readonly token: string | null }) =>
+  HttpApiClient.make(CliApi, {
+    baseUrl: opts.baseUrl,
+    transformClient:
+      opts.token === null
+        ? undefined
+        : (client) =>
+            client.pipe(
+              HttpClient.mapRequest(
+                HttpClientRequest.setHeader("Authorization", `Bearer ${opts.token}`),
+              ),
+            ),
+  });

--- a/packages/api-client/src/config.ts
+++ b/packages/api-client/src/config.ts
@@ -1,0 +1,10 @@
+// Runtime config resolved from the environment. The CLI/MCP point at a
+// deployed server via `APP_API_URL`; the default targets the local BFF.
+export const resolveBaseUrl = (): string => process.env.APP_API_URL ?? "http://localhost:3001";
+
+// CI/headless override: a pre-minted PAT in the environment wins over any
+// stored credential, so pipelines need no `auth login` and no on-disk state.
+export const tokenFromEnv = (): string | null => {
+  const fromEnv = process.env.APP_API_TOKEN;
+  return fromEnv !== undefined && fromEnv.length > 0 ? fromEnv : null;
+};

--- a/packages/api-client/src/credentials.ts
+++ b/packages/api-client/src/credentials.ts
@@ -1,0 +1,69 @@
+import { homedir } from "node:os";
+
+import * as FileSystem from "@effect/platform/FileSystem";
+import * as Path from "@effect/platform/Path";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { tokenFromEnv } from "./config.js";
+
+// On-disk credential file: `$XDG_CONFIG_HOME/org-cli/credentials.json`
+// (falls back to `~/.config`). Holds the device-flow / pasted token and an
+// optional default org so todo commands don't need `--org` every time.
+const CONFIG_DIR = "org-cli";
+const FILE_NAME = "credentials.json";
+
+export class Credentials extends Schema.Class<Credentials>("Credentials")({
+  token: Schema.optional(Schema.String),
+  defaultOrgId: Schema.optional(Schema.String),
+}) {}
+
+const empty = Credentials.make({});
+
+const credentialsPath = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  const base = process.env.XDG_CONFIG_HOME ?? path.join(homedir(), ".config");
+  return path.join(base, CONFIG_DIR, FILE_NAME);
+});
+
+const decode = Schema.decodeUnknown(Schema.parseJson(Credentials));
+
+// Missing or unparseable file → empty credentials (first run, or a stale
+// hand-edit shouldn't crash the CLI). Genuine FS errors are defects.
+export const readCredentials: Effect.Effect<Credentials, never, FileSystem.FileSystem | Path.Path> =
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const file = yield* credentialsPath;
+    if (!(yield* fs.exists(file))) return empty;
+    const raw = yield* fs.readFileString(file);
+    return yield* decode(raw).pipe(Effect.orElseSucceed(() => empty));
+  }).pipe(Effect.orDie);
+
+const writeCredentials = (
+  creds: Credentials,
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const file = yield* credentialsPath;
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    yield* fs.writeFileString(file, `${JSON.stringify(creds, null, 2)}\n`);
+    // Token is a bearer secret — keep the file owner-only.
+    yield* fs.chmod(file, 0o600);
+  }).pipe(Effect.orDie);
+
+export const saveToken = (token: string) =>
+  Effect.flatMap(readCredentials, (c) => writeCredentials(Credentials.make({ ...c, token })));
+
+export const clearToken = Effect.flatMap(readCredentials, (c) =>
+  writeCredentials(Credentials.make({ defaultOrgId: c.defaultOrgId })),
+);
+
+export const saveDefaultOrg = (defaultOrgId: string) =>
+  Effect.flatMap(readCredentials, (c) =>
+    writeCredentials(Credentials.make({ ...c, defaultOrgId })),
+  );
+
+// Env token (CI) wins over the stored one; null when neither is set.
+export const resolveToken = (creds: Credentials): string | null =>
+  tokenFromEnv() ?? creds.token ?? null;

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,10 @@
+export { makeCliClient } from "./client.js";
+export { resolveBaseUrl, tokenFromEnv } from "./config.js";
+export {
+  clearToken,
+  Credentials,
+  readCredentials,
+  resolveToken,
+  saveDefaultOrg,
+  saveToken,
+} from "./credentials.js";

--- a/packages/api-client/tsconfig.build.json
+++ b/packages/api-client/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true,
+    "composite": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  },
+  "references": [{ "path": "tsconfig.src.json" }]
+}

--- a/packages/api-client/tsconfig.src.json
+++ b/packages/api-client/tsconfig.src.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
+  "references": [{ "path": "../contracts" }],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "build/src",
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@org/cli",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Command-line client for the effect-monorepo: device-flow auth, organizations, todos.",
+  "bin": {
+    "org": "build/esm/main.js"
+  },
+  "scripts": {
+    "check": "tsc -b tsconfig.json",
+    "clean": "rm -rf build .tsbuildinfo",
+    "build": "tsc -b tsconfig.build.json",
+    "dev": "tsx src/main.ts",
+    "start": "node build/esm/main.js",
+    "lint": "eslint . --quiet",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@effect/cli": "0.75.2",
+    "@effect/platform": "*",
+    "@effect/platform-node": "*",
+    "@effect/printer": "0.49.0",
+    "@effect/printer-ansi": "0.49.0",
+    "@org/api-client": "workspace:^",
+    "@org/contracts": "workspace:^",
+    "effect": "^3.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.19.2"
+  }
+}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,111 @@
+import * as Command from "@effect/cli/Command";
+import * as Options from "@effect/cli/Options";
+import {
+  clearToken,
+  makeCliClient,
+  readCredentials,
+  resolveBaseUrl,
+  resolveToken,
+  saveToken,
+} from "@org/api-client";
+import * as Console from "effect/Console";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
+
+import { CliError, maskToken, openBrowser, toCliError } from "../internal.js";
+
+// `auth login [--with-token <pat>]`
+//   - with a token: store it (CI / paste path) and validate it.
+//   - without: run the app-native device flow (RFC 8628) — print + open the
+//     verification URL, then poll until the browser approves.
+const withTokenOption = Options.text("with-token").pipe(
+  Options.optional,
+  Options.withDescription("Store a pre-minted personal access token instead of the device flow"),
+);
+
+const validate = (token: string) =>
+  Effect.flatMap(makeCliClient({ baseUrl: resolveBaseUrl(), token }), (client) =>
+    client.cliOrganization.listMine(),
+  );
+
+const login = Command.make("login", { withToken: withTokenOption }, ({ withToken }) =>
+  Effect.gen(function* () {
+    if (Option.isSome(withToken)) {
+      yield* validate(withToken.value);
+      yield* saveToken(withToken.value);
+      yield* Console.log("✓ Token stored and verified.");
+      return;
+    }
+
+    const client = yield* makeCliClient({ baseUrl: resolveBaseUrl(), token: null });
+    const start = yield* client.cliAuth.deviceStart();
+    yield* Console.log(
+      [
+        "",
+        "To sign in, open this URL in your browser:",
+        "",
+        `  ${start.verification_uri_complete}`,
+        "",
+        `and confirm the code:  ${start.user_code}`,
+        "",
+        "Waiting for approval…",
+      ].join("\n"),
+    );
+    yield* openBrowser(start.verification_uri_complete);
+
+    // Poll the token endpoint; keep retrying while the grant is pending,
+    // bounded by the grant's own lifetime.
+    const token = yield* client.cliAuth
+      .deviceToken({ payload: { device_code: start.device_code } })
+      .pipe(
+        Effect.retry({
+          while: (error) => error._tag === "DeviceAuthorizationPending",
+          schedule: Schedule.spaced(Duration.seconds(start.interval)),
+        }),
+        Effect.timeoutFail({
+          duration: Duration.seconds(start.expires_in + 5),
+          onTimeout: () =>
+            new CliError({ message: "Timed out waiting for device approval. Try again." }),
+        }),
+      );
+
+    yield* saveToken(token.access_token);
+    yield* Console.log("✓ Authenticated! You're signed in.");
+  }).pipe(Effect.catchAll((error) => Effect.fail(toCliError(error)))),
+);
+
+const status = Command.make("status", {}, () =>
+  Effect.gen(function* () {
+    const creds = yield* readCredentials;
+    const token = resolveToken(creds);
+    if (token === null) {
+      yield* Console.log("Not authenticated. Run `org auth login`.");
+      return;
+    }
+    const client = yield* makeCliClient({ baseUrl: resolveBaseUrl(), token });
+    yield* client.cliOrganization.listMine().pipe(
+      Effect.matchEffect({
+        onSuccess: () => Console.log(`Authenticated (token ${maskToken(token)}).`),
+        onFailure: (error) =>
+          error._tag === "Unauthorized"
+            ? Console.log("Token is invalid or expired. Run `org auth login`.")
+            : Effect.fail(toCliError(error)),
+      }),
+    );
+  }),
+);
+
+const logout = Command.make("logout", {}, () =>
+  Effect.gen(function* () {
+    yield* clearToken;
+    yield* Console.log(
+      "Logged out — local credentials cleared. The token stays valid server-side until it expires; revoke it in the web UI to invalidate immediately.",
+    );
+  }),
+);
+
+export const authCommand = Command.make("auth", {}, () =>
+  Console.log("Usage: org auth <login|status|logout>"),
+).pipe(Command.withSubcommands([login, status, logout]));

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,18 @@
+import * as Args from "@effect/cli/Args";
+import * as Command from "@effect/cli/Command";
+import { saveDefaultOrg } from "@org/api-client";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+
+const orgIdArg = Args.text({ name: "orgId" });
+
+const setOrg = Command.make("set-org", { orgId: orgIdArg }, ({ orgId }) =>
+  Effect.gen(function* () {
+    yield* saveDefaultOrg(orgId);
+    yield* Console.log(`Default organization set to ${orgId}.`);
+  }),
+);
+
+export const configCommand = Command.make("config", {}, () =>
+  Console.log("Usage: org config set-org <orgId>"),
+).pipe(Command.withSubcommands([setOrg]));

--- a/packages/cli/src/commands/orgs.ts
+++ b/packages/cli/src/commands/orgs.ts
@@ -1,0 +1,23 @@
+import * as Command from "@effect/cli/Command";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+
+import { authedClient, toCliError } from "../internal.js";
+
+const list = Command.make("list", {}, () =>
+  Effect.gen(function* () {
+    const client = yield* authedClient;
+    const orgs = yield* client.cliOrganization.listMine();
+    if (orgs.length === 0) {
+      yield* Console.log("(no organizations)");
+      return;
+    }
+    for (const org of orgs) {
+      yield* Console.log(`${org.id}  ${org.name}${org.isAdmin ? "  (admin)" : ""}`);
+    }
+  }).pipe(Effect.catchAll((error) => Effect.fail(toCliError(error)))),
+);
+
+export const orgsCommand = Command.make("orgs", {}, () => Console.log("Usage: org orgs list")).pipe(
+  Command.withSubcommands([list]),
+);

--- a/packages/cli/src/commands/todos.ts
+++ b/packages/cli/src/commands/todos.ts
@@ -1,0 +1,63 @@
+import * as Args from "@effect/cli/Args";
+import * as Command from "@effect/cli/Command";
+import * as Options from "@effect/cli/Options";
+import { OrganizationId, TodoId } from "@org/contracts/EntityIds";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+
+import { authedClient, resolveOrg, toCliError } from "../internal.js";
+
+const orgOption = Options.text("org").pipe(
+  Options.optional,
+  Options.withAlias("o"),
+  Options.withDescription("Organization id (defaults to the configured org)"),
+);
+
+const titleArg = Args.text({ name: "title" });
+const todoIdArg = Args.text({ name: "todoId" });
+
+const list = Command.make("list", { org: orgOption }, ({ org }) =>
+  Effect.gen(function* () {
+    const client = yield* authedClient;
+    const orgId = OrganizationId.make(yield* resolveOrg(org));
+    const todos = yield* client.cliTodos.list({ path: { orgId } });
+    if (todos.length === 0) {
+      yield* Console.log("(no todos)");
+      return;
+    }
+    for (const todo of todos) {
+      yield* Console.log(`${todo.completed ? "[x]" : "[ ]"} ${todo.id}  ${todo.title}`);
+    }
+  }).pipe(Effect.catchAll((error) => Effect.fail(toCliError(error)))),
+);
+
+const create = Command.make("create", { org: orgOption, title: titleArg }, ({ org, title }) =>
+  Effect.gen(function* () {
+    const client = yield* authedClient;
+    const orgId = OrganizationId.make(yield* resolveOrg(org));
+    const todo = yield* client.cliTodos.create({ path: { orgId }, payload: { title } });
+    yield* Console.log(`Created ${todo.id}: ${todo.title}`);
+  }).pipe(Effect.catchAll((error) => Effect.fail(toCliError(error)))),
+);
+
+const complete = Command.make("complete", { org: orgOption, id: todoIdArg }, ({ id, org }) =>
+  Effect.gen(function* () {
+    const client = yield* authedClient;
+    const orgId = OrganizationId.make(yield* resolveOrg(org));
+    const todo = yield* client.cliTodos.complete({ path: { orgId, id: TodoId.make(id) } });
+    yield* Console.log(`Completed ${todo.id}: ${todo.title}`);
+  }).pipe(Effect.catchAll((error) => Effect.fail(toCliError(error)))),
+);
+
+const remove = Command.make("remove", { org: orgOption, id: todoIdArg }, ({ id, org }) =>
+  Effect.gen(function* () {
+    const client = yield* authedClient;
+    const orgId = OrganizationId.make(yield* resolveOrg(org));
+    yield* client.cliTodos.remove({ path: { orgId, id: TodoId.make(id) } });
+    yield* Console.log(`Removed ${id}.`);
+  }).pipe(Effect.catchAll((error) => Effect.fail(toCliError(error)))),
+);
+
+export const todosCommand = Command.make("todos", {}, () =>
+  Console.log("Usage: org todos <list|create|complete|remove>"),
+).pipe(Command.withSubcommands([list, create, complete, remove]));

--- a/packages/cli/src/internal.ts
+++ b/packages/cli/src/internal.ts
@@ -1,0 +1,93 @@
+import { spawn } from "node:child_process";
+
+import { makeCliClient, readCredentials, resolveBaseUrl, resolveToken } from "@org/api-client";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+// The CLI's user-facing failure. Everything fatal is funnelled here so the
+// entrypoint can print one clean line and exit non-zero (no stack dump).
+export class CliError extends Data.TaggedError("CliError")<{ readonly message: string }> {}
+
+// Builds an authenticated CLI client from the stored/env token, or fails with
+// a friendly nudge to sign in.
+export const authedClient = Effect.gen(function* () {
+  const creds = yield* readCredentials;
+  const token = resolveToken(creds);
+  if (token === null) {
+    return yield* Effect.fail(
+      new CliError({
+        message: "Not authenticated. Run `org auth login`, or set APP_API_TOKEN.",
+      }),
+    );
+  }
+  return yield* makeCliClient({ baseUrl: resolveBaseUrl(), token });
+});
+
+// Resolves the org id from an explicit `--org` flag, else the configured
+// default, else fails.
+export const resolveOrg = (explicit: Option.Option<string>) =>
+  Effect.gen(function* () {
+    if (Option.isSome(explicit)) return explicit.value;
+    const creds = yield* readCredentials;
+    if (creds.defaultOrgId !== undefined) return creds.defaultOrgId;
+    return yield* Effect.fail(
+      new CliError({
+        message: "No organization selected. Pass --org <id> or run `org config set-org <id>`.",
+      }),
+    );
+  });
+
+// Best-effort: open the verification URL in the user's browser. Failure is
+// fine — the URL is also printed. Skipped in headless/CI contexts
+// (`NO_BROWSER=1` or `CI` set) so automation doesn't spawn a browser.
+export const openBrowser = (url: string) =>
+  Effect.try(() => {
+    if (process.env.NO_BROWSER === "1" || (process.env.CI ?? "") !== "") return;
+    const opener =
+      process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+    const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+    spawn(opener, args, { stdio: "ignore", detached: true }).unref();
+  }).pipe(Effect.ignore);
+
+// Show enough of a token to recognise it, never the whole secret.
+export const maskToken = (token: string): string =>
+  token.length <= 16 ? `${token.slice(0, 4)}…` : `${token.slice(0, 12)}…${token.slice(-4)}`;
+
+// Maps any wire/domain failure to a single friendly `CliError`. Wrap a
+// command's body with `Effect.catchAll(toCliError)` so the entrypoint only
+// ever sees `CliError`.
+export const toCliError = (error: unknown): CliError => {
+  if (error instanceof CliError) return error;
+  const tag =
+    typeof error === "object" && error !== null && "_tag" in error
+      ? String((error as { readonly _tag: unknown })._tag)
+      : "";
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { readonly message: unknown }).message)
+      : "";
+  switch (tag) {
+    case "Unauthorized":
+      return new CliError({
+        message: "Not authorized — your token may be invalid or expired. Run `org auth login`.",
+      });
+    case "Forbidden":
+      return new CliError({ message: "You don't have access to that organization or resource." });
+    case "ServiceUnavailable":
+      return new CliError({ message: "The server is temporarily unavailable. Try again shortly." });
+    case "CliTodoNotFoundError":
+      return new CliError({ message: message.length > 0 ? message : "Todo not found." });
+    case "DeviceTokenExpired":
+      return new CliError({
+        message: "The device code expired before approval. Run `org auth login` again.",
+      });
+    case "DeviceCodeNotFound":
+      return new CliError({ message: "That device code is invalid. Run `org auth login` again." });
+    case "RequestError":
+    case "ResponseError":
+      return new CliError({ message: `Could not reach the server at ${resolveBaseUrl()}.` });
+    default:
+      return new CliError({ message: tag.length > 0 ? `Request failed (${tag}).` : String(error) });
+  }
+};

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import * as Command from "@effect/cli/Command";
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import * as NodeContext from "@effect/platform-node/NodeContext";
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { authCommand } from "./commands/auth.js";
+import { configCommand } from "./commands/config.js";
+import { orgsCommand } from "./commands/orgs.js";
+import { todosCommand } from "./commands/todos.js";
+import type { CliError } from "./internal.js";
+
+const root = Command.make("org", {}, () =>
+  Console.log("Run `org --help` to see available commands."),
+).pipe(Command.withSubcommands([authCommand, orgsCommand, todosCommand, configCommand]));
+
+const run = Command.run(root, {
+  name: "org — effect-monorepo CLI",
+  version: "0.0.0",
+});
+
+run(process.argv).pipe(
+  // Commands funnel fatal failures to `CliError`; print one clean line and
+  // exit non-zero. @effect/cli's own help / validation handling is untouched.
+  Effect.catchTag("CliError", (error: CliError) =>
+    Console.error(error.message).pipe(Effect.zipRight(Effect.sync(() => (process.exitCode = 1)))),
+  ),
+  Effect.provide(Layer.mergeAll(NodeContext.layer, FetchHttpClient.layer)),
+  NodeRuntime.runMain,
+);

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true,
+    "composite": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@org/api-client": ["../api-client/src/index.js"],
+      "@org/api-client/*": ["../api-client/src/*.js"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  },
+  "references": [{ "path": "tsconfig.src.json" }]
+}

--- a/packages/cli/tsconfig.src.json
+++ b/packages/cli/tsconfig.src.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
+  "references": [{ "path": "../api-client" }, { "path": "../contracts" }],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "build/src",
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@org/api-client": ["../api-client/src/index.js"],
+      "@org/api-client/*": ["../api-client/src/*.js"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  }
+}

--- a/packages/contracts/src/CliApi.ts
+++ b/packages/contracts/src/CliApi.ts
@@ -1,0 +1,14 @@
+import * as HttpApi from "@effect/platform/HttpApi";
+
+import * as CliAuthContract from "./api/CliAuthContract.js";
+import * as CliOrganizationContract from "./api/CliOrganizationContract.js";
+import * as CliTodosContract from "./api/CliTodosContract.js";
+
+// The CLI/MCP wire surface, decoupled from the GUI's `DomainApi` (ADR-0024).
+// Served by the same server under a `/cli` prefix; its endpoint adapters live
+// in each module's `interface/cli/` and dispatch to the same command/query
+// bus handlers the GUI's `interface/http/` adapters use.
+export class CliApi extends HttpApi.make("cli")
+  .add(CliAuthContract.DeviceGroup)
+  .add(CliOrganizationContract.Group)
+  .add(CliTodosContract.Group) {}

--- a/packages/contracts/src/DomainApi.ts
+++ b/packages/contracts/src/DomainApi.ts
@@ -14,5 +14,7 @@ export class DomainApi extends HttpApi.make("domain")
   .add(OrganizationContract.InvitationGroup)
   .add(AuthContract.PublicGroup)
   .add(AuthContract.PrivateGroup)
+  .add(AuthContract.TokensGroup)
+  .add(AuthContract.DeviceApprovalGroup)
   .add(BillingContract.PrivateGroup)
   .add(BillingContract.PublicGroup) {}

--- a/packages/contracts/src/EntityIds.ts
+++ b/packages/contracts/src/EntityIds.ts
@@ -14,3 +14,6 @@ export type InvitationId = typeof InvitationId.Type;
 
 export const SubscriptionId = Schema.String.pipe(Schema.brand("SubscriptionId"));
 export type SubscriptionId = typeof SubscriptionId.Type;
+
+export const ApiTokenId = Schema.String.pipe(Schema.brand("ApiTokenId"));
+export type ApiTokenId = typeof ApiTokenId.Type;

--- a/packages/contracts/src/api/AuthContract.ts
+++ b/packages/contracts/src/api/AuthContract.ts
@@ -3,7 +3,7 @@ import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
 import * as Schema from "effect/Schema";
 
 import * as CustomHttpApiError from "../CustomHttpApiError.js";
-import { UserId } from "../EntityIds.js";
+import { ApiTokenId, UserId } from "../EntityIds.js";
 import { UserAuthMiddleware } from "../Policy.js";
 
 // ==========================================
@@ -64,3 +64,81 @@ export class PrivateGroup extends HttpApiGroup.make("authSession")
   // Group-wide 503 surface — see UserContract for rationale.
   .addError(CustomHttpApiError.ServiceUnavailable)
   .prefix("/auth") {}
+
+// ==========================================
+// API tokens: GUI-managed personal access tokens (ADR-0024)
+// ==========================================
+
+// Owner-facing summary of an active token. Carries no secret — `prefix` is
+// the non-secret display fragment shown so an owner can tell tokens apart.
+export class ApiTokenSummary extends Schema.Class<ApiTokenSummary>("ApiTokenSummary")({
+  id: ApiTokenId,
+  label: Schema.String,
+  prefix: Schema.String,
+  expiresAt: Schema.NullOr(Schema.DateTimeUtc),
+  createdAt: Schema.DateTimeUtc,
+  lastUsedAt: Schema.DateTimeUtc,
+}) {}
+
+export class CreateApiTokenPayload extends Schema.Class<CreateApiTokenPayload>(
+  "CreateApiTokenPayload",
+)({
+  label: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(255)),
+  // Days until the token expires. Optional — the server falls back to its
+  // configured default. Capped to keep CI tokens from living forever.
+  expiresInDays: Schema.optional(
+    Schema.Int.pipe(Schema.greaterThanOrEqualTo(1), Schema.lessThanOrEqualTo(3650)),
+  ),
+}) {}
+
+// The plaintext `token` is returned exactly once at creation and never again.
+export class CreateApiTokenResponse extends Schema.Class<CreateApiTokenResponse>(
+  "CreateApiTokenResponse",
+)({
+  id: ApiTokenId,
+  token: Schema.String,
+  prefix: Schema.String,
+  expiresAt: Schema.NullOr(Schema.DateTimeUtc),
+}) {}
+
+export class DeviceApprovalPayload extends Schema.Class<DeviceApprovalPayload>(
+  "DeviceApprovalPayload",
+)({
+  userCode: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(32)),
+}) {}
+
+// Browser-side approval of a CLI device grant (ADR-0024). The signed-in user
+// submits the code the CLI showed them; the server binds the grant to them.
+// On the GUI surface (the human is in the browser); the CLI's start/poll
+// endpoints live on `CliApi`.
+export class DeviceApprovalGroup extends HttpApiGroup.make("authDevice")
+  .middleware(UserAuthMiddleware)
+  .add(
+    HttpApiEndpoint.post("approve", "/approve")
+      .setPayload(DeviceApprovalPayload)
+      .addError(CustomHttpApiError.NotFound)
+      .addError(CustomHttpApiError.Gone)
+      .addSuccess(Schema.Void),
+  )
+  .addError(CustomHttpApiError.ServiceUnavailable)
+  .prefix("/auth/device") {}
+
+// Token management is a human-in-the-browser concern (a user mints a CI
+// token); the CLI/MCP obtain tokens via the device flow or a pre-minted PAT.
+// Hence this lives on the GUI `DomainApi`, not the CLI surface (ADR-0024).
+export class TokensGroup extends HttpApiGroup.make("authTokens")
+  .middleware(UserAuthMiddleware)
+  .add(
+    HttpApiEndpoint.post("create", "/")
+      .setPayload(CreateApiTokenPayload)
+      .addSuccess(CreateApiTokenResponse),
+  )
+  .add(HttpApiEndpoint.get("list", "/").addSuccess(Schema.Array(ApiTokenSummary)))
+  .add(
+    HttpApiEndpoint.del("revoke", "/:id")
+      .setPath(Schema.Struct({ id: ApiTokenId }))
+      .addError(CustomHttpApiError.NotFound)
+      .addSuccess(Schema.Void),
+  )
+  .addError(CustomHttpApiError.ServiceUnavailable)
+  .prefix("/auth/tokens") {}

--- a/packages/contracts/src/api/CliAuthContract.ts
+++ b/packages/contracts/src/api/CliAuthContract.ts
@@ -1,0 +1,67 @@
+import * as HttpApiEndpoint from "@effect/platform/HttpApiEndpoint";
+import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
+import * as HttpApiSchema from "@effect/platform/HttpApiSchema";
+import * as Schema from "effect/Schema";
+
+import * as CustomHttpApiError from "../CustomHttpApiError.js";
+
+// ==========================================
+// Device authorization grant (RFC 8628), app-native — the CLI/MCP wire
+// surface for sign-in. Public: the caller has no credential yet (ADR-0024).
+// ==========================================
+
+export class DeviceStartResponse extends Schema.Class<DeviceStartResponse>("DeviceStartResponse")({
+  // Held by the CLI and presented on each poll. Secret.
+  device_code: Schema.String,
+  // Shown to the user to type into the browser (e.g. ABCD-2345).
+  user_code: Schema.String,
+  // Where to go to approve, and the same URL with the code pre-filled.
+  verification_uri: Schema.String,
+  verification_uri_complete: Schema.String,
+  // Seconds the CLI should wait between polls, and until the codes lapse.
+  interval: Schema.Number,
+  expires_in: Schema.Number,
+}) {}
+
+export class DeviceTokenPayload extends Schema.Class<DeviceTokenPayload>("DeviceTokenPayload")({
+  device_code: Schema.String,
+}) {}
+
+export class DeviceTokenResponse extends Schema.Class<DeviceTokenResponse>("DeviceTokenResponse")({
+  access_token: Schema.String,
+  token_type: Schema.Literal("Bearer"),
+  expires_at: Schema.NullOr(Schema.DateTimeUtc),
+}) {}
+
+// RFC 8628 token-endpoint errors. All 400; the tag is the discriminator the
+// CLI switches on (keep polling on pending; stop on the rest).
+export class DeviceAuthorizationPending extends Schema.TaggedError<DeviceAuthorizationPending>(
+  "DeviceAuthorizationPending",
+)(
+  "DeviceAuthorizationPending",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 400 }),
+) {}
+
+export class DeviceTokenExpired extends Schema.TaggedError<DeviceTokenExpired>(
+  "DeviceTokenExpired",
+)("DeviceTokenExpired", { message: Schema.String }, HttpApiSchema.annotations({ status: 400 })) {}
+
+export class DeviceCodeNotFound extends Schema.TaggedError<DeviceCodeNotFound>(
+  "DeviceCodeNotFound",
+)("DeviceCodeNotFound", { message: Schema.String }, HttpApiSchema.annotations({ status: 400 })) {}
+
+export class DeviceGroup extends HttpApiGroup.make("cliAuth")
+  .add(HttpApiEndpoint.post("deviceStart", "/start").addSuccess(DeviceStartResponse))
+  .add(
+    HttpApiEndpoint.post("deviceToken", "/token")
+      .setPayload(DeviceTokenPayload)
+      .addError(DeviceAuthorizationPending)
+      .addError(DeviceTokenExpired)
+      .addError(DeviceCodeNotFound)
+      .addSuccess(DeviceTokenResponse),
+  )
+  // Both endpoints persist (start inserts, token mints) — transient store
+  // failure surfaces as 503.
+  .addError(CustomHttpApiError.ServiceUnavailable)
+  .prefix("/cli/device") {}

--- a/packages/contracts/src/api/CliOrganizationContract.ts
+++ b/packages/contracts/src/api/CliOrganizationContract.ts
@@ -1,0 +1,22 @@
+import * as HttpApiEndpoint from "@effect/platform/HttpApiEndpoint";
+import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
+import * as Schema from "effect/Schema";
+
+import * as CustomHttpApiError from "../CustomHttpApiError.js";
+import { OrganizationId } from "../EntityIds.js";
+import { UserAuthMiddleware } from "../Policy.js";
+
+// CLI-facing organization surface (ADR-0024). Deliberately leaner than the
+// GUI's `MyOrganization` — the CLI only needs to name an org and know
+// whether the caller administers it — so the two contracts diverge.
+export class CliOrganization extends Schema.Class<CliOrganization>("CliOrganization")({
+  id: OrganizationId,
+  name: Schema.String,
+  isAdmin: Schema.Boolean,
+}) {}
+
+export class Group extends HttpApiGroup.make("cliOrganization")
+  .middleware(UserAuthMiddleware)
+  .add(HttpApiEndpoint.get("listMine", "/").addSuccess(Schema.Array(CliOrganization)))
+  .addError(CustomHttpApiError.ServiceUnavailable)
+  .prefix("/cli/orgs") {}

--- a/packages/contracts/src/api/CliTodosContract.ts
+++ b/packages/contracts/src/api/CliTodosContract.ts
@@ -1,0 +1,60 @@
+import * as HttpApiEndpoint from "@effect/platform/HttpApiEndpoint";
+import * as HttpApiGroup from "@effect/platform/HttpApiGroup";
+import * as HttpApiSchema from "@effect/platform/HttpApiSchema";
+import * as Schema from "effect/Schema";
+
+import * as CustomHttpApiError from "../CustomHttpApiError.js";
+import { OrganizationId, TodoId } from "../EntityIds.js";
+import { UserAuthMiddleware } from "../Policy.js";
+
+// CLI-specific error, distinct from the GUI's `TodosContract.TodoNotFoundError`
+// so the two contracts evolve independently (ADR-0024).
+export class CliTodoNotFoundError extends Schema.TaggedError<CliTodoNotFoundError>(
+  "CliTodoNotFoundError",
+)("CliTodoNotFoundError", { message: Schema.String }, HttpApiSchema.annotations({ status: 404 })) {}
+
+export class CliTodo extends Schema.Class<CliTodo>("CliTodo")({
+  id: TodoId,
+  title: Schema.String,
+  completed: Schema.Boolean,
+}) {}
+
+export class CliCreateTodoPayload extends Schema.Class<CliCreateTodoPayload>(
+  "CliCreateTodoPayload",
+)({
+  title: Schema.Trim.pipe(Schema.nonEmptyString()),
+}) {}
+
+// CLI-facing todos surface. Same org-scoped paths as the GUI, but its own
+// shapes and a first-class `complete` verb (the GUI only has `update`).
+export class Group extends HttpApiGroup.make("cliTodos")
+  .middleware(UserAuthMiddleware)
+  .add(
+    HttpApiEndpoint.get("list", "/:orgId/todos")
+      .setPath(Schema.Struct({ orgId: OrganizationId }))
+      .addError(CustomHttpApiError.Forbidden)
+      .addSuccess(Schema.Array(CliTodo)),
+  )
+  .add(
+    HttpApiEndpoint.post("create", "/:orgId/todos")
+      .setPath(Schema.Struct({ orgId: OrganizationId }))
+      .setPayload(CliCreateTodoPayload)
+      .addError(CustomHttpApiError.Forbidden)
+      .addSuccess(CliTodo),
+  )
+  .add(
+    HttpApiEndpoint.post("complete", "/:orgId/todos/:id/complete")
+      .setPath(Schema.Struct({ orgId: OrganizationId, id: TodoId }))
+      .addError(CustomHttpApiError.Forbidden)
+      .addError(CliTodoNotFoundError)
+      .addSuccess(CliTodo),
+  )
+  .add(
+    HttpApiEndpoint.del("remove", "/:orgId/todos/:id")
+      .setPath(Schema.Struct({ orgId: OrganizationId, id: TodoId }))
+      .addError(CustomHttpApiError.Forbidden)
+      .addError(CliTodoNotFoundError)
+      .addSuccess(Schema.Void),
+  )
+  .addError(CustomHttpApiError.ServiceUnavailable)
+  .prefix("/cli/orgs") {}

--- a/packages/contracts/src/api/Contracts.ts
+++ b/packages/contracts/src/api/Contracts.ts
@@ -1,5 +1,8 @@
 export * as AuthContract from "./AuthContract.js";
 export * as BillingContract from "./BillingContract.js";
+export * as CliAuthContract from "./CliAuthContract.js";
+export * as CliOrganizationContract from "./CliOrganizationContract.js";
+export * as CliTodosContract from "./CliTodosContract.js";
 export * as OrganizationContract from "./OrganizationContract.js";
 export * as TodosContract from "./TodosContract.js";
 export * as UserContract from "./UserContract.js";

--- a/packages/database/migrations/V021__create_table_auth_api_tokens.sql
+++ b/packages/database/migrations/V021__create_table_auth_api_tokens.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "auth"."api_tokens" (
+	"id" uuid PRIMARY KEY,
+	"user_id" uuid NOT NULL REFERENCES "user"."users"("id") ON DELETE CASCADE,
+	-- sha256(token) hex. The plaintext token is shown to the caller exactly
+	-- once at mint time and never stored; lookups hash the presented bearer
+	-- and match against this column.
+	"token_hash" text NOT NULL UNIQUE,
+	-- Non-secret display fragment (e.g. `pat_1a2b3c4d`) so the owner can tell
+	-- their tokens apart in a listing without exposing the secret.
+	"prefix" varchar(64) NOT NULL,
+	"label" varchar(255) NOT NULL,
+	-- Fixed expiry (NOT sliding): a token expires at a wall-clock instant
+	-- regardless of use. Nullable to leave room for non-expiring tokens later;
+	-- the mint path always sets it in v1.
+	"expires_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL DEFAULT now(),
+	"last_used_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "api_tokens_user_id_idx" ON "auth"."api_tokens"("user_id");

--- a/packages/database/migrations/V022__create_table_auth_device_grants.sql
+++ b/packages/database/migrations/V022__create_table_auth_device_grants.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "auth"."device_grants" (
+	"id" uuid PRIMARY KEY,
+	-- sha256(device_code) hex. The CLI holds the plaintext device_code; the
+	-- poll endpoint hashes the presented value and matches against this.
+	"device_code_hash" text NOT NULL UNIQUE,
+	-- Short, human-typable code the user enters in the browser (e.g. ABCD-1234).
+	"user_code" varchar(32) NOT NULL UNIQUE,
+	-- 'pending' until the browser approves, then 'approved'.
+	"status" varchar(16) NOT NULL DEFAULT 'pending',
+	-- Null until approved; set to the approving user on approval.
+	"user_id" uuid REFERENCES "user"."users"("id") ON DELETE CASCADE,
+	"created_at" timestamp with time zone NOT NULL DEFAULT now(),
+	-- Short TTL (~10 min). A lapsed grant is rejected and swept later.
+	"expires_at" timestamp with time zone NOT NULL,
+	"approved_at" timestamp with time zone
+);
+
+CREATE INDEX "device_grants_user_code_idx" ON "auth"."device_grants"("user_code");

--- a/packages/database/src/row-schemas/auth.ts
+++ b/packages/database/src/row-schemas/auth.ts
@@ -26,3 +26,34 @@ export type SessionRow = typeof SessionRow.Type;
 
 export const SessionRowStd: StandardSchemaV1<unknown, SessionRow> =
   Schema.standardSchemaV1(SessionRow);
+
+export const ApiTokenRow = Schema.Struct({
+  id: Schema.UUID,
+  user_id: Schema.UUID,
+  token_hash: Schema.String,
+  prefix: Schema.String,
+  label: Schema.String,
+  expires_at: Schema.NullOr(Schema.DateTimeUtcFromDate),
+  revoked_at: Schema.NullOr(Schema.DateTimeUtcFromDate),
+  created_at: Schema.DateTimeUtcFromDate,
+  last_used_at: Schema.DateTimeUtcFromDate,
+});
+export type ApiTokenRow = typeof ApiTokenRow.Type;
+
+export const ApiTokenRowStd: StandardSchemaV1<unknown, ApiTokenRow> =
+  Schema.standardSchemaV1(ApiTokenRow);
+
+export const DeviceGrantRow = Schema.Struct({
+  id: Schema.UUID,
+  device_code_hash: Schema.String,
+  user_code: Schema.String,
+  status: Schema.String,
+  user_id: Schema.NullOr(Schema.UUID),
+  created_at: Schema.DateTimeUtcFromDate,
+  expires_at: Schema.DateTimeUtcFromDate,
+  approved_at: Schema.NullOr(Schema.DateTimeUtcFromDate),
+});
+export type DeviceGrantRow = typeof DeviceGrantRow.Type;
+
+export const DeviceGrantRowStd: StandardSchemaV1<unknown, DeviceGrantRow> =
+  Schema.standardSchemaV1(DeviceGrantRow);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,53 @@
+# @org/mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server (stdio transport) that exposes the application's CLI surface as tools, so an MCP client (Claude Desktop, IDE agents, etc.) can manage todos and organizations.
+
+It reuses `@org/api-client` over the same `CliApi` the CLI uses (ADR-0024), so MCP tool calls run the exact same authenticated requests as `org …` CLI commands.
+
+## Tools
+
+| Tool                 | Arguments         | Effect                          |
+| -------------------- | ----------------- | ------------------------------- |
+| `list_organizations` | —                 | List the caller's organizations |
+| `list_todos`         | `orgId`           | List an org's todos             |
+| `create_todo`        | `orgId`, `title`  | Create a todo                   |
+| `complete_todo`      | `orgId`, `todoId` | Mark a todo done                |
+| `remove_todo`        | `orgId`, `todoId` | Delete a todo                   |
+
+Expected-error cases (not authorized, todo not found, server unreachable, …) come back as a tool result with `isError: true` and a human-readable message, not a protocol error.
+
+## Authentication
+
+The server resolves a bearer token per call, in order:
+
+1. `APP_API_TOKEN` environment variable (recommended for MCP clients / CI), or
+2. the credential file written by `org auth login` (`$XDG_CONFIG_HOME/org-cli/credentials.json`).
+
+`APP_API_URL` selects the server (default `http://localhost:3001`). Mint a token in the web UI (Settings → API tokens) or via the CLI device flow.
+
+## Run
+
+Local/dev (stdio):
+
+```bash
+APP_API_TOKEN=pat_… APP_API_URL=https://your-server pnpm -F @org/mcp dev
+```
+
+### MCP client launch config
+
+```jsonc
+{
+  "mcpServers": {
+    "org": {
+      "command": "pnpm",
+      "args": ["-C", "/abs/path/to/repo", "-F", "@org/mcp", "exec", "tsx", "src/main.ts"],
+      "env": {
+        "APP_API_TOKEN": "pat_…",
+        "APP_API_URL": "https://your-server",
+      },
+    },
+  },
+}
+```
+
+> Note: stdout is the JSON-RPC channel — the server writes all diagnostics to stderr. A published, prebuilt binary entry (`org-mcp`) is a follow-up alongside the workspace's distribution packaging; until then run via `tsx` as above.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@org/mcp",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Model Context Protocol (stdio) server exposing the effect-monorepo CLI surface as tools.",
+  "bin": {
+    "org-mcp": "build/esm/main.js"
+  },
+  "scripts": {
+    "check": "tsc -b tsconfig.json",
+    "clean": "rm -rf build .tsbuildinfo",
+    "build": "tsc -b tsconfig.build.json",
+    "dev": "tsx src/main.ts",
+    "start": "node build/esm/main.js",
+    "lint": "eslint . --quiet",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@effect/platform": "*",
+    "@effect/platform-node": "*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@org/api-client": "workspace:^",
+    "@org/contracts": "workspace:^",
+    "effect": "^3.20.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.19.2"
+  }
+}

--- a/packages/mcp/src/main.ts
+++ b/packages/mcp/src/main.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import * as NodeContext from "@effect/platform-node/NodeContext";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { makeCliClient, readCredentials, resolveBaseUrl, resolveToken } from "@org/api-client";
+import { OrganizationId, TodoId } from "@org/contracts/EntityIds";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import { z } from "zod";
+
+// MCP (stdio) server exposing the CLI surface as tools (ADR-0024). It reuses
+// `@org/api-client` over `CliApi`, so the MCP tools and the CLI run the exact
+// same authenticated requests. Auth comes from `APP_API_TOKEN` or the stored
+// credential (resolved per call). stdout is the JSON-RPC channel — all
+// diagnostics go to stderr only.
+
+type CliClient = Effect.Effect.Success<ReturnType<typeof makeCliClient>>;
+
+type ToolOutcome<A> =
+  | { readonly ok: true; readonly value: A }
+  | { readonly ok: false; readonly message: string };
+
+const friendlyError = (error: unknown): string => {
+  const tag =
+    typeof error === "object" && error !== null && "_tag" in error
+      ? String((error as { readonly _tag: unknown })._tag)
+      : "";
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { readonly message: unknown }).message)
+      : "";
+  switch (tag) {
+    case "Unauthorized":
+      return "Not authorized — the token is invalid or expired.";
+    case "Forbidden":
+      return "No access to that organization or resource.";
+    case "ServiceUnavailable":
+      return "The server is temporarily unavailable.";
+    case "CliTodoNotFoundError":
+      return message.length > 0 ? message : "Todo not found.";
+    case "RequestError":
+    case "ResponseError":
+      return `Could not reach the server at ${resolveBaseUrl()}.`;
+    default:
+      return tag.length > 0
+        ? `Request failed (${tag}).`
+        : message.length > 0
+          ? message
+          : String(error);
+  }
+};
+
+// Resolves the token, builds the client, runs `body`, and folds every failure
+// into a friendly outcome so the tool handler never rejects on expected errors.
+const callTool = <A>(body: (client: CliClient) => Effect.Effect<A, unknown, never>) =>
+  Effect.gen(function* () {
+    const creds = yield* readCredentials;
+    const token = resolveToken(creds);
+    if (token === null) {
+      return {
+        ok: false as const,
+        message: "Not authenticated. Set APP_API_TOKEN, or run `org auth login` with the CLI.",
+      };
+    }
+    const client = yield* makeCliClient({ baseUrl: resolveBaseUrl(), token });
+    const value = yield* body(client);
+    return { ok: true as const, value };
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.succeed({ ok: false as const, message: friendlyError(error) }),
+    ),
+  );
+
+const runtime = ManagedRuntime.make(Layer.mergeAll(NodeContext.layer, FetchHttpClient.layer));
+
+const textResult = (text: string) => ({ content: [{ type: "text" as const, text }] });
+const errorResult = (message: string) => ({
+  content: [{ type: "text" as const, text: message }],
+  isError: true,
+});
+const jsonResult = (data: unknown) => textResult(JSON.stringify(data, null, 2));
+
+// Runs a tool effect through the shared runtime, mapping the outcome to an
+// MCP result. Defects (unexpected) become an error result rather than a crash.
+const dispatch = async <A>(
+  effect: Effect.Effect<
+    ToolOutcome<A>,
+    never,
+    ManagedRuntime.ManagedRuntime.Context<typeof runtime>
+  >,
+  format: (value: A) => ReturnType<typeof textResult>,
+) => {
+  try {
+    const outcome = await runtime.runPromise(effect);
+    return outcome.ok ? format(outcome.value) : errorResult(outcome.message);
+  } catch (error) {
+    return errorResult(friendlyError(error));
+  }
+};
+
+const server = new McpServer({ name: "org-mcp", version: "0.0.0" });
+
+server.registerTool(
+  "list_organizations",
+  {
+    title: "List organizations",
+    description: "List the organizations the authenticated user belongs to.",
+  },
+  () =>
+    dispatch(
+      callTool((client) => client.cliOrganization.listMine()),
+      jsonResult,
+    ),
+);
+
+server.registerTool(
+  "list_todos",
+  {
+    title: "List todos",
+    description: "List the todos in an organization.",
+    inputSchema: { orgId: z.string().describe("Organization id") },
+  },
+  ({ orgId }) =>
+    dispatch(
+      callTool((client) => client.cliTodos.list({ path: { orgId: OrganizationId.make(orgId) } })),
+      jsonResult,
+    ),
+);
+
+server.registerTool(
+  "create_todo",
+  {
+    title: "Create todo",
+    description: "Create a todo in an organization.",
+    inputSchema: {
+      orgId: z.string().describe("Organization id"),
+      title: z.string().min(1).describe("Todo title"),
+    },
+  },
+  ({ orgId, title }) =>
+    dispatch(
+      callTool((client) =>
+        client.cliTodos.create({ path: { orgId: OrganizationId.make(orgId) }, payload: { title } }),
+      ),
+      jsonResult,
+    ),
+);
+
+server.registerTool(
+  "complete_todo",
+  {
+    title: "Complete todo",
+    description: "Mark a todo as done.",
+    inputSchema: {
+      orgId: z.string().describe("Organization id"),
+      todoId: z.string().describe("Todo id"),
+    },
+  },
+  ({ orgId, todoId }) =>
+    dispatch(
+      callTool((client) =>
+        client.cliTodos.complete({
+          path: { orgId: OrganizationId.make(orgId), id: TodoId.make(todoId) },
+        }),
+      ),
+      jsonResult,
+    ),
+);
+
+server.registerTool(
+  "remove_todo",
+  {
+    title: "Remove todo",
+    description: "Delete a todo from an organization.",
+    inputSchema: {
+      orgId: z.string().describe("Organization id"),
+      todoId: z.string().describe("Todo id"),
+    },
+  },
+  ({ orgId, todoId }) =>
+    dispatch(
+      callTool((client) =>
+        client.cliTodos.remove({
+          path: { orgId: OrganizationId.make(orgId), id: TodoId.make(todoId) },
+        }),
+      ),
+      () => textResult(`Removed todo ${todoId}.`),
+    ),
+);
+
+async function main() {
+  await server.connect(new StdioServerTransport());
+  // stderr only — stdout is the JSON-RPC protocol channel.
+  process.stderr.write("org-mcp: ready on stdio\n");
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`org-mcp: fatal ${String(error)}\n`);
+  process.exit(1);
+});

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true,
+    "composite": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@org/api-client": ["../api-client/src/index.js"],
+      "@org/api-client/*": ["../api-client/src/*.js"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  },
+  "references": [{ "path": "tsconfig.src.json" }]
+}

--- a/packages/mcp/tsconfig.src.json
+++ b/packages/mcp/tsconfig.src.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
+  "references": [{ "path": "../api-client" }, { "path": "../contracts" }],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "build/src",
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@org/api-client": ["../api-client/src/index.js"],
+      "@org/api-client/*": ["../api-client/src/*.js"],
+      "@org/contracts": ["../contracts/src/index.js"],
+      "@org/contracts/*": ["../contracts/src/*.js"]
+    }
+  }
+}

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -1,4 +1,8 @@
 import * as HttpApi from "@effect/platform/HttpApi";
+import { CliApi } from "@org/contracts/CliApi";
 import { DomainApi } from "@org/contracts/DomainApi";
 
-export const Api = HttpApi.make("api").addHttpApi(DomainApi);
+// Two API products on one server (ADR-0024): the GUI BFF (`DomainApi`) and
+// the CLI/MCP surface (`CliApi`, under `/cli`). Distinct group names + path
+// prefixes, so they compose without collision.
+export const Api = HttpApi.make("api").addHttpApi(DomainApi).addHttpApi(CliApi);

--- a/packages/server/src/common/env-vars.ts
+++ b/packages/server/src/common/env-vars.ts
@@ -52,6 +52,25 @@ export class EnvVars extends Effect.Service<EnvVars>()("EnvVars", {
         "SESSION_TOUCH_THRESHOLD_SECONDS",
       ).pipe(Config.withDefault(60)),
 
+      // API tokens (ADR-0024). Default expiry applied when a mint request
+      // omits `expiresInDays`. Touch threshold throttles the per-request
+      // `last_used_at` write the bearer path issues, same as sessions.
+      API_TOKEN_DEFAULT_TTL_DAYS: yield* Config.integer("API_TOKEN_DEFAULT_TTL_DAYS").pipe(
+        Config.withDefault(90),
+      ),
+      API_TOKEN_TOUCH_THRESHOLD_SECONDS: yield* Config.integer(
+        "API_TOKEN_TOUCH_THRESHOLD_SECONDS",
+      ).pipe(Config.withDefault(60)),
+
+      // Device authorization flow (ADR-0024). Grant TTL (how long the user
+      // has to approve) and the poll interval the CLI is told to wait.
+      DEVICE_CODE_TTL_SECONDS: yield* Config.integer("DEVICE_CODE_TTL_SECONDS").pipe(
+        Config.withDefault(600),
+      ),
+      DEVICE_POLL_INTERVAL_SECONDS: yield* Config.integer("DEVICE_POLL_INTERVAL_SECONDS").pipe(
+        Config.withDefault(5),
+      ),
+
       // Email / Notifications
       // Transport selection for the application `Mailer` port. `log` (default)
       // writes a structured log line — no real send. `smtp` targets the local

--- a/packages/server/src/modules/auth/auth-command-handlers.ts
+++ b/packages/server/src/modules/auth/auth-command-handlers.ts
@@ -2,6 +2,27 @@ import type * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
 import { type Database } from "@org/database/index";
 import * as Effect from "effect/Effect";
 
+import { approveDeviceGrant } from "@/modules/auth/commands/approve-device-grant.js";
+import {
+  type ApproveDeviceGrantCommand,
+  approveDeviceGrantCommandSpanAttributes,
+} from "@/modules/auth/commands/approve-device-grant-command.js";
+import { mintApiToken } from "@/modules/auth/commands/mint-api-token.js";
+import {
+  type MintApiTokenCommand,
+  mintApiTokenCommandSpanAttributes,
+  type MintApiTokenResult,
+} from "@/modules/auth/commands/mint-api-token-command.js";
+import { pollDeviceGrant } from "@/modules/auth/commands/poll-device-grant.js";
+import {
+  type PollDeviceGrantCommand,
+  pollDeviceGrantCommandSpanAttributes,
+} from "@/modules/auth/commands/poll-device-grant-command.js";
+import { revokeApiToken } from "@/modules/auth/commands/revoke-api-token.js";
+import {
+  type RevokeApiTokenCommand,
+  revokeApiTokenCommandSpanAttributes,
+} from "@/modules/auth/commands/revoke-api-token-command.js";
 import { revokeSession } from "@/modules/auth/commands/revoke-session.js";
 import {
   type RevokeSessionCommand,
@@ -13,12 +34,31 @@ import {
   signInCommandSpanAttributes,
   type SignInResult,
 } from "@/modules/auth/commands/sign-in-command.js";
+import { startDeviceGrant } from "@/modules/auth/commands/start-device-grant.js";
+import {
+  type StartDeviceGrantCommand,
+  startDeviceGrantCommandSpanAttributes,
+  type StartDeviceGrantResult,
+} from "@/modules/auth/commands/start-device-grant-command.js";
+import { touchApiToken } from "@/modules/auth/commands/touch-api-token.js";
+import {
+  type TouchApiTokenCommand,
+  touchApiTokenCommandSpanAttributes,
+} from "@/modules/auth/commands/touch-api-token-command.js";
 import { touchSession } from "@/modules/auth/commands/touch-session.js";
 import {
   type TouchSessionCommand,
   touchSessionCommandSpanAttributes,
 } from "@/modules/auth/commands/touch-session-command.js";
+import { type ApiTokenNotFound } from "@/modules/auth/domain/api-token-errors.js";
+import {
+  type DeviceGrantExpired,
+  type DeviceGrantNotFound,
+  type DeviceGrantPending,
+} from "@/modules/auth/domain/device-grant-errors.js";
+import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/api-token-repository-live.js";
 import { AuthIdentityRepositoryLive } from "@/modules/auth/infrastructure/auth-identity-repository-live.js";
+import { DeviceGrantRepositoryLive } from "@/modules/auth/infrastructure/device-grant-repository-live.js";
 import { SessionRepositoryLive } from "@/modules/auth/infrastructure/session-repository-live.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { commandHandlers } from "@/platform/ddd/ports/command-bus.js";
@@ -39,6 +79,43 @@ type TouchSessionBusOutput = Effect.Effect<void, never, Database.Database>;
 
 type RevokeSessionBusOutput = Effect.Effect<void, never, Database.Database>;
 
+// Mint/revoke run in a unit of work; the repository wrap discharges
+// `ApiTokenRepository`, leaving `Database` (its dependency) + `UnitOfWork`.
+type MintApiTokenBusOutput = Effect.Effect<
+  MintApiTokenResult,
+  PersistenceUnavailable,
+  Database.Database | UnitOfWork
+>;
+
+type RevokeApiTokenBusOutput = Effect.Effect<
+  void,
+  ApiTokenNotFound | PersistenceUnavailable,
+  Database.Database | UnitOfWork
+>;
+
+// Fire-and-forget last-used stamp; swallows its own errors (no uow).
+type TouchApiTokenBusOutput = Effect.Effect<void, never, Database.Database>;
+
+// Device flow (ADR-0024). Start/approve run in a uow over the grant repo;
+// poll additionally mints (ApiToken repo), all in one transaction.
+type StartDeviceGrantBusOutput = Effect.Effect<
+  StartDeviceGrantResult,
+  PersistenceUnavailable,
+  Database.Database | UnitOfWork
+>;
+
+type ApproveDeviceGrantBusOutput = Effect.Effect<
+  void,
+  DeviceGrantNotFound | DeviceGrantExpired | PersistenceUnavailable,
+  Database.Database | UnitOfWork
+>;
+
+type PollDeviceGrantBusOutput = Effect.Effect<
+  MintApiTokenResult,
+  DeviceGrantNotFound | DeviceGrantExpired | DeviceGrantPending | PersistenceUnavailable,
+  Database.Database | UnitOfWork
+>;
+
 declare module "@/platform/ddd/ports/command-bus.js" {
   interface CommandRegistry {
     SignInCommand: {
@@ -52,6 +129,30 @@ declare module "@/platform/ddd/ports/command-bus.js" {
     RevokeSessionCommand: {
       readonly command: RevokeSessionCommand;
       readonly output: RevokeSessionBusOutput;
+    };
+    MintApiTokenCommand: {
+      readonly command: MintApiTokenCommand;
+      readonly output: MintApiTokenBusOutput;
+    };
+    RevokeApiTokenCommand: {
+      readonly command: RevokeApiTokenCommand;
+      readonly output: RevokeApiTokenBusOutput;
+    };
+    TouchApiTokenCommand: {
+      readonly command: TouchApiTokenCommand;
+      readonly output: TouchApiTokenBusOutput;
+    };
+    StartDeviceGrantCommand: {
+      readonly command: StartDeviceGrantCommand;
+      readonly output: StartDeviceGrantBusOutput;
+    };
+    ApproveDeviceGrantCommand: {
+      readonly command: ApproveDeviceGrantCommand;
+      readonly output: ApproveDeviceGrantBusOutput;
+    };
+    PollDeviceGrantCommand: {
+      readonly command: PollDeviceGrantCommand;
+      readonly output: PollDeviceGrantBusOutput;
     };
   }
 }
@@ -74,5 +175,38 @@ export const authCommandHandlers = commandHandlers({
     handle: (cmd): RevokeSessionBusOutput =>
       revokeSession(cmd).pipe(Effect.provide(SessionRepositoryLive)),
     spanAttributes: revokeSessionCommandSpanAttributes,
+  },
+  MintApiTokenCommand: {
+    handle: (cmd): MintApiTokenBusOutput =>
+      mintApiToken(cmd).pipe(Effect.provide(ApiTokenRepositoryLive)),
+    spanAttributes: mintApiTokenCommandSpanAttributes,
+  },
+  RevokeApiTokenCommand: {
+    handle: (cmd): RevokeApiTokenBusOutput =>
+      revokeApiToken(cmd).pipe(Effect.provide(ApiTokenRepositoryLive)),
+    spanAttributes: revokeApiTokenCommandSpanAttributes,
+  },
+  TouchApiTokenCommand: {
+    handle: (cmd): TouchApiTokenBusOutput =>
+      touchApiToken(cmd).pipe(Effect.provide(ApiTokenRepositoryLive)),
+    spanAttributes: touchApiTokenCommandSpanAttributes,
+  },
+  StartDeviceGrantCommand: {
+    handle: (cmd): StartDeviceGrantBusOutput =>
+      startDeviceGrant(cmd).pipe(Effect.provide(DeviceGrantRepositoryLive)),
+    spanAttributes: startDeviceGrantCommandSpanAttributes,
+  },
+  ApproveDeviceGrantCommand: {
+    handle: (cmd): ApproveDeviceGrantBusOutput =>
+      approveDeviceGrant(cmd).pipe(Effect.provide(DeviceGrantRepositoryLive)),
+    spanAttributes: approveDeviceGrantCommandSpanAttributes,
+  },
+  PollDeviceGrantCommand: {
+    handle: (cmd): PollDeviceGrantBusOutput =>
+      pollDeviceGrant(cmd).pipe(
+        Effect.provide(DeviceGrantRepositoryLive),
+        Effect.provide(ApiTokenRepositoryLive),
+      ),
+    spanAttributes: pollDeviceGrantCommandSpanAttributes,
   },
 });

--- a/packages/server/src/modules/auth/auth-query-handlers.ts
+++ b/packages/server/src/modules/auth/auth-query-handlers.ts
@@ -1,18 +1,35 @@
 import { type Database } from "@org/database/index";
 import * as Effect from "effect/Effect";
 
+import { type ApiToken } from "@/modules/auth/domain/api-token.aggregate.js";
+import {
+  type ApiTokenExpired,
+  type ApiTokenNotFound,
+  type ApiTokenRevoked,
+} from "@/modules/auth/domain/api-token-errors.js";
 import { type Session } from "@/modules/auth/domain/session.aggregate.js";
 import {
   type SessionExpired,
   type SessionNotFound,
   type SessionRevoked,
 } from "@/modules/auth/domain/session-errors.js";
+import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/api-token-repository-live.js";
 import { SessionRepositoryLive } from "@/modules/auth/infrastructure/session-repository-live.js";
+import { findApiTokenByHash } from "@/modules/auth/queries/find-api-token-by-hash.js";
+import {
+  type FindApiTokenByHashQuery,
+  findApiTokenByHashQuerySpanAttributes,
+} from "@/modules/auth/queries/find-api-token-by-hash-query.js";
 import { findSession } from "@/modules/auth/queries/find-session.js";
 import {
   type FindSessionQuery,
   findSessionQuerySpanAttributes,
 } from "@/modules/auth/queries/find-session-query.js";
+import { listMyApiTokens } from "@/modules/auth/queries/list-my-api-tokens.js";
+import {
+  type ListMyApiTokensQuery,
+  listMyApiTokensQuerySpanAttributes,
+} from "@/modules/auth/queries/list-my-api-tokens-query.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { queryHandlers } from "@/platform/ddd/ports/query-bus.js";
 
@@ -22,11 +39,31 @@ type FindSessionBusOutput = Effect.Effect<
   Database.Database
 >;
 
+type FindApiTokenByHashBusOutput = Effect.Effect<
+  ApiToken,
+  ApiTokenNotFound | ApiTokenExpired | ApiTokenRevoked | PersistenceUnavailable,
+  Database.Database
+>;
+
+type ListMyApiTokensBusOutput = Effect.Effect<
+  ReadonlyArray<ApiToken>,
+  PersistenceUnavailable,
+  Database.Database
+>;
+
 declare module "@/platform/ddd/ports/query-bus.js" {
   interface QueryRegistry {
     FindSessionQuery: {
       readonly query: FindSessionQuery;
       readonly output: FindSessionBusOutput;
+    };
+    FindApiTokenByHashQuery: {
+      readonly query: FindApiTokenByHashQuery;
+      readonly output: FindApiTokenByHashBusOutput;
+    };
+    ListMyApiTokensQuery: {
+      readonly query: ListMyApiTokensQuery;
+      readonly output: ListMyApiTokensBusOutput;
     };
   }
 }
@@ -35,5 +72,15 @@ export const authQueryHandlers = queryHandlers({
   FindSessionQuery: {
     handle: (q): FindSessionBusOutput => findSession(q).pipe(Effect.provide(SessionRepositoryLive)),
     spanAttributes: findSessionQuerySpanAttributes,
+  },
+  FindApiTokenByHashQuery: {
+    handle: (q): FindApiTokenByHashBusOutput =>
+      findApiTokenByHash(q).pipe(Effect.provide(ApiTokenRepositoryLive)),
+    spanAttributes: findApiTokenByHashQuerySpanAttributes,
+  },
+  ListMyApiTokensQuery: {
+    handle: (q): ListMyApiTokensBusOutput =>
+      listMyApiTokens(q).pipe(Effect.provide(ApiTokenRepositoryLive)),
+    spanAttributes: listMyApiTokensQuerySpanAttributes,
   },
 });

--- a/packages/server/src/modules/auth/commands/approve-device-grant-command.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant-command.ts
@@ -1,0 +1,30 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import {
+  type DeviceGrantExpired,
+  type DeviceGrantNotFound,
+} from "@/modules/auth/domain/device-grant-errors.js";
+import { type DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/ports/unit-of-work.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Browser-side approval: the signed-in user submits the `userCode` they were
+// shown by the CLI; we bind the grant to them.
+export const ApproveDeviceGrantCommand = Schema.TaggedStruct("ApproveDeviceGrantCommand", {
+  userCode: Schema.String,
+  userId: UserId,
+});
+export type ApproveDeviceGrantCommand = typeof ApproveDeviceGrantCommand.Type;
+
+export const approveDeviceGrantCommandSpanAttributes: SpanAttributesExtractor<
+  ApproveDeviceGrantCommand
+> = (c) => ({ "user.id": c.userId });
+
+export type ApproveDeviceGrantOutput = Effect.Effect<
+  void,
+  DeviceGrantNotFound | DeviceGrantExpired | PersistenceUnavailable,
+  DeviceGrantRepository | UnitOfWork
+>;

--- a/packages/server/src/modules/auth/commands/approve-device-grant.test.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
+import { approveDeviceGrant } from "@/modules/auth/commands/approve-device-grant.js";
+import { ApproveDeviceGrantCommand } from "@/modules/auth/commands/approve-device-grant-command.js";
+import { startDeviceGrant } from "@/modules/auth/commands/start-device-grant.js";
+import { StartDeviceGrantCommand } from "@/modules/auth/commands/start-device-grant-command.js";
+import {
+  DeviceGrantExpired,
+  DeviceGrantNotFound,
+} from "@/modules/auth/domain/device-grant-errors.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { DeviceGrantRepositoryFake } from "@/modules/auth/infrastructure/device-grant-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const TestLayer = Layer.mergeAll(DeviceGrantRepositoryFake, IdentityUnitOfWork);
+const errorOf = (exit: Exit.Exit<unknown, unknown>) =>
+  Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+
+describe("approveDeviceGrant", () => {
+  it.effect("binds a pending grant to the approving user", () =>
+    Effect.gen(function* () {
+      const { userCode } = yield* startDeviceGrant(
+        StartDeviceGrantCommand.make({ ttlSeconds: 600 }),
+      );
+      yield* approveDeviceGrant(ApproveDeviceGrantCommand.make({ userCode, userId }));
+      const repo = yield* DeviceGrantRepository;
+      const grant = yield* repo.findByUserCode(userCode);
+      deepStrictEqual(grant.status, "approved");
+      deepStrictEqual(grant.userId, userId);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails DeviceGrantNotFound for an unknown user code", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        approveDeviceGrant(ApproveDeviceGrantCommand.make({ userCode: "ZZZZ-9999", userId })),
+      );
+      deepStrictEqual(errorOf(exit) instanceof DeviceGrantNotFound, true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails DeviceGrantExpired for a lapsed grant", () =>
+    Effect.gen(function* () {
+      const { userCode } = yield* startDeviceGrant(
+        StartDeviceGrantCommand.make({ ttlSeconds: -10 }),
+      );
+      const exit = yield* Effect.exit(
+        approveDeviceGrant(ApproveDeviceGrantCommand.make({ userCode, userId })),
+      );
+      deepStrictEqual(errorOf(exit) instanceof DeviceGrantExpired, true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/commands/approve-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant.ts
@@ -1,0 +1,27 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import {
+  type ApproveDeviceGrantCommand,
+  type ApproveDeviceGrantOutput,
+} from "@/modules/auth/commands/approve-device-grant-command.js";
+import * as DeviceGrant from "@/modules/auth/domain/device-grant.aggregate.js";
+import { DeviceGrantExpired } from "@/modules/auth/domain/device-grant-errors.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
+
+// Looks up the grant by its user code, refuses a lapsed one, and binds it to
+// the approving user. Idempotent: re-approving an already-approved grant just
+// re-stamps it (a double-submit from the browser is harmless).
+//
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const approveDeviceGrant = (cmd: ApproveDeviceGrantCommand): ApproveDeviceGrantOutput =>
+  Effect.gen(function* () {
+    const repo = yield* DeviceGrantRepository;
+    const grant = yield* repo.findByUserCode(cmd.userCode);
+    const now = yield* DateTime.now;
+    if (DeviceGrant.isExpired(grant, now)) {
+      return yield* Effect.fail(new DeviceGrantExpired());
+    }
+    yield* repo.update(DeviceGrant.approve({ grant, userId: cmd.userId, now }));
+  }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/mint-api-token-command.ts
+++ b/packages/server/src/modules/auth/commands/mint-api-token-command.ts
@@ -1,0 +1,46 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type ApiToken } from "@/modules/auth/domain/api-token.aggregate.js";
+import { type ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/ports/unit-of-work.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Mints a new API token for the caller. `expiresInDays` is resolved by the
+// endpoint (payload value or the configured default) so the handler can
+// compute `expiresAt` against the server clock — no client/server skew.
+export const MintApiTokenCommand = Schema.TaggedStruct("MintApiTokenCommand", {
+  userId: UserId,
+  label: Schema.String,
+  expiresInDays: Schema.Number,
+});
+export type MintApiTokenCommand = typeof MintApiTokenCommand.Type;
+
+export const mintApiTokenCommandSpanAttributes: SpanAttributesExtractor<MintApiTokenCommand> = (
+  c,
+) => ({ "user.id": c.userId });
+
+// The resolved inputs the mint core needs. The command is one source of
+// these; the device-flow poll is another (it mints on the user's behalf).
+export type MintApiTokenInput = {
+  readonly userId: UserId;
+  readonly label: string;
+  readonly expiresInDays: number;
+};
+
+// The plaintext `token` is returned to the caller exactly once (the endpoint
+// surfaces it); only its hash is persisted on `apiToken`.
+export type MintApiTokenResult = {
+  readonly apiToken: ApiToken;
+  readonly token: string;
+};
+
+// Raw handler effect — `ApiTokenRepository` is discharged by the wrap in
+// `auth-command-handlers.ts`; `UnitOfWork` is reintroduced by `withUnitOfWork`.
+export type MintApiTokenOutput = Effect.Effect<
+  MintApiTokenResult,
+  PersistenceUnavailable,
+  ApiTokenRepository | UnitOfWork
+>;

--- a/packages/server/src/modules/auth/commands/mint-api-token.test.ts
+++ b/packages/server/src/modules/auth/commands/mint-api-token.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { mintApiToken } from "@/modules/auth/commands/mint-api-token.js";
+import { MintApiTokenCommand } from "@/modules/auth/commands/mint-api-token-command.js";
+import { API_TOKEN_PREFIX, hashToken } from "@/modules/auth/domain/api-token-token.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/api-token-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const TestLayer = Layer.mergeAll(ApiTokenRepositoryFake, IdentityUnitOfWork);
+
+describe("mintApiToken", () => {
+  it.effect("returns a plaintext token once and persists only its hash", () =>
+    Effect.gen(function* () {
+      const { apiToken, token } = yield* mintApiToken(
+        MintApiTokenCommand.make({ userId, label: "ci", expiresInDays: 90 }),
+      );
+      // Plaintext is the prefixed opaque token; the stored hash matches it.
+      ok(token.startsWith(`${API_TOKEN_PREFIX}_`));
+      deepStrictEqual(apiToken.tokenHash, hashToken(token));
+      ok(!apiToken.tokenHash.includes(token));
+      // The display prefix is a leading, non-secret fragment of the token.
+      ok(token.startsWith(apiToken.prefix));
+      deepStrictEqual(apiToken.userId, userId);
+      deepStrictEqual(apiToken.label, "ci");
+      deepStrictEqual(apiToken.revokedAt, null);
+      ok(apiToken.expiresAt !== null);
+
+      // Round-trips: the minted token resolves by its hash.
+      const repo = yield* ApiTokenRepository;
+      const found = yield* repo.findByHash(hashToken(token));
+      deepStrictEqual(found.id, apiToken.id);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("mints distinct tokens on each call", () =>
+    Effect.gen(function* () {
+      const a = yield* mintApiToken(
+        MintApiTokenCommand.make({ userId, label: "a", expiresInDays: 1 }),
+      );
+      const b = yield* mintApiToken(
+        MintApiTokenCommand.make({ userId, label: "b", expiresInDays: 1 }),
+      );
+      ok(a.token !== b.token);
+      ok(a.apiToken.id !== b.apiToken.id);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/commands/mint-api-token.ts
+++ b/packages/server/src/modules/auth/commands/mint-api-token.ts
@@ -1,0 +1,56 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import {
+  type MintApiTokenCommand,
+  type MintApiTokenInput,
+  type MintApiTokenOutput,
+  type MintApiTokenResult,
+} from "@/modules/auth/commands/mint-api-token-command.js";
+import * as ApiToken from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { assembleToken, displayPrefix, hashToken } from "@/modules/auth/domain/api-token-token.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
+
+// Core mint, WITHOUT the unit-of-work boundary. Generates an opaque
+// `pat_<publicId>_<secret>`, persists only its sha256 hash, and returns the
+// plaintext once. Random generation is the sole impure step (kept in
+// `Effect.sync`); formatting + hashing are pure domain helpers shared with
+// the auth middleware's per-request lookup.
+//
+// Exposed sans-uow so a caller already inside a transaction (the device-flow
+// poll) can mint + consume its grant atomically without nesting a second
+// unit of work. `mintApiToken` adds the boundary for direct bus dispatch.
+export const mintApiTokenCore = (
+  input: MintApiTokenInput,
+): Effect.Effect<MintApiTokenResult, PersistenceUnavailable, ApiTokenRepository> =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    const { publicId, secret } = yield* Effect.sync(() => ({
+      publicId: randomBytes(4).toString("hex"),
+      secret: randomBytes(32).toString("base64url"),
+    }));
+    const token = assembleToken(publicId, secret);
+    const id = ApiTokenId.make(yield* Effect.sync(() => randomUUID()));
+    const now = yield* DateTime.now;
+    const apiToken = ApiToken.mint({
+      id,
+      userId: input.userId,
+      tokenHash: hashToken(token),
+      prefix: displayPrefix(publicId),
+      label: input.label,
+      now,
+      expiresAt: DateTime.add(now, { days: input.expiresInDays }),
+    });
+    yield* repo.insert(apiToken);
+    yield* Effect.annotateCurrentSpan("user.id", input.userId);
+    return { apiToken, token };
+  });
+
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const mintApiToken = (cmd: MintApiTokenCommand): MintApiTokenOutput =>
+  mintApiTokenCore(cmd).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/poll-device-grant-command.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant-command.ts
@@ -1,0 +1,35 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type MintApiTokenResult } from "@/modules/auth/commands/mint-api-token-command.js";
+import {
+  type DeviceGrantExpired,
+  type DeviceGrantNotFound,
+  type DeviceGrantPending,
+} from "@/modules/auth/domain/device-grant-errors.js";
+import { type ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/ports/unit-of-work.js";
+
+// CLI poll: exchange a device code for an app token once the grant is
+// approved. `tokenExpiresInDays` is resolved by the endpoint from config.
+export const PollDeviceGrantCommand = Schema.TaggedStruct("PollDeviceGrantCommand", {
+  deviceCode: Schema.String,
+  tokenExpiresInDays: Schema.Number,
+});
+export type PollDeviceGrantCommand = typeof PollDeviceGrantCommand.Type;
+
+// Deliberately empty: `deviceCode` is secret-derived and must not land in a span.
+export const pollDeviceGrantCommandSpanAttributes: SpanAttributesExtractor<
+  PollDeviceGrantCommand
+> = () => ({});
+
+// On success returns a freshly-minted token (plaintext once) — same shape as
+// the mint command, since the poll consumes the grant and mints on approval.
+export type PollDeviceGrantOutput = Effect.Effect<
+  MintApiTokenResult,
+  DeviceGrantNotFound | DeviceGrantExpired | DeviceGrantPending | PersistenceUnavailable,
+  DeviceGrantRepository | ApiTokenRepository | UnitOfWork
+>;

--- a/packages/server/src/modules/auth/commands/poll-device-grant.test.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
+import { approveDeviceGrant } from "@/modules/auth/commands/approve-device-grant.js";
+import { ApproveDeviceGrantCommand } from "@/modules/auth/commands/approve-device-grant-command.js";
+import { pollDeviceGrant } from "@/modules/auth/commands/poll-device-grant.js";
+import { PollDeviceGrantCommand } from "@/modules/auth/commands/poll-device-grant-command.js";
+import { startDeviceGrant } from "@/modules/auth/commands/start-device-grant.js";
+import { StartDeviceGrantCommand } from "@/modules/auth/commands/start-device-grant-command.js";
+import { hashToken } from "@/modules/auth/domain/api-token-token.js";
+import {
+  DeviceGrantExpired,
+  DeviceGrantNotFound,
+  DeviceGrantPending,
+} from "@/modules/auth/domain/device-grant-errors.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/api-token-repository-fake.js";
+import { DeviceGrantRepositoryFake } from "@/modules/auth/infrastructure/device-grant-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const TestLayer = Layer.mergeAll(
+  DeviceGrantRepositoryFake,
+  ApiTokenRepositoryFake,
+  IdentityUnitOfWork,
+);
+const poll = (deviceCode: string) =>
+  pollDeviceGrant(PollDeviceGrantCommand.make({ deviceCode, tokenExpiresInDays: 90 }));
+const errorOf = (exit: Exit.Exit<unknown, unknown>) =>
+  Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+
+describe("pollDeviceGrant", () => {
+  it.effect("fails DeviceGrantPending before approval", () =>
+    Effect.gen(function* () {
+      const { deviceCode } = yield* startDeviceGrant(
+        StartDeviceGrantCommand.make({ ttlSeconds: 600 }),
+      );
+      deepStrictEqual(
+        errorOf(yield* Effect.exit(poll(deviceCode))) instanceof DeviceGrantPending,
+        true,
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("mints a token on approval and consumes the grant (single-use)", () =>
+    Effect.gen(function* () {
+      const { deviceCode, userCode } = yield* startDeviceGrant(
+        StartDeviceGrantCommand.make({ ttlSeconds: 600 }),
+      );
+      yield* approveDeviceGrant(ApproveDeviceGrantCommand.make({ userCode, userId }));
+
+      const { apiToken, token } = yield* poll(deviceCode);
+      ok(token.startsWith("pat_"));
+      deepStrictEqual(apiToken.userId, userId);
+      // Minted token is resolvable by its hash…
+      const apiTokens = yield* ApiTokenRepository;
+      deepStrictEqual((yield* apiTokens.findByHash(hashToken(token))).id, apiToken.id);
+      // …and the grant is consumed: a second poll finds nothing.
+      const grants = yield* DeviceGrantRepository;
+      deepStrictEqual(
+        Exit.isFailure(yield* Effect.exit(grants.findByCodeHash(hashToken(deviceCode)))),
+        true,
+      );
+      deepStrictEqual(
+        errorOf(yield* Effect.exit(poll(deviceCode))) instanceof DeviceGrantNotFound,
+        true,
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails DeviceGrantExpired for a lapsed grant", () =>
+    Effect.gen(function* () {
+      const { deviceCode } = yield* startDeviceGrant(
+        StartDeviceGrantCommand.make({ ttlSeconds: -10 }),
+      );
+      deepStrictEqual(
+        errorOf(yield* Effect.exit(poll(deviceCode))) instanceof DeviceGrantExpired,
+        true,
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails DeviceGrantNotFound for an unknown device code", () =>
+    Effect.gen(function* () {
+      deepStrictEqual(
+        errorOf(yield* Effect.exit(poll("bogus"))) instanceof DeviceGrantNotFound,
+        true,
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/commands/poll-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant.ts
@@ -1,0 +1,50 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import { mintApiTokenCore } from "@/modules/auth/commands/mint-api-token.js";
+import {
+  type PollDeviceGrantCommand,
+  type PollDeviceGrantOutput,
+} from "@/modules/auth/commands/poll-device-grant-command.js";
+import { hashToken } from "@/modules/auth/domain/api-token-token.js";
+import * as DeviceGrant from "@/modules/auth/domain/device-grant.aggregate.js";
+import {
+  DeviceGrantExpired,
+  DeviceGrantPending,
+} from "@/modules/auth/domain/device-grant-errors.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
+
+// Single-use exchange. Hashes the presented device code, then:
+//   - lapsed grant  → consume it + fail `DeviceGrantExpired`
+//   - still pending  → fail `DeviceGrantPending` (CLI keeps polling)
+//   - approved       → mint a token AND consume the grant in one transaction
+//                      (so a token can never be minted twice from one grant).
+// Minting reuses `mintApiTokenCore` (sans its own uow) to stay in this single
+// transaction rather than nesting a savepoint.
+//
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const pollDeviceGrant = (cmd: PollDeviceGrantCommand): PollDeviceGrantOutput =>
+  Effect.gen(function* () {
+    const grants = yield* DeviceGrantRepository;
+    const grant = yield* grants.findByCodeHash(hashToken(cmd.deviceCode));
+    const now = yield* DateTime.now;
+
+    if (DeviceGrant.isExpired(grant, now)) {
+      yield* grants
+        .delete(grant.id)
+        .pipe(Effect.catchTag("DeviceGrantNotFound", () => Effect.void));
+      return yield* Effect.fail(new DeviceGrantExpired());
+    }
+    if (grant.status === "pending" || grant.userId === null) {
+      return yield* Effect.fail(new DeviceGrantPending());
+    }
+
+    const minted = yield* mintApiTokenCore({
+      userId: grant.userId,
+      label: "cli",
+      expiresInDays: cmd.tokenExpiresInDays,
+    });
+    yield* grants.delete(grant.id);
+    return minted;
+  }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/revoke-api-token-command.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token-command.ts
@@ -1,0 +1,31 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type ApiTokenNotFound } from "@/modules/auth/domain/api-token-errors.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { type ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/ports/unit-of-work.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Revokes one of the caller's own tokens. Carries `userId` so the handler
+// can scope the revoke to the owner — a token belonging to someone else is
+// reported as `ApiTokenNotFound`, never revealed.
+export const RevokeApiTokenCommand = Schema.TaggedStruct("RevokeApiTokenCommand", {
+  apiTokenId: ApiTokenId,
+  userId: UserId,
+});
+export type RevokeApiTokenCommand = typeof RevokeApiTokenCommand.Type;
+
+export const revokeApiTokenCommandSpanAttributes: SpanAttributesExtractor<RevokeApiTokenCommand> = (
+  c,
+) => ({ "auth.api_token.id": c.apiTokenId, "user.id": c.userId });
+
+// Raw handler effect — `ApiTokenRepository` is discharged by the wrap in
+// `auth-command-handlers.ts`; `UnitOfWork` is reintroduced by `withUnitOfWork`.
+export type RevokeApiTokenOutput = Effect.Effect<
+  void,
+  ApiTokenNotFound | PersistenceUnavailable,
+  ApiTokenRepository | UnitOfWork
+>;

--- a/packages/server/src/modules/auth/commands/revoke-api-token.test.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
+import { mintApiToken } from "@/modules/auth/commands/mint-api-token.js";
+import { MintApiTokenCommand } from "@/modules/auth/commands/mint-api-token-command.js";
+import { revokeApiToken } from "@/modules/auth/commands/revoke-api-token.js";
+import { RevokeApiTokenCommand } from "@/modules/auth/commands/revoke-api-token-command.js";
+import { ApiTokenNotFound } from "@/modules/auth/domain/api-token-errors.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/api-token-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");
+const TestLayer = Layer.mergeAll(ApiTokenRepositoryFake, IdentityUnitOfWork);
+
+const mint = (owner: UserId) =>
+  mintApiToken(MintApiTokenCommand.make({ userId: owner, label: "ci", expiresInDays: 90 }));
+
+describe("revokeApiToken", () => {
+  it.effect("revokes the caller's own token", () =>
+    Effect.gen(function* () {
+      const { apiToken } = yield* mint(userId);
+      yield* revokeApiToken(RevokeApiTokenCommand.make({ apiTokenId: apiToken.id, userId }));
+      const repo = yield* ApiTokenRepository;
+      deepStrictEqual((yield* repo.findById(apiToken.id)).revokedAt !== null, true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("refuses (as NotFound) to revoke another user's token, leaving it active", () =>
+    Effect.gen(function* () {
+      const { apiToken } = yield* mint(otherUserId);
+      const exit = yield* Effect.exit(
+        revokeApiToken(RevokeApiTokenCommand.make({ apiTokenId: apiToken.id, userId })),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof ApiTokenNotFound, true);
+      }
+      const repo = yield* ApiTokenRepository;
+      deepStrictEqual((yield* repo.findById(apiToken.id)).revokedAt, null);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("fails ApiTokenNotFound for an unknown id", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        revokeApiToken(
+          RevokeApiTokenCommand.make({
+            apiTokenId: ApiTokenId.make("99999999-9999-9999-9999-999999999999"),
+            userId,
+          }),
+        ),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/commands/revoke-api-token.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token.ts
@@ -1,0 +1,24 @@
+import * as Effect from "effect/Effect";
+
+import {
+  type RevokeApiTokenCommand,
+  type RevokeApiTokenOutput,
+} from "@/modules/auth/commands/revoke-api-token-command.js";
+import { ApiTokenNotFound } from "@/modules/auth/domain/api-token-errors.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
+
+// Ownership-scoped revoke: load the token, refuse (as NotFound) if it isn't
+// the caller's, then soft-delete. Returning NotFound for a foreign token
+// avoids leaking the existence of other users' tokens.
+//
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const revokeApiToken = (cmd: RevokeApiTokenCommand): RevokeApiTokenOutput =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    const token = yield* repo.findById(cmd.apiTokenId);
+    if (token.userId !== cmd.userId) {
+      return yield* Effect.fail(new ApiTokenNotFound());
+    }
+    yield* repo.delete(cmd.apiTokenId);
+  }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/start-device-grant-command.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant-command.ts
@@ -1,0 +1,35 @@
+import type * as DateTime from "effect/DateTime";
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { type UnitOfWork } from "@/platform/ddd/ports/unit-of-work.js";
+
+// Begins a device authorization grant. `ttlSeconds` is resolved by the
+// endpoint from config so the handler computes `expiresAt` against the
+// server clock.
+export const StartDeviceGrantCommand = Schema.TaggedStruct("StartDeviceGrantCommand", {
+  ttlSeconds: Schema.Number,
+});
+export type StartDeviceGrantCommand = typeof StartDeviceGrantCommand.Type;
+
+export const startDeviceGrantCommandSpanAttributes: SpanAttributesExtractor<
+  StartDeviceGrantCommand
+> = () => ({});
+
+// The plaintext `deviceCode` is returned to the CLI once (it holds it and
+// polls with it); only its hash is persisted. `userCode` is what the human
+// types in the browser.
+export type StartDeviceGrantResult = {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly expiresAt: DateTime.Utc;
+};
+
+export type StartDeviceGrantOutput = Effect.Effect<
+  StartDeviceGrantResult,
+  PersistenceUnavailable,
+  DeviceGrantRepository | UnitOfWork
+>;

--- a/packages/server/src/modules/auth/commands/start-device-grant.test.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { startDeviceGrant } from "@/modules/auth/commands/start-device-grant.js";
+import { StartDeviceGrantCommand } from "@/modules/auth/commands/start-device-grant-command.js";
+import { hashToken } from "@/modules/auth/domain/api-token-token.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { DeviceGrantRepositoryFake } from "@/modules/auth/infrastructure/device-grant-repository-fake.js";
+import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
+
+const TestLayer = Layer.mergeAll(DeviceGrantRepositoryFake, IdentityUnitOfWork);
+
+describe("startDeviceGrant", () => {
+  it.effect("returns codes and persists a pending grant keyed by the device-code hash", () =>
+    Effect.gen(function* () {
+      const { deviceCode, userCode } = yield* startDeviceGrant(
+        StartDeviceGrantCommand.make({ ttlSeconds: 600 }),
+      );
+      ok(deviceCode.length > 0);
+      ok(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(userCode));
+
+      const repo = yield* DeviceGrantRepository;
+      const stored = yield* repo.findByCodeHash(hashToken(deviceCode));
+      deepStrictEqual(stored.status, "pending");
+      deepStrictEqual(stored.userId, null);
+      deepStrictEqual(stored.userCode, userCode);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/commands/start-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant.ts
@@ -1,0 +1,42 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import {
+  type StartDeviceGrantCommand,
+  type StartDeviceGrantOutput,
+} from "@/modules/auth/commands/start-device-grant-command.js";
+import { hashToken } from "@/modules/auth/domain/api-token-token.js";
+import * as DeviceGrant from "@/modules/auth/domain/device-grant.aggregate.js";
+import { toUserCode } from "@/modules/auth/domain/device-grant-codes.js";
+import { DeviceGrantId } from "@/modules/auth/domain/device-grant-id.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
+
+// Mints a high-entropy device code (returned once, only its hash stored) and
+// a short human-typable user code, persists a pending grant, and returns the
+// codes for the CLI + the verification page. A user-code collision within
+// the short TTL window is astronomically unlikely; if one ever hit the
+// unique index, the insert surfaces as a defect (retry is the CLI's job).
+//
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const startDeviceGrant = (cmd: StartDeviceGrantCommand): StartDeviceGrantOutput =>
+  Effect.gen(function* () {
+    const repo = yield* DeviceGrantRepository;
+    const { deviceCode, userCode } = yield* Effect.sync(() => ({
+      deviceCode: randomBytes(32).toString("base64url"),
+      userCode: toUserCode(randomBytes(8)),
+    }));
+    const id = DeviceGrantId.make(yield* Effect.sync(() => randomUUID()));
+    const now = yield* DateTime.now;
+    const grant = DeviceGrant.start({
+      id,
+      deviceCodeHash: hashToken(deviceCode),
+      userCode,
+      now,
+      ttlSeconds: cmd.ttlSeconds,
+    });
+    yield* repo.insert(grant);
+    return { deviceCode, userCode, expiresAt: grant.expiresAt };
+  }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/start-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant.ts
@@ -26,7 +26,7 @@ export const startDeviceGrant = (cmd: StartDeviceGrantCommand): StartDeviceGrant
     const repo = yield* DeviceGrantRepository;
     const { deviceCode, userCode } = yield* Effect.sync(() => ({
       deviceCode: randomBytes(32).toString("base64url"),
-      userCode: toUserCode(randomBytes(8)),
+      userCode: toUserCode(randomBytes(16)),
     }));
     const id = DeviceGrantId.make(yield* Effect.sync(() => randomUUID()));
     const now = yield* DateTime.now;

--- a/packages/server/src/modules/auth/commands/touch-api-token-command.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token-command.ts
@@ -1,0 +1,25 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { type ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+
+// Records last-used time for a token, dispatched by the auth middleware
+// after a successful bearer lookup. Throttled + race-tolerant in the handler
+// (mirrors `TouchSessionCommand`), so it's safe to fire on every request.
+// Unlike sessions there is no sliding TTL — this only stamps `lastUsedAt`.
+export const TouchApiTokenCommand = Schema.TaggedStruct("TouchApiTokenCommand", {
+  apiTokenId: ApiTokenId,
+  thresholdSeconds: Schema.Number,
+});
+export type TouchApiTokenCommand = typeof TouchApiTokenCommand.Type;
+
+export const touchApiTokenCommandSpanAttributes: SpanAttributesExtractor<TouchApiTokenCommand> = (
+  c,
+) => ({ "auth.api_token.id": c.apiTokenId });
+
+// Raw handler effect — `ApiTokenRepository` is discharged by the wrap in
+// `auth-command-handlers.ts`. Errors are swallowed (benign races / transient
+// store), so the channel is `never`.
+export type TouchApiTokenOutput = Effect.Effect<void, never, ApiTokenRepository>;

--- a/packages/server/src/modules/auth/commands/touch-api-token.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import { touchApiToken } from "@/modules/auth/commands/touch-api-token.js";
+import { TouchApiTokenCommand } from "@/modules/auth/commands/touch-api-token-command.js";
+import * as ApiToken from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/api-token-repository-fake.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+const apiTokenId = ApiTokenId.make("11111111-1111-1111-1111-111111111111");
+const userId = UserId.make("22222222-2222-2222-2222-222222222222");
+
+const seed = (lastUsedAt: DateTime.Utc) =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    const token = ApiToken.mint({
+      id: apiTokenId,
+      userId,
+      tokenHash: "hash",
+      prefix: "pat_abcd1234",
+      label: "ci",
+      now: lastUsedAt,
+      expiresAt: DateTime.add(lastUsedAt, { days: 90 }),
+    });
+    yield* repo.insert(token);
+    return token;
+  });
+
+const cmd = TouchApiTokenCommand.make({ apiTokenId, thresholdSeconds: 60 });
+const provide = Effect.provide(ApiTokenRepositoryFake);
+
+describe("touchApiToken", () => {
+  // `it.live` uses the real Clock so `DateTime.now` in the handler is "now",
+  // making the throttle window meaningful (the TestClock sits at epoch 0).
+  it.live("stamps lastUsedAt once the throttle window has elapsed", () =>
+    Effect.gen(function* () {
+      const farPast = DateTime.unsafeMake(new Date("2000-01-01T00:00:00Z"));
+      const before = yield* seed(farPast);
+      yield* touchApiToken(cmd);
+      const repo = yield* ApiTokenRepository;
+      const after = yield* repo.findById(apiTokenId);
+      deepStrictEqual(DateTime.greaterThan(after.lastUsedAt, before.lastUsedAt), true);
+      // Fixed expiry: touch must NOT extend it.
+      deepStrictEqual(after.expiresAt, before.expiresAt);
+    }).pipe(provide),
+  );
+
+  it.live("skips the write while within the throttle window", () =>
+    Effect.gen(function* () {
+      const justNow = yield* DateTime.now;
+      const before = yield* seed(justNow);
+      yield* touchApiToken(TouchApiTokenCommand.make({ apiTokenId, thresholdSeconds: 3600 }));
+      const repo = yield* ApiTokenRepository;
+      const after = yield* repo.findById(apiTokenId);
+      deepStrictEqual(after.lastUsedAt, before.lastUsedAt);
+    }).pipe(provide),
+  );
+
+  it.effect("is a no-op on a missing token (error channel is never)", () =>
+    Effect.gen(function* () {
+      yield* touchApiToken(cmd);
+      deepStrictEqual(true, true);
+    }).pipe(provide),
+  );
+});

--- a/packages/server/src/modules/auth/commands/touch-api-token.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token.ts
@@ -1,0 +1,39 @@
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+
+import {
+  type TouchApiTokenCommand,
+  type TouchApiTokenOutput,
+} from "@/modules/auth/commands/touch-api-token-command.js";
+import * as ApiToken from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+
+// Last-used stamp, throttled + race-tolerant.
+//
+// Throttled: skip the write when the prior `lastUsedAt` is younger than
+// `thresholdSeconds`, so a chatty CLI/MCP doesn't UPDATE on every call.
+// Race/transient-tolerant: a token revoked or removed between the
+// middleware's lookup and our update is benign (`update` fails NotFound),
+// and a transient store outage shouldn't fail a request the bearer check
+// already authorized — both are swallowed.
+//
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const touchApiToken = (cmd: TouchApiTokenCommand): TouchApiTokenOutput =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    const token = yield* repo.findById(cmd.apiTokenId).pipe(
+      Effect.catchTag("ApiTokenNotFound", () => Effect.succeed(null)),
+      Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)),
+    );
+    if (token?.revokedAt !== null) return;
+
+    const now = yield* DateTime.now;
+    const elapsed = DateTime.distanceDuration(token.lastUsedAt, now);
+    if (Duration.lessThan(elapsed, Duration.seconds(cmd.thresholdSeconds))) return;
+
+    yield* repo.update(ApiToken.touch({ token, now })).pipe(
+      Effect.catchTag("ApiTokenNotFound", () => Effect.void),
+      Effect.catchTag("PersistenceUnavailable", () => Effect.void),
+    );
+  });

--- a/packages/server/src/modules/auth/domain/api-token-errors.ts
+++ b/packages/server/src/modules/auth/domain/api-token-errors.ts
@@ -1,0 +1,20 @@
+import * as Schema from "effect/Schema";
+
+// Fieldless: raised both by `findById` (revoke path — the caller already
+// holds the id from the request) and by `findByHash` (per-request lookup,
+// where a miss has no id to report). Keeping it fieldless lets one error
+// serve both without an awkward optional id.
+export class ApiTokenNotFound extends Schema.TaggedError<ApiTokenNotFound>("ApiTokenNotFound")(
+  "ApiTokenNotFound",
+  {},
+) {}
+
+export class ApiTokenExpired extends Schema.TaggedError<ApiTokenExpired>("ApiTokenExpired")(
+  "ApiTokenExpired",
+  {},
+) {}
+
+export class ApiTokenRevoked extends Schema.TaggedError<ApiTokenRevoked>("ApiTokenRevoked")(
+  "ApiTokenRevoked",
+  {},
+) {}

--- a/packages/server/src/modules/auth/domain/api-token-id.ts
+++ b/packages/server/src/modules/auth/domain/api-token-id.ts
@@ -1,0 +1,9 @@
+import * as Schema from "effect/Schema";
+
+// Module-internal id for an `ApiToken`, mirroring `SessionId`. The
+// contract exposes a structurally-compatible `ApiTokenId` brand
+// (`@org/contracts/EntityIds`) for the wire types; both resolve to
+// `string & Brand<"ApiTokenId">`, so a domain id flows into a contract
+// field without a cast.
+export const ApiTokenId = Schema.UUID.pipe(Schema.brand("ApiTokenId"));
+export type ApiTokenId = typeof ApiTokenId.Type;

--- a/packages/server/src/modules/auth/domain/api-token-token.test.ts
+++ b/packages/server/src/modules/auth/domain/api-token-token.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+
+import { API_TOKEN_PREFIX, assembleToken, displayPrefix, hashToken } from "./api-token-token.js";
+
+describe("api-token-token", () => {
+  it("assembles the wire format pat_<publicId>_<secret>", () => {
+    deepStrictEqual(assembleToken("abcd1234", "secret"), `${API_TOKEN_PREFIX}_abcd1234_secret`);
+  });
+
+  it("derives a non-secret display prefix that omits the secret", () => {
+    const token = assembleToken("abcd1234", "supersecretvalue");
+    const prefix = displayPrefix("abcd1234");
+    deepStrictEqual(prefix, "pat_abcd1234");
+    ok(!prefix.includes("supersecretvalue"));
+    ok(token.startsWith(prefix));
+  });
+
+  it("hashes deterministically and differs across inputs", () => {
+    deepStrictEqual(hashToken("pat_a_b"), hashToken("pat_a_b"));
+    ok(hashToken("pat_a_b") !== hashToken("pat_a_c"));
+    // sha256 hex is 64 chars
+    deepStrictEqual(hashToken("anything").length, 64);
+  });
+});

--- a/packages/server/src/modules/auth/domain/api-token-token.ts
+++ b/packages/server/src/modules/auth/domain/api-token-token.ts
@@ -1,0 +1,26 @@
+import { createHash } from "node:crypto";
+
+// Pure token-format helpers for the `ApiToken` credential. Random secret
+// generation (the only impure step) lives in the mint command via
+// `Effect.sync`; everything here is deterministic so it stays in the
+// domain. `hashToken` is shared with the auth middleware (via the module
+// barrel) so the mint-time hash and the per-request lookup hash agree.
+//
+// Wire format: `pat_<publicId>_<secret>`.
+//   - `publicId` is a short, NON-secret random id surfaced as the display
+//     `prefix` so an owner can tell tokens apart in a listing.
+//   - `secret` is high-entropy (32 random bytes); only its sha256 hash is
+//     ever persisted.
+
+export const API_TOKEN_PREFIX = "pat";
+
+export const assembleToken = (publicId: string, secret: string): string =>
+  `${API_TOKEN_PREFIX}_${publicId}_${secret}`;
+
+export const displayPrefix = (publicId: string): string => `${API_TOKEN_PREFIX}_${publicId}`;
+
+// sha256 hex. The tokens are high-entropy random values, so an unsalted
+// digest is sufficient — there is no low-entropy space to brute-force if
+// the column ever leaks.
+export const hashToken = (token: string): string =>
+  createHash("sha256").update(token).digest("hex");

--- a/packages/server/src/modules/auth/domain/api-token.aggregate.test.ts
+++ b/packages/server/src/modules/auth/domain/api-token.aggregate.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import * as ApiToken from "./api-token.aggregate.js";
+import { ApiTokenId } from "./api-token-id.js";
+
+const apiTokenId = ApiTokenId.make("11111111-1111-1111-1111-111111111111");
+const userId = UserId.make("22222222-2222-2222-2222-222222222222");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+
+const mint = (expiresAt: DateTime.Utc | null) =>
+  ApiToken.mint({
+    id: apiTokenId,
+    userId,
+    tokenHash: "hash",
+    prefix: "pat_abcd1234",
+    label: "ci",
+    now,
+    expiresAt,
+  });
+
+describe("ApiToken.mint", () => {
+  it("populates required fields and starts unrevoked", () => {
+    const expiresAt = DateTime.add(now, { days: 90 });
+    const token = mint(expiresAt);
+    deepStrictEqual(token.id, apiTokenId);
+    deepStrictEqual(token.userId, userId);
+    deepStrictEqual(token.label, "ci");
+    deepStrictEqual(token.prefix, "pat_abcd1234");
+    deepStrictEqual(token.expiresAt, expiresAt);
+    deepStrictEqual(token.revokedAt, null);
+    deepStrictEqual(token.createdAt, now);
+    deepStrictEqual(token.lastUsedAt, now);
+  });
+});
+
+describe("ApiToken.touch", () => {
+  it("advances lastUsedAt but never extends expiresAt (fixed expiry)", () => {
+    const expiresAt = DateTime.add(now, { days: 90 });
+    const seed = mint(expiresAt);
+    const later = DateTime.add(now, { days: 1 });
+    const touched = ApiToken.touch({ token: seed, now: later });
+    deepStrictEqual(touched.lastUsedAt, later);
+    deepStrictEqual(touched.expiresAt, expiresAt);
+    deepStrictEqual(touched.id, seed.id);
+    deepStrictEqual(touched.createdAt, seed.createdAt);
+    deepStrictEqual(touched.tokenHash, seed.tokenHash);
+  });
+});
+
+describe("ApiToken.isExpired", () => {
+  it("is false before the expiry instant and true at/after it", () => {
+    const expiresAt = DateTime.add(now, { days: 90 });
+    const token = mint(expiresAt);
+    deepStrictEqual(ApiToken.isExpired(token, now), false);
+    deepStrictEqual(ApiToken.isExpired(token, expiresAt), true);
+    deepStrictEqual(ApiToken.isExpired(token, DateTime.add(expiresAt, { seconds: 1 })), true);
+  });
+
+  it("treats a null expiresAt as non-expiring", () => {
+    const token = mint(null);
+    deepStrictEqual(ApiToken.isExpired(token, DateTime.add(now, { days: 100000 })), false);
+  });
+});

--- a/packages/server/src/modules/auth/domain/api-token.aggregate.ts
+++ b/packages/server/src/modules/auth/domain/api-token.aggregate.ts
@@ -1,0 +1,74 @@
+import * as DateTime from "effect/DateTime";
+import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { ApiTokenId } from "./api-token-id.js";
+
+// A long-lived bearer credential a user mints for the CLI / MCP / CI. Unlike
+// `Session` (sliding TTL), an `ApiToken` has a FIXED expiry: it lapses at a
+// wall-clock instant regardless of use. Only the sha256 hash of the secret
+// is retained (`tokenHash`); the plaintext is shown once at mint time.
+export class ApiToken extends Schema.Class<ApiToken>("ApiToken")({
+  id: ApiTokenId,
+  userId: UserId,
+  tokenHash: Schema.String,
+  // Non-secret display fragment (`pat_<publicId>`).
+  prefix: Schema.String,
+  label: Schema.String,
+  // Nullable to leave room for non-expiring tokens later; `mint` always
+  // sets it in v1.
+  expiresAt: Schema.NullOr(Schema.DateTimeUtc),
+  revokedAt: Schema.NullOr(Schema.DateTimeUtc),
+  createdAt: Schema.DateTimeUtc,
+  lastUsedAt: Schema.DateTimeUtc,
+}) {}
+
+export type MintInput = {
+  readonly id: ApiTokenId;
+  readonly userId: UserId;
+  readonly tokenHash: string;
+  readonly prefix: string;
+  readonly label: string;
+  readonly now: DateTime.Utc;
+  readonly expiresAt: DateTime.Utc | null;
+};
+
+export const mint = (input: MintInput): ApiToken =>
+  ApiToken.make({
+    id: input.id,
+    userId: input.userId,
+    tokenHash: input.tokenHash,
+    prefix: input.prefix,
+    label: input.label,
+    expiresAt: input.expiresAt,
+    revokedAt: null,
+    createdAt: input.now,
+    lastUsedAt: input.now,
+  });
+
+export type TouchInput = {
+  readonly token: ApiToken;
+  readonly now: DateTime.Utc;
+};
+
+// Records usage only — stamps `lastUsedAt`. Deliberately does NOT advance
+// `expiresAt`: API tokens are fixed-expiry, so usage never extends their
+// lifetime (the contrast with `Session.touch`, which slides the window).
+export const touch = (input: TouchInput): ApiToken =>
+  ApiToken.make({
+    id: input.token.id,
+    userId: input.token.userId,
+    tokenHash: input.token.tokenHash,
+    prefix: input.token.prefix,
+    label: input.token.label,
+    expiresAt: input.token.expiresAt,
+    revokedAt: input.token.revokedAt,
+    createdAt: input.token.createdAt,
+    lastUsedAt: input.now,
+  });
+
+// A null `expiresAt` means non-expiring (reserved for later); such a token
+// never lapses on time alone.
+export const isExpired = (token: ApiToken, now: DateTime.Utc): boolean =>
+  token.expiresAt !== null && DateTime.lessThanOrEqualTo(token.expiresAt, now);

--- a/packages/server/src/modules/auth/domain/device-grant-codes.test.ts
+++ b/packages/server/src/modules/auth/domain/device-grant-codes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest";
-import { deepStrictEqual, ok } from "assert";
+import { deepStrictEqual, ok, throws } from "assert";
 
 import { toUserCode, USER_CODE_ALPHABET } from "./device-grant-codes.js";
 
@@ -14,5 +14,15 @@ describe("toUserCode", () => {
     const code = toUserCode(new Uint8Array([255, 254, 253, 252, 251, 250, 249, 248]));
     for (const ch of code.replace("-", "")) ok(USER_CODE_ALPHABET.includes(ch));
     ok(!/[O01I]/.test(code));
+  });
+
+  it("consumes the first 8 usable bytes; the 32-char alphabet divides 256 so none are rejected", () => {
+    // limit = 256 - (256 % 32) = 256, so every byte 0..255 is accepted and the
+    // first 8 are used verbatim; trailing bytes are headroom for the rejection guard.
+    deepStrictEqual(toUserCode(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 99, 99])), "ABCD-EFGH");
+  });
+
+  it("throws when there are too few bytes to build 8 characters", () => {
+    throws(() => toUserCode(new Uint8Array([0, 1, 2])), /not enough random bytes/);
   });
 });

--- a/packages/server/src/modules/auth/domain/device-grant-codes.test.ts
+++ b/packages/server/src/modules/auth/domain/device-grant-codes.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+
+import { toUserCode, USER_CODE_ALPHABET } from "./device-grant-codes.js";
+
+describe("toUserCode", () => {
+  it("formats 8 chars as XXXX-XXXX from the confusable-free alphabet", () => {
+    const code = toUserCode(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]));
+    deepStrictEqual(code, "ABCD-EFGH");
+    deepStrictEqual(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(code), true);
+  });
+
+  it("maps every byte into the alphabet (modulo) and omits 0/O/1/I", () => {
+    const code = toUserCode(new Uint8Array([255, 254, 253, 252, 251, 250, 249, 248]));
+    for (const ch of code.replace("-", "")) ok(USER_CODE_ALPHABET.includes(ch));
+    ok(!/[O01I]/.test(code));
+  });
+});

--- a/packages/server/src/modules/auth/domain/device-grant-codes.ts
+++ b/packages/server/src/modules/auth/domain/device-grant-codes.ts
@@ -6,11 +6,24 @@
 // No 0/O/1/I — they're easy to mistype off a screen.
 export const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
+// Maps random `bytes` onto the alphabet via rejection sampling: any byte in
+// the biased tail (>= the largest multiple of the alphabet length that fits
+// in 256) is discarded, so every symbol stays equally likely regardless of
+// the alphabet length. For the current 32-char alphabet 256 is an exact
+// multiple, so nothing is ever rejected — but the guard keeps the mapping
+// uniform if the alphabet ever changes. Caller must supply enough bytes; the
+// start command overdraws so exhaustion can't happen in practice.
 export const toUserCode = (bytes: Uint8Array): string => {
+  const n = USER_CODE_ALPHABET.length;
+  const limit = 256 - (256 % n);
   let chars = "";
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < bytes.length && chars.length < 8; i++) {
     const byte = bytes[i] ?? 0;
-    chars += USER_CODE_ALPHABET[byte % USER_CODE_ALPHABET.length];
+    if (byte >= limit) continue;
+    chars += USER_CODE_ALPHABET[byte % n];
+  }
+  if (chars.length < 8) {
+    throw new Error("toUserCode: not enough random bytes to build a user code");
   }
   return `${chars.slice(0, 4)}-${chars.slice(4, 8)}`;
 };

--- a/packages/server/src/modules/auth/domain/device-grant-codes.ts
+++ b/packages/server/src/modules/auth/domain/device-grant-codes.ts
@@ -1,0 +1,16 @@
+// Pure helper for the human-typable user code. Random generation (the impure
+// step) lives in the start command; this maps random bytes deterministically
+// onto a confusable-free alphabet and formats it `XXXX-XXXX`. Device-code
+// hashing reuses `hashToken` from `api-token-token.ts` (same sha256 scheme).
+
+// No 0/O/1/I — they're easy to mistype off a screen.
+export const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+export const toUserCode = (bytes: Uint8Array): string => {
+  let chars = "";
+  for (let i = 0; i < 8; i++) {
+    const byte = bytes[i] ?? 0;
+    chars += USER_CODE_ALPHABET[byte % USER_CODE_ALPHABET.length];
+  }
+  return `${chars.slice(0, 4)}-${chars.slice(4, 8)}`;
+};

--- a/packages/server/src/modules/auth/domain/device-grant-errors.ts
+++ b/packages/server/src/modules/auth/domain/device-grant-errors.ts
@@ -1,0 +1,17 @@
+import * as Schema from "effect/Schema";
+
+// Unknown device_code / user_code, or a consumed (deleted) grant.
+export class DeviceGrantNotFound extends Schema.TaggedError<DeviceGrantNotFound>(
+  "DeviceGrantNotFound",
+)("DeviceGrantNotFound", {}) {}
+
+// The grant's short TTL has lapsed.
+export class DeviceGrantExpired extends Schema.TaggedError<DeviceGrantExpired>(
+  "DeviceGrantExpired",
+)("DeviceGrantExpired", {}) {}
+
+// Not yet approved in the browser — the CLI should keep polling. RFC 8628's
+// `authorization_pending`.
+export class DeviceGrantPending extends Schema.TaggedError<DeviceGrantPending>(
+  "DeviceGrantPending",
+)("DeviceGrantPending", {}) {}

--- a/packages/server/src/modules/auth/domain/device-grant-id.ts
+++ b/packages/server/src/modules/auth/domain/device-grant-id.ts
@@ -1,0 +1,4 @@
+import * as Schema from "effect/Schema";
+
+export const DeviceGrantId = Schema.UUID.pipe(Schema.brand("DeviceGrantId"));
+export type DeviceGrantId = typeof DeviceGrantId.Type;

--- a/packages/server/src/modules/auth/domain/device-grant.aggregate.test.ts
+++ b/packages/server/src/modules/auth/domain/device-grant.aggregate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import * as DeviceGrant from "./device-grant.aggregate.js";
+import { DeviceGrantId } from "./device-grant-id.js";
+
+const id = DeviceGrantId.make("11111111-1111-1111-1111-111111111111");
+const userId = UserId.make("22222222-2222-2222-2222-222222222222");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+
+const start = () =>
+  DeviceGrant.start({ id, deviceCodeHash: "hash", userCode: "ABCD-2345", now, ttlSeconds: 600 });
+
+describe("DeviceGrant.start", () => {
+  it("creates a pending, unapproved grant with a TTL'd expiry", () => {
+    const grant = start();
+    deepStrictEqual(grant.status, "pending");
+    deepStrictEqual(grant.userId, null);
+    deepStrictEqual(grant.approvedAt, null);
+    deepStrictEqual(grant.createdAt, now);
+    deepStrictEqual(grant.expiresAt, DateTime.add(now, { seconds: 600 }));
+  });
+});
+
+describe("DeviceGrant.approve", () => {
+  it("binds the grant to the approving user and stamps approvedAt", () => {
+    const later = DateTime.add(now, { seconds: 30 });
+    const approved = DeviceGrant.approve({ grant: start(), userId, now: later });
+    deepStrictEqual(approved.status, "approved");
+    deepStrictEqual(approved.userId, userId);
+    deepStrictEqual(approved.approvedAt, later);
+    // identity + lifecycle window preserved
+    deepStrictEqual(approved.id, id);
+    deepStrictEqual(approved.expiresAt, start().expiresAt);
+  });
+});
+
+describe("DeviceGrant.isExpired", () => {
+  it("is false before expiry and true at/after it", () => {
+    const grant = start();
+    deepStrictEqual(DeviceGrant.isExpired(grant, now), false);
+    deepStrictEqual(DeviceGrant.isExpired(grant, grant.expiresAt), true);
+    deepStrictEqual(
+      DeviceGrant.isExpired(grant, DateTime.add(grant.expiresAt, { seconds: 1 })),
+      true,
+    );
+  });
+});

--- a/packages/server/src/modules/auth/domain/device-grant.aggregate.ts
+++ b/packages/server/src/modules/auth/domain/device-grant.aggregate.ts
@@ -1,0 +1,66 @@
+import * as DateTime from "effect/DateTime";
+import * as Schema from "effect/Schema";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { DeviceGrantId } from "./device-grant-id.js";
+
+// A short-lived OAuth 2.0 Device Authorization Grant (RFC 8628), app-native:
+// the CLI starts one, the user approves it in the browser (already signed in),
+// and the CLI polls until it can exchange the device code for an app token.
+// Only the sha256 hash of the device code is retained; the user code is a
+// low-entropy, single-use, short-TTL value typed by a human, stored plaintext.
+export class DeviceGrant extends Schema.Class<DeviceGrant>("DeviceGrant")({
+  id: DeviceGrantId,
+  deviceCodeHash: Schema.String,
+  userCode: Schema.String,
+  status: Schema.Literal("pending", "approved"),
+  userId: Schema.NullOr(UserId),
+  createdAt: Schema.DateTimeUtc,
+  expiresAt: Schema.DateTimeUtc,
+  approvedAt: Schema.NullOr(Schema.DateTimeUtc),
+}) {}
+
+export type StartInput = {
+  readonly id: DeviceGrantId;
+  readonly deviceCodeHash: string;
+  readonly userCode: string;
+  readonly now: DateTime.Utc;
+  readonly ttlSeconds: number;
+};
+
+export const start = (input: StartInput): DeviceGrant =>
+  DeviceGrant.make({
+    id: input.id,
+    deviceCodeHash: input.deviceCodeHash,
+    userCode: input.userCode,
+    status: "pending",
+    userId: null,
+    createdAt: input.now,
+    expiresAt: DateTime.add(input.now, { seconds: input.ttlSeconds }),
+    approvedAt: null,
+  });
+
+export type ApproveInput = {
+  readonly grant: DeviceGrant;
+  readonly userId: UserId;
+  readonly now: DateTime.Utc;
+};
+
+// Binds the grant to the approving user. Pure; the use case enforces the
+// guards (must be unexpired) before calling. Idempotent on an
+// already-approved grant — re-approval just re-stamps.
+export const approve = (input: ApproveInput): DeviceGrant =>
+  DeviceGrant.make({
+    id: input.grant.id,
+    deviceCodeHash: input.grant.deviceCodeHash,
+    userCode: input.grant.userCode,
+    status: "approved",
+    userId: input.userId,
+    createdAt: input.grant.createdAt,
+    expiresAt: input.grant.expiresAt,
+    approvedAt: input.now,
+  });
+
+export const isExpired = (grant: DeviceGrant, now: DateTime.Utc): boolean =>
+  DateTime.lessThanOrEqualTo(grant.expiresAt, now);

--- a/packages/server/src/modules/auth/domain/ports/repositories/api-token-repository.ts
+++ b/packages/server/src/modules/auth/domain/ports/repositories/api-token-repository.ts
@@ -1,0 +1,43 @@
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+import { type ApiToken } from "@/modules/auth/domain/api-token.aggregate.js";
+import { type ApiTokenNotFound } from "@/modules/auth/domain/api-token-errors.js";
+import { type ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+// Dumb collection port (per `feedback_dumb_repositories`): save / findByX
+// only. Domain verbs (mint, revoke, touch) live in the use cases and the
+// aggregate; the soft-delete storage mechanism behind `delete` is an
+// implementation detail.
+export type ApiTokenRepositoryShape = {
+  readonly insert: (token: ApiToken) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findById: (
+    id: ApiTokenId,
+  ) => Effect.Effect<ApiToken, ApiTokenNotFound | PersistenceUnavailable>;
+  // Per-request lookup of the presented bearer (already hashed by the
+  // caller — the raw secret never reaches the repository).
+  readonly findByHash: (
+    tokenHash: string,
+  ) => Effect.Effect<ApiToken, ApiTokenNotFound | PersistenceUnavailable>;
+  // Active (non-revoked) tokens for the owner's management listing.
+  readonly listByUser: (
+    userId: UserId,
+  ) => Effect.Effect<ReadonlyArray<ApiToken>, PersistenceUnavailable>;
+  // Soft-delete via `revoked_at` (SQL `WHERE revoked_at IS NULL`). A
+  // re-revoke matches zero rows and surfaces as `ApiTokenNotFound`, same as
+  // a genuine miss — both mean "no active token to revoke" to the caller.
+  // (`ApiTokenRevoked` is produced by the find-by-hash query, not here.)
+  readonly delete: (
+    id: ApiTokenId,
+  ) => Effect.Effect<void, ApiTokenNotFound | PersistenceUnavailable>;
+  readonly update: (
+    token: ApiToken,
+  ) => Effect.Effect<void, ApiTokenNotFound | PersistenceUnavailable>;
+};
+
+export class ApiTokenRepository extends Context.Tag("ApiTokenRepository")<
+  ApiTokenRepository,
+  ApiTokenRepositoryShape
+>() {}

--- a/packages/server/src/modules/auth/domain/ports/repositories/device-grant-repository.ts
+++ b/packages/server/src/modules/auth/domain/ports/repositories/device-grant-repository.ts
@@ -1,0 +1,32 @@
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+import { type DeviceGrant } from "@/modules/auth/domain/device-grant.aggregate.js";
+import { type DeviceGrantNotFound } from "@/modules/auth/domain/device-grant-errors.js";
+import { type DeviceGrantId } from "@/modules/auth/domain/device-grant-id.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+
+// Dumb collection port (per `feedback_dumb_repositories`). Lookups by the two
+// codes the flow keys on: device_code_hash (CLI poll) and user_code (browser
+// approve).
+export type DeviceGrantRepositoryShape = {
+  readonly insert: (grant: DeviceGrant) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findByCodeHash: (
+    deviceCodeHash: string,
+  ) => Effect.Effect<DeviceGrant, DeviceGrantNotFound | PersistenceUnavailable>;
+  readonly findByUserCode: (
+    userCode: string,
+  ) => Effect.Effect<DeviceGrant, DeviceGrantNotFound | PersistenceUnavailable>;
+  readonly update: (
+    grant: DeviceGrant,
+  ) => Effect.Effect<void, DeviceGrantNotFound | PersistenceUnavailable>;
+  // Consumes a grant (single-use) once its token has been issued.
+  readonly delete: (
+    id: DeviceGrantId,
+  ) => Effect.Effect<void, DeviceGrantNotFound | PersistenceUnavailable>;
+};
+
+export class DeviceGrantRepository extends Context.Tag("DeviceGrantRepository")<
+  DeviceGrantRepository,
+  DeviceGrantRepositoryShape
+>() {}

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -5,9 +5,19 @@ export { authQueryHandlers } from "./auth-query-handlers.js";
 // platform middleware. The auth-module's handlers wrap their own
 // SessionRepository internally (Stage B).
 export { AuthSharedDepsLive } from "./auth-shared-deps.js";
+export { MintApiTokenCommand } from "./commands/mint-api-token-command.js";
+export { RevokeApiTokenCommand } from "./commands/revoke-api-token-command.js";
 export { RevokeSessionCommand } from "./commands/revoke-session-command.js";
 export { SignInCommand } from "./commands/sign-in-command.js";
+// Dispatched by the auth middleware on the bearer path (ADR-0024).
+export { TouchApiTokenCommand } from "./commands/touch-api-token-command.js";
 export { TouchSessionCommand } from "./commands/touch-session-command.js";
+export { ApiToken } from "./domain/api-token.aggregate.js";
+export { ApiTokenExpired, ApiTokenNotFound, ApiTokenRevoked } from "./domain/api-token-errors.js";
+export { ApiTokenId } from "./domain/api-token-id.js";
+// hashToken is shared with the auth middleware so the mint-time hash and
+// the per-request bearer lookup agree.
+export { hashToken } from "./domain/api-token-token.js";
 export { Session } from "./domain/session.aggregate.js";
 export {
   AuthIdentityNotFound,
@@ -16,4 +26,6 @@ export {
   SessionRevoked,
 } from "./domain/session-errors.js";
 export { SessionId } from "./domain/session-id.js";
+export { FindApiTokenByHashQuery } from "./queries/find-api-token-by-hash-query.js";
 export { FindSessionQuery } from "./queries/find-session-query.js";
+export { ListMyApiTokensQuery } from "./queries/list-my-api-tokens-query.js";

--- a/packages/server/src/modules/auth/infrastructure/api-token-mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-mapper.ts
@@ -1,0 +1,32 @@
+import { type RowSchemas } from "@org/database/index";
+import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { ApiToken } from "../domain/api-token.aggregate.js";
+import { ApiTokenId } from "../domain/api-token-id.js";
+
+export const toDomain = (row: RowSchemas.ApiTokenRow): ApiToken =>
+  ApiToken.make({
+    id: ApiTokenId.make(row.id),
+    userId: UserId.make(row.user_id),
+    tokenHash: row.token_hash,
+    prefix: row.prefix,
+    label: row.label,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
+  });
+
+export const toPersistence = (token: ApiToken) => ({
+  id: token.id,
+  user_id: token.userId,
+  token_hash: token.tokenHash,
+  prefix: token.prefix,
+  label: token.label,
+  expires_at: token.expiresAt === null ? null : DateTime.toDate(token.expiresAt),
+  revoked_at: token.revokedAt === null ? null : DateTime.toDate(token.revokedAt),
+  created_at: DateTime.toDate(token.createdAt),
+  last_used_at: DateTime.toDate(token.lastUsedAt),
+});

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import * as ApiToken from "../domain/api-token.aggregate.js";
+import { ApiTokenNotFound } from "../domain/api-token-errors.js";
+import { ApiTokenId } from "../domain/api-token-id.js";
+import { ApiTokenRepository } from "../domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryFake } from "./api-token-repository-fake.js";
+
+const idA = ApiTokenId.make("11111111-1111-1111-1111-111111111111");
+const idB = ApiTokenId.make("22222222-2222-2222-2222-222222222222");
+const idMissing = ApiTokenId.make("99999999-9999-9999-9999-999999999999");
+const userId = UserId.make("33333333-3333-3333-3333-333333333333");
+const otherUserId = UserId.make("44444444-4444-4444-4444-444444444444");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+
+const make = (id: ApiTokenId, opts: { userId?: UserId; hash?: string; createdAt?: DateTime.Utc }) =>
+  ApiToken.mint({
+    id,
+    userId: opts.userId ?? userId,
+    tokenHash: opts.hash ?? `hash-${id}`,
+    prefix: "pat_abcd1234",
+    label: "ci",
+    now: opts.createdAt ?? now,
+    expiresAt: DateTime.add(opts.createdAt ?? now, { days: 90 }),
+  });
+
+const provide = Effect.provide(ApiTokenRepositoryFake);
+
+describe("ApiTokenRepositoryFake", () => {
+  it.effect("insert + findById + findByHash round-trip", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      yield* repo.insert(make(idA, { hash: "hash-A" }));
+      deepStrictEqual((yield* repo.findById(idA)).id, idA);
+      deepStrictEqual((yield* repo.findByHash("hash-A")).id, idA);
+    }).pipe(provide),
+  );
+
+  it.effect("findById / findByHash fail ApiTokenNotFound when absent", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      const byId = yield* Effect.exit(repo.findById(idMissing));
+      const byHash = yield* Effect.exit(repo.findByHash("nope"));
+      deepStrictEqual(Exit.isFailure(byId), true);
+      deepStrictEqual(Exit.isFailure(byHash), true);
+      if (Exit.isFailure(byId)) {
+        const error = byId.cause._tag === "Fail" ? byId.cause.error : null;
+        deepStrictEqual(error instanceof ApiTokenNotFound, true);
+      }
+    }).pipe(provide),
+  );
+
+  it.effect("listByUser returns only the caller's active tokens, newest first", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      yield* repo.insert(make(idA, { hash: "a", createdAt: now }));
+      yield* repo.insert(make(idB, { hash: "b", createdAt: DateTime.add(now, { hours: 1 }) }));
+      yield* repo.insert(make(idMissing, { userId: otherUserId, hash: "c" }));
+      const mine = yield* repo.listByUser(userId);
+      deepStrictEqual(
+        mine.map((t) => t.id),
+        [idB, idA],
+      );
+    }).pipe(provide),
+  );
+
+  it.effect("delete soft-revokes; a second delete fails NotFound; listByUser hides it", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      yield* repo.insert(make(idA, { hash: "a" }));
+      yield* repo.delete(idA);
+      deepStrictEqual((yield* repo.findById(idA)).revokedAt !== null, true);
+      deepStrictEqual((yield* repo.listByUser(userId)).length, 0);
+      const second = yield* Effect.exit(repo.delete(idA));
+      deepStrictEqual(Exit.isFailure(second), true);
+    }).pipe(provide),
+  );
+
+  it.effect("update advances lastUsedAt for an active token and fails NotFound when revoked", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      const seed = make(idA, { hash: "a" });
+      yield* repo.insert(seed);
+      const later = DateTime.add(now, { hours: 2 });
+      yield* repo.update(ApiToken.touch({ token: seed, now: later }));
+      deepStrictEqual((yield* repo.findById(idA)).lastUsedAt, later);
+
+      yield* repo.delete(idA);
+      const exit = yield* Effect.exit(repo.update(ApiToken.touch({ token: seed, now: later })));
+      deepStrictEqual(Exit.isFailure(exit), true);
+    }).pipe(provide),
+  );
+});

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.ts
@@ -1,0 +1,86 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Order from "effect/Order";
+import * as Ref from "effect/Ref";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+
+import { ApiToken } from "../domain/api-token.aggregate.js";
+import { ApiTokenNotFound } from "../domain/api-token-errors.js";
+import { type ApiTokenId } from "../domain/api-token-id.js";
+import { ApiTokenRepository } from "../domain/ports/repositories/api-token-repository.js";
+
+export const ApiTokenRepositoryFake = Layer.effect(
+  ApiTokenRepository,
+  Effect.gen(function* () {
+    const store = yield* Ref.make(HashMap.empty<ApiTokenId, ApiToken>());
+
+    const insert = (token: ApiToken): Effect.Effect<void> =>
+      Ref.update(store, HashMap.set(token.id, token));
+
+    const findById = (id: ApiTokenId): Effect.Effect<ApiToken, ApiTokenNotFound> =>
+      Effect.flatMap(Ref.get(store), (m) =>
+        Option.match(HashMap.get(m, id), {
+          onNone: () => Effect.fail(new ApiTokenNotFound()),
+          onSome: Effect.succeed,
+        }),
+      );
+
+    const findByHash = (tokenHash: string): Effect.Effect<ApiToken, ApiTokenNotFound> =>
+      Effect.flatMap(Ref.get(store), (m) => {
+        const match = Array.from(HashMap.values(m)).find((t) => t.tokenHash === tokenHash);
+        return match === undefined ? Effect.fail(new ApiTokenNotFound()) : Effect.succeed(match);
+      });
+
+    // Active (non-revoked) tokens, newest first — mirrors the live SQL.
+    const listByUser = (userId: UserId): Effect.Effect<ReadonlyArray<ApiToken>> =>
+      Effect.map(Ref.get(store), (m) =>
+        Array.from(HashMap.values(m))
+          .filter((t) => t.userId === userId && t.revokedAt === null)
+          .sort(Order.reverse(Order.mapInput(DateTime.Order, (t: ApiToken) => t.createdAt))),
+      );
+
+    // Mirrors the live impl: a re-delete on an already-revoked token is
+    // reported as ApiTokenNotFound (the SQL UPDATE matches `WHERE revoked_at
+    // IS NULL`, so the second call returns zero rows and `orFail` raises).
+    const deleteToken = (id: ApiTokenId): Effect.Effect<void, ApiTokenNotFound> =>
+      Effect.gen(function* () {
+        const m = yield* Ref.get(store);
+        const existing = HashMap.get(m, id);
+        if (Option.isNone(existing) || existing.value.revokedAt !== null) {
+          return yield* Effect.fail(new ApiTokenNotFound());
+        }
+        const now = yield* DateTime.now;
+        yield* Ref.update(
+          store,
+          HashMap.set(id, ApiToken.make({ ...existing.value, revokedAt: now })),
+        );
+      });
+
+    // Mirrors the live impl: only updates rows where revoked_at IS NULL.
+    const update = (token: ApiToken): Effect.Effect<void, ApiTokenNotFound> =>
+      Effect.gen(function* () {
+        const m = yield* Ref.get(store);
+        const existing = HashMap.get(m, token.id);
+        if (Option.isNone(existing) || existing.value.revokedAt !== null) {
+          return yield* Effect.fail(new ApiTokenNotFound());
+        }
+        yield* Ref.update(
+          store,
+          HashMap.set(token.id, ApiToken.make({ ...existing.value, lastUsedAt: token.lastUsedAt })),
+        );
+      });
+
+    return ApiTokenRepository.of({
+      insert,
+      findById,
+      findByHash,
+      listByUser,
+      delete: deleteToken,
+      update,
+    });
+  }),
+);

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-live.integration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it } from "@effect/vitest";
+import { Database, sql } from "@org/database/index";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import { beforeEach } from "vitest";
+
+import * as ApiToken from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenNotFound } from "@/modules/auth/domain/api-token-errors.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/api-token-repository-live.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const idA = ApiTokenId.make("22222222-2222-2222-2222-222222222222");
+const idB = ApiTokenId.make("33333333-3333-3333-3333-333333333333");
+
+const TestLayer = ApiTokenRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
+
+const insertUserRow = Effect.gen(function* () {
+  const db = yield* Database.Database;
+  yield* db.execute((client) =>
+    client.query(sql.unsafe`
+      INSERT INTO "user".users (id, email, country, street, postal_code, created_at, updated_at)
+      VALUES (${userId}, 'tokens@example.com', 'N/A', 'N/A', 'N/A', now(), now())
+    `),
+  );
+}).pipe(Effect.orDie);
+
+const make = (id: ApiTokenId, hash: string, now: DateTime.Utc, createdAt?: DateTime.Utc) =>
+  ApiToken.mint({
+    id,
+    userId,
+    tokenHash: hash,
+    prefix: "pat_abcd1234",
+    label: "ci",
+    now: createdAt ?? now,
+    expiresAt: DateTime.add(createdAt ?? now, { days: 90 }),
+  });
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("ApiTokenRepositoryLive (integration)", () => {
+  beforeEach(async () => {
+    await Effect.runPromise(
+      truncate("auth.api_tokens", "user.users").pipe(Effect.provide(TestDatabaseLive)),
+    );
+  });
+
+  it.effect("insert + findById + findByHash round-trip a token through the DB", () =>
+    Effect.gen(function* () {
+      yield* insertUserRow;
+      const repo = yield* ApiTokenRepository;
+      const now = yield* DateTime.now;
+      yield* repo.insert(make(idA, "hash-A", now));
+      const byId = yield* repo.findById(idA);
+      deepStrictEqual(byId.id, idA);
+      deepStrictEqual(byId.userId, userId);
+      deepStrictEqual(byId.tokenHash, "hash-A");
+      deepStrictEqual(byId.revokedAt, null);
+      deepStrictEqual((yield* repo.findByHash("hash-A")).id, idA);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("findByHash fails ApiTokenNotFound for an unknown hash", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      const exit = yield* Effect.exit(repo.findByHash("missing"));
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof ApiTokenNotFound, true);
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("listByUser returns active tokens newest-first and hides revoked", () =>
+    Effect.gen(function* () {
+      yield* insertUserRow;
+      const repo = yield* ApiTokenRepository;
+      const now = yield* DateTime.now;
+      yield* repo.insert(make(idA, "a", now, now));
+      yield* repo.insert(make(idB, "b", now, DateTime.add(now, { hours: 1 })));
+      yield* repo.delete(idA);
+      const mine = yield* repo.listByUser(userId);
+      deepStrictEqual(
+        mine.map((t) => t.id),
+        [idB],
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("delete soft-revokes and a second delete is reported as NotFound", () =>
+    Effect.gen(function* () {
+      yield* insertUserRow;
+      const repo = yield* ApiTokenRepository;
+      const now = yield* DateTime.now;
+      yield* repo.insert(make(idA, "a", now));
+      yield* repo.delete(idA);
+      deepStrictEqual((yield* repo.findById(idA)).revokedAt !== null, true);
+      const second = yield* Effect.exit(repo.delete(idA));
+      deepStrictEqual(Exit.isFailure(second), true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("update persists last_used_at for an active token", () =>
+    Effect.gen(function* () {
+      yield* insertUserRow;
+      const repo = yield* ApiTokenRepository;
+      const now = yield* DateTime.now;
+      const seed = make(idA, "a", now);
+      yield* repo.insert(seed);
+      const later = DateTime.add(now, { hours: 2 });
+      yield* repo.update(ApiToken.touch({ token: seed, now: later }));
+      const found = yield* repo.findById(idA);
+      deepStrictEqual(found.lastUsedAt, later);
+      deepStrictEqual(found.expiresAt, seed.expiresAt);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-live.ts
@@ -1,0 +1,131 @@
+import { Database, orFail, RowSchemas, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { type UserId } from "@/platform/ids/user-id.js";
+import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
+
+import { type ApiToken } from "../domain/api-token.aggregate.js";
+import { ApiTokenNotFound } from "../domain/api-token-errors.js";
+import { type ApiTokenId } from "../domain/api-token-id.js";
+import { ApiTokenRepository } from "../domain/ports/repositories/api-token-repository.js";
+import * as ApiTokenMapper from "./api-token-mapper.js";
+
+export const ApiTokenRepositoryLive = Layer.effect(
+  ApiTokenRepository,
+  Effect.gen(function* () {
+    const db = yield* Database.Database;
+
+    const insert = db.makeQuery((execute, token: ApiToken) => {
+      const row = ApiTokenMapper.toPersistence(token);
+      return execute((client) =>
+        client.query(sql.unsafe`
+          INSERT INTO auth.api_tokens
+            (id, user_id, token_hash, prefix, label, expires_at, revoked_at, created_at, last_used_at)
+          VALUES (
+            ${row.id},
+            ${row.user_id},
+            ${row.token_hash},
+            ${row.prefix},
+            ${row.label},
+            ${row.expires_at === null ? null : sql.timestamp(row.expires_at)},
+            ${row.revoked_at === null ? null : sql.timestamp(row.revoked_at)},
+            ${sql.timestamp(row.created_at)},
+            ${sql.timestamp(row.last_used_at)}
+          )
+        `),
+      ).pipe(
+        Effect.asVoid,
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("ApiTokenRepository.insert"),
+      );
+    });
+
+    const findById = db.makeQuery((execute, id: ApiTokenId) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
+          SELECT * FROM auth.api_tokens WHERE id = ${id}
+        `),
+      ).pipe(
+        orFail(() => new ApiTokenNotFound()),
+        Effect.map(ApiTokenMapper.toDomain),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("ApiTokenRepository.findById"),
+      ),
+    );
+
+    const findByHash = db.makeQuery((execute, tokenHash: string) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
+          SELECT * FROM auth.api_tokens WHERE token_hash = ${tokenHash}
+        `),
+      ).pipe(
+        orFail(() => new ApiTokenNotFound()),
+        Effect.map(ApiTokenMapper.toDomain),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("ApiTokenRepository.findByHash"),
+      ),
+    );
+
+    const listByUser = db.makeQuery((execute, userId: UserId) =>
+      execute((client) =>
+        client.any(sql.type(RowSchemas.ApiTokenRowStd)`
+          SELECT * FROM auth.api_tokens
+          WHERE user_id = ${userId} AND revoked_at IS NULL
+          ORDER BY created_at DESC
+        `),
+      ).pipe(
+        Effect.map((rows) => rows.map(ApiTokenMapper.toDomain)),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("ApiTokenRepository.listByUser"),
+      ),
+    );
+
+    const deleteById = db.makeQuery((execute, id: ApiTokenId) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
+          UPDATE auth.api_tokens SET revoked_at = now()
+          WHERE id = ${id} AND revoked_at IS NULL
+          RETURNING *
+        `),
+      ).pipe(
+        orFail(() => new ApiTokenNotFound()),
+        Effect.asVoid,
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("ApiTokenRepository.delete"),
+      ),
+    );
+
+    const update = db.makeQuery((execute, token: ApiToken) => {
+      const row = ApiTokenMapper.toPersistence(token);
+      return execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
+          UPDATE auth.api_tokens
+          SET last_used_at = ${sql.timestamp(row.last_used_at)}
+          WHERE id = ${row.id} AND revoked_at IS NULL
+          RETURNING *
+        `),
+      ).pipe(
+        orFail(() => new ApiTokenNotFound()),
+        Effect.asVoid,
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("ApiTokenRepository.update"),
+      );
+    });
+
+    return ApiTokenRepository.of({
+      insert,
+      findById,
+      findByHash,
+      listByUser,
+      delete: deleteById,
+      update,
+    });
+  }),
+);

--- a/packages/server/src/modules/auth/infrastructure/device-grant-mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-mapper.ts
@@ -1,0 +1,32 @@
+import { type RowSchemas } from "@org/database/index";
+import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { DeviceGrant } from "../domain/device-grant.aggregate.js";
+import { DeviceGrantId } from "../domain/device-grant-id.js";
+
+export const toDomain = (row: RowSchemas.DeviceGrantRow): DeviceGrant =>
+  DeviceGrant.make({
+    id: DeviceGrantId.make(row.id),
+    deviceCodeHash: row.device_code_hash,
+    userCode: row.user_code,
+    // The column is a free-text varchar at the DB level; collapse anything
+    // other than the approved sentinel to pending.
+    status: row.status === "approved" ? "approved" : "pending",
+    userId: row.user_id === null ? null : UserId.make(row.user_id),
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    approvedAt: row.approved_at,
+  });
+
+export const toPersistence = (grant: DeviceGrant) => ({
+  id: grant.id,
+  device_code_hash: grant.deviceCodeHash,
+  user_code: grant.userCode,
+  status: grant.status,
+  user_id: grant.userId,
+  created_at: DateTime.toDate(grant.createdAt),
+  expires_at: DateTime.toDate(grant.expiresAt),
+  approved_at: grant.approvedAt === null ? null : DateTime.toDate(grant.approvedAt),
+});

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import * as DeviceGrant from "../domain/device-grant.aggregate.js";
+import { DeviceGrantNotFound } from "../domain/device-grant-errors.js";
+import { DeviceGrantId } from "../domain/device-grant-id.js";
+import { DeviceGrantRepository } from "../domain/ports/repositories/device-grant-repository.js";
+import { DeviceGrantRepositoryFake } from "./device-grant-repository-fake.js";
+
+const id = DeviceGrantId.make("11111111-1111-1111-1111-111111111111");
+const userId = UserId.make("22222222-2222-2222-2222-222222222222");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+
+const seed = () =>
+  Effect.gen(function* () {
+    const repo = yield* DeviceGrantRepository;
+    const grant = DeviceGrant.start({
+      id,
+      deviceCodeHash: "dc-hash",
+      userCode: "ABCD-2345",
+      now,
+      ttlSeconds: 600,
+    });
+    yield* repo.insert(grant);
+    return grant;
+  });
+
+const provide = Effect.provide(DeviceGrantRepositoryFake);
+
+describe("DeviceGrantRepositoryFake", () => {
+  it.effect("insert + lookup by code hash and by user code", () =>
+    Effect.gen(function* () {
+      yield* seed();
+      const repo = yield* DeviceGrantRepository;
+      deepStrictEqual((yield* repo.findByCodeHash("dc-hash")).id, id);
+      deepStrictEqual((yield* repo.findByUserCode("ABCD-2345")).id, id);
+    }).pipe(provide),
+  );
+
+  it.effect("lookups fail DeviceGrantNotFound when absent", () =>
+    Effect.gen(function* () {
+      const repo = yield* DeviceGrantRepository;
+      const exit = yield* Effect.exit(repo.findByUserCode("ZZZZ-9999"));
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof DeviceGrantNotFound, true);
+      }
+    }).pipe(provide),
+  );
+
+  it.effect("update persists approval", () =>
+    Effect.gen(function* () {
+      const grant = yield* seed();
+      const repo = yield* DeviceGrantRepository;
+      yield* repo.update(DeviceGrant.approve({ grant, userId, now }));
+      const after = yield* repo.findByCodeHash("dc-hash");
+      deepStrictEqual(after.status, "approved");
+      deepStrictEqual(after.userId, userId);
+    }).pipe(provide),
+  );
+
+  it.effect("delete consumes the grant; a second delete fails NotFound", () =>
+    Effect.gen(function* () {
+      yield* seed();
+      const repo = yield* DeviceGrantRepository;
+      yield* repo.delete(id);
+      const lookup = yield* Effect.exit(repo.findByCodeHash("dc-hash"));
+      deepStrictEqual(Exit.isFailure(lookup), true);
+      const second = yield* Effect.exit(repo.delete(id));
+      deepStrictEqual(Exit.isFailure(second), true);
+    }).pipe(provide),
+  );
+});

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.ts
@@ -1,0 +1,59 @@
+import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+
+import { type DeviceGrant } from "../domain/device-grant.aggregate.js";
+import { DeviceGrantNotFound } from "../domain/device-grant-errors.js";
+import { type DeviceGrantId } from "../domain/device-grant-id.js";
+import { DeviceGrantRepository } from "../domain/ports/repositories/device-grant-repository.js";
+
+export const DeviceGrantRepositoryFake = Layer.effect(
+  DeviceGrantRepository,
+  Effect.gen(function* () {
+    const store = yield* Ref.make(HashMap.empty<DeviceGrantId, DeviceGrant>());
+
+    const insert = (grant: DeviceGrant): Effect.Effect<void> =>
+      Ref.update(store, HashMap.set(grant.id, grant));
+
+    const findBy = (
+      pred: (g: DeviceGrant) => boolean,
+    ): Effect.Effect<DeviceGrant, DeviceGrantNotFound> =>
+      Effect.flatMap(Ref.get(store), (m) => {
+        const match = Array.from(HashMap.values(m)).find(pred);
+        return match === undefined ? Effect.fail(new DeviceGrantNotFound()) : Effect.succeed(match);
+      });
+
+    const findByCodeHash = (deviceCodeHash: string) =>
+      findBy((g) => g.deviceCodeHash === deviceCodeHash);
+
+    const findByUserCode = (userCode: string) => findBy((g) => g.userCode === userCode);
+
+    const update = (grant: DeviceGrant): Effect.Effect<void, DeviceGrantNotFound> =>
+      Effect.gen(function* () {
+        const m = yield* Ref.get(store);
+        if (Option.isNone(HashMap.get(m, grant.id))) {
+          return yield* Effect.fail(new DeviceGrantNotFound());
+        }
+        yield* Ref.update(store, HashMap.set(grant.id, grant));
+      });
+
+    const deleteGrant = (id: DeviceGrantId): Effect.Effect<void, DeviceGrantNotFound> =>
+      Effect.gen(function* () {
+        const m = yield* Ref.get(store);
+        if (Option.isNone(HashMap.get(m, id))) {
+          return yield* Effect.fail(new DeviceGrantNotFound());
+        }
+        yield* Ref.update(store, HashMap.remove(id));
+      });
+
+    return DeviceGrantRepository.of({
+      insert,
+      findByCodeHash,
+      findByUserCode,
+      update,
+      delete: deleteGrant,
+    });
+  }),
+);

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.integration.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from "@effect/vitest";
+import { Database, sql } from "@org/database/index";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import { beforeEach } from "vitest";
+
+import * as DeviceGrant from "@/modules/auth/domain/device-grant.aggregate.js";
+import { DeviceGrantNotFound } from "@/modules/auth/domain/device-grant-errors.js";
+import { DeviceGrantId } from "@/modules/auth/domain/device-grant-id.js";
+import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant-repository.js";
+import { DeviceGrantRepositoryLive } from "@/modules/auth/infrastructure/device-grant-repository-live.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const id = DeviceGrantId.make("22222222-2222-2222-2222-222222222222");
+
+const TestLayer = DeviceGrantRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
+
+const insertUserRow = Effect.gen(function* () {
+  const db = yield* Database.Database;
+  yield* db.execute((client) =>
+    client.query(sql.unsafe`
+      INSERT INTO "user".users (id, email, country, street, postal_code, created_at, updated_at)
+      VALUES (${userId}, 'device@example.com', 'N/A', 'N/A', 'N/A', now(), now())
+    `),
+  );
+}).pipe(Effect.orDie);
+
+const start = (now: DateTime.Utc) =>
+  DeviceGrant.start({ id, deviceCodeHash: "dc-hash", userCode: "ABCD-2345", now, ttlSeconds: 600 });
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("DeviceGrantRepositoryLive (integration)", () => {
+  beforeEach(async () => {
+    await Effect.runPromise(
+      truncate("auth.device_grants", "user.users").pipe(Effect.provide(TestDatabaseLive)),
+    );
+  });
+
+  it.effect("insert + findByCodeHash + findByUserCode round-trip", () =>
+    Effect.gen(function* () {
+      const repo = yield* DeviceGrantRepository;
+      const now = yield* DateTime.now;
+      yield* repo.insert(start(now));
+      deepStrictEqual((yield* repo.findByCodeHash("dc-hash")).id, id);
+      const byUser = yield* repo.findByUserCode("ABCD-2345");
+      deepStrictEqual(byUser.status, "pending");
+      deepStrictEqual(byUser.userId, null);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("update persists an approval (status + user_id + approved_at)", () =>
+    Effect.gen(function* () {
+      yield* insertUserRow;
+      const repo = yield* DeviceGrantRepository;
+      const now = yield* DateTime.now;
+      const grant = start(now);
+      yield* repo.insert(grant);
+      yield* repo.update(DeviceGrant.approve({ grant, userId, now }));
+      const after = yield* repo.findByCodeHash("dc-hash");
+      deepStrictEqual(after.status, "approved");
+      deepStrictEqual(after.userId, userId);
+      deepStrictEqual(after.approvedAt !== null, true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("delete consumes the grant; a second delete is NotFound", () =>
+    Effect.gen(function* () {
+      const repo = yield* DeviceGrantRepository;
+      const now = yield* DateTime.now;
+      yield* repo.insert(start(now));
+      yield* repo.delete(id);
+      const lookup = yield* Effect.exit(repo.findByCodeHash("dc-hash"));
+      deepStrictEqual(Exit.isFailure(lookup), true);
+      if (Exit.isFailure(lookup)) {
+        const error = lookup.cause._tag === "Fail" ? lookup.cause.error : null;
+        deepStrictEqual(error instanceof DeviceGrantNotFound, true);
+      }
+      const second = yield* Effect.exit(repo.delete(id));
+      deepStrictEqual(Exit.isFailure(second), true);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.ts
@@ -1,0 +1,113 @@
+import { Database, orFail, RowSchemas, sql } from "@org/database/index";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
+
+import { type DeviceGrant } from "../domain/device-grant.aggregate.js";
+import { DeviceGrantNotFound } from "../domain/device-grant-errors.js";
+import { type DeviceGrantId } from "../domain/device-grant-id.js";
+import { DeviceGrantRepository } from "../domain/ports/repositories/device-grant-repository.js";
+import * as DeviceGrantMapper from "./device-grant-mapper.js";
+
+export const DeviceGrantRepositoryLive = Layer.effect(
+  DeviceGrantRepository,
+  Effect.gen(function* () {
+    const db = yield* Database.Database;
+
+    const insert = db.makeQuery((execute, grant: DeviceGrant) => {
+      const row = DeviceGrantMapper.toPersistence(grant);
+      return execute((client) =>
+        client.query(sql.unsafe`
+          INSERT INTO auth.device_grants
+            (id, device_code_hash, user_code, status, user_id, created_at, expires_at, approved_at)
+          VALUES (
+            ${row.id},
+            ${row.device_code_hash},
+            ${row.user_code},
+            ${row.status},
+            ${row.user_id},
+            ${sql.timestamp(row.created_at)},
+            ${sql.timestamp(row.expires_at)},
+            ${row.approved_at === null ? null : sql.timestamp(row.approved_at)}
+          )
+        `),
+      ).pipe(
+        Effect.asVoid,
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("DeviceGrantRepository.insert"),
+      );
+    });
+
+    const findByCodeHash = db.makeQuery((execute, deviceCodeHash: string) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
+          SELECT * FROM auth.device_grants WHERE device_code_hash = ${deviceCodeHash}
+        `),
+      ).pipe(
+        orFail(() => new DeviceGrantNotFound()),
+        Effect.map(DeviceGrantMapper.toDomain),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("DeviceGrantRepository.findByCodeHash"),
+      ),
+    );
+
+    const findByUserCode = db.makeQuery((execute, userCode: string) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
+          SELECT * FROM auth.device_grants WHERE user_code = ${userCode}
+        `),
+      ).pipe(
+        orFail(() => new DeviceGrantNotFound()),
+        Effect.map(DeviceGrantMapper.toDomain),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("DeviceGrantRepository.findByUserCode"),
+      ),
+    );
+
+    const update = db.makeQuery((execute, grant: DeviceGrant) => {
+      const row = DeviceGrantMapper.toPersistence(grant);
+      return execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
+          UPDATE auth.device_grants
+          SET status = ${row.status},
+              user_id = ${row.user_id},
+              approved_at = ${row.approved_at === null ? null : sql.timestamp(row.approved_at)}
+          WHERE id = ${row.id}
+          RETURNING *
+        `),
+      ).pipe(
+        orFail(() => new DeviceGrantNotFound()),
+        Effect.asVoid,
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("DeviceGrantRepository.update"),
+      );
+    });
+
+    const deleteById = db.makeQuery((execute, id: DeviceGrantId) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
+          DELETE FROM auth.device_grants WHERE id = ${id} RETURNING *
+        `),
+      ).pipe(
+        orFail(() => new DeviceGrantNotFound()),
+        Effect.asVoid,
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("DeviceGrantRepository.delete"),
+      ),
+    );
+
+    return DeviceGrantRepository.of({
+      insert,
+      findByCodeHash,
+      findByUserCode,
+      update,
+      delete: deleteById,
+    });
+  }),
+);

--- a/packages/server/src/modules/auth/interface/cli/cli-auth-live.ts
+++ b/packages/server/src/modules/auth/interface/cli/cli-auth-live.ts
@@ -1,0 +1,12 @@
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+
+import { Api } from "@/api.js";
+
+import { deviceStartEndpoint } from "./device-start.endpoint.js";
+import { deviceTokenEndpoint } from "./device-token.endpoint.js";
+
+// Registers the CLI-facing device-auth endpoints (the `cliAuth` group on
+// `CliApi`). Thin group registration, mirroring `auth-live.ts` for HTTP.
+export const CliAuthLive = HttpApiBuilder.group(Api, "cliAuth", (handlers) =>
+  handlers.handle("deviceStart", deviceStartEndpoint).handle("deviceToken", deviceTokenEndpoint),
+);

--- a/packages/server/src/modules/auth/interface/cli/device-start.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/cli/device-start.endpoint.integration.test.ts
@@ -1,0 +1,30 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+// Public endpoint — no caller identity needed.
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("POST /cli/device/start (integration)", () => {
+  const { run } = useServerTestRuntime(["auth.device_grants"]);
+
+  it("returns device + user codes and a verification URL", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const res = yield* client.cliAuth.deviceStart();
+        ok(res.device_code.length > 0);
+        ok(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(res.user_code));
+        ok(res.verification_uri.endsWith("/device"));
+        ok(res.verification_uri_complete.includes(encodeURIComponent(res.user_code)));
+        ok(res.interval > 0);
+        ok(res.expires_in > 0);
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/auth/interface/cli/device-start.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/cli/device-start.endpoint.ts
@@ -1,0 +1,30 @@
+import { CliAuthContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
+import { EnvVars } from "@/common/env-vars.js";
+import { StartDeviceGrantCommand } from "@/modules/auth/commands/start-device-grant-command.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// CLI adapter (ADR-0024): starts a device grant and returns the codes plus
+// the verification URL the user should open. Dispatches the same
+// `StartDeviceGrantCommand` the bus exposes — no GUI coupling.
+export const deviceStartEndpoint = (
+  _request: EndpointRequest<typeof CliAuthContract.DeviceGroup, "deviceStart">,
+) =>
+  Effect.gen(function* () {
+    const env = yield* EnvVars;
+    const commandBus = yield* CommandBus;
+    const { deviceCode, userCode } = yield* commandBus.execute(
+      StartDeviceGrantCommand.make({ ttlSeconds: env.DEVICE_CODE_TTL_SECONDS }),
+    );
+    const verificationUri = `${env.APP_URL}/device`;
+    return new CliAuthContract.DeviceStartResponse({
+      device_code: deviceCode,
+      user_code: userCode,
+      verification_uri: verificationUri,
+      verification_uri_complete: `${verificationUri}?code=${encodeURIComponent(userCode)}`,
+      interval: env.DEVICE_POLL_INTERVAL_SECONDS,
+      expires_in: env.DEVICE_CODE_TTL_SECONDS,
+    });
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("CliAuthLive.deviceStart"));

--- a/packages/server/src/modules/auth/interface/cli/device-token.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/cli/device-token.endpoint.integration.test.ts
@@ -1,0 +1,68 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+// Drives the full device flow through the real HTTP surface: the fake auth
+// middleware supplies the super-admin caller for the browser `approve` step.
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("POST /cli/device/token (integration)", () => {
+  const { run } = useServerTestRuntime(
+    ["auth.device_grants", "auth.api_tokens", "user.users", "platform.roles"],
+    { seedSuperAdminCaller: true },
+  );
+
+  it("returns authorization_pending before approval", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { device_code: deviceCode } = yield* client.cliAuth.deviceStart();
+        const error = yield* client.cliAuth
+          .deviceToken({ payload: { device_code: deviceCode } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "DeviceAuthorizationPending");
+      }),
+    );
+  });
+
+  it("exchanges an approved grant for a working bearer token, single-use", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { device_code: deviceCode, user_code: userCode } =
+          yield* client.cliAuth.deviceStart();
+        // Browser approves (fake super-admin caller)…
+        yield* client.authDevice.approve({ payload: { userCode } });
+        // …CLI exchanges the device code for a token.
+        const res = yield* client.cliAuth.deviceToken({ payload: { device_code: deviceCode } });
+        ok(res.access_token.startsWith("pat_"));
+        deepStrictEqual(res.token_type, "Bearer");
+        // (That the bearer token authenticates the real middleware is covered
+        // by the Phase-A manual E2E; the test server uses the auth fake.)
+
+        // Grant is consumed: a second poll is rejected.
+        const error = yield* client.cliAuth
+          .deviceToken({ payload: { device_code: deviceCode } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "DeviceCodeNotFound");
+      }),
+    );
+  });
+
+  it("rejects an unknown device code", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const error = yield* client.cliAuth
+          .deviceToken({ payload: { device_code: "not-a-real-code" } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "DeviceCodeNotFound");
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/auth/interface/cli/device-token.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/cli/device-token.endpoint.ts
@@ -1,0 +1,43 @@
+import { CliAuthContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
+import { EnvVars } from "@/common/env-vars.js";
+import { PollDeviceGrantCommand } from "@/modules/auth/commands/poll-device-grant-command.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// CLI adapter (ADR-0024): the poll/exchange endpoint. Maps the device-grant
+// domain errors to the RFC-8628-shaped contract errors the CLI switches on
+// (keep polling on pending; stop on expired/unknown).
+export const deviceTokenEndpoint = (
+  request: EndpointRequest<typeof CliAuthContract.DeviceGroup, "deviceToken">,
+) =>
+  Effect.gen(function* () {
+    const env = yield* EnvVars;
+    const commandBus = yield* CommandBus;
+    const { apiToken, token } = yield* commandBus.execute(
+      PollDeviceGrantCommand.make({
+        deviceCode: request.payload.device_code,
+        tokenExpiresInDays: env.API_TOKEN_DEFAULT_TTL_DAYS,
+      }),
+    );
+    return new CliAuthContract.DeviceTokenResponse({
+      access_token: token,
+      token_type: "Bearer",
+      expires_at: apiToken.expiresAt,
+    });
+  }).pipe(
+    Effect.catchTag("DeviceGrantPending", () =>
+      Effect.fail(
+        new CliAuthContract.DeviceAuthorizationPending({ message: "authorization_pending" }),
+      ),
+    ),
+    Effect.catchTag("DeviceGrantExpired", () =>
+      Effect.fail(new CliAuthContract.DeviceTokenExpired({ message: "expired_token" })),
+    ),
+    Effect.catchTag("DeviceGrantNotFound", () =>
+      Effect.fail(new CliAuthContract.DeviceCodeNotFound({ message: "invalid device code" })),
+    ),
+    recoverPersistenceUnavailable,
+    Effect.withSpan("CliAuthLive.deviceToken"),
+  );

--- a/packages/server/src/modules/auth/interface/http/auth-live.ts
+++ b/packages/server/src/modules/auth/interface/http/auth-live.ts
@@ -3,10 +3,15 @@ import * as Layer from "effect/Layer";
 
 import { Api } from "@/api.js";
 
+import { CliAuthLive } from "../cli/cli-auth-live.js";
 import { callbackEndpoint } from "./callback.endpoint.js";
+import { createTokenEndpoint } from "./create-token.endpoint.js";
+import { deviceApproveEndpoint } from "./device-approve.endpoint.js";
+import { listTokensEndpoint } from "./list-tokens.endpoint.js";
 import { loginEndpoint } from "./login.endpoint.js";
 import { logoutEndpoint } from "./logout.endpoint.js";
 import { meEndpoint } from "./me.endpoint.js";
+import { revokeTokenEndpoint } from "./revoke-token.endpoint.js";
 
 const AuthPublicLive = HttpApiBuilder.group(Api, "auth", (handlers) =>
   handlers
@@ -19,4 +24,27 @@ const AuthPrivateLive = HttpApiBuilder.group(Api, "authSession", (handlers) =>
   handlers.handle("me", meEndpoint),
 );
 
-export const AuthLive = Layer.mergeAll(AuthPublicLive, AuthPrivateLive);
+// GUI-managed personal access tokens (ADR-0024). Mint/list/revoke are a
+// human-in-the-browser concern, so they live on the GUI surface alongside
+// `me`, all behind `UserAuthMiddleware`.
+const AuthTokensLive = HttpApiBuilder.group(Api, "authTokens", (handlers) =>
+  handlers
+    .handle("create", createTokenEndpoint)
+    .handle("list", listTokensEndpoint)
+    .handle("revoke", revokeTokenEndpoint),
+);
+
+// Browser-side device-grant approval (GUI surface).
+const AuthDeviceLive = HttpApiBuilder.group(Api, "authDevice", (handlers) =>
+  handlers.handle("approve", deviceApproveEndpoint),
+);
+
+export const AuthLive = Layer.mergeAll(
+  AuthPublicLive,
+  AuthPrivateLive,
+  AuthTokensLive,
+  AuthDeviceLive,
+  // CLI-facing device start/poll (the `cliAuth` group on CliApi). Registered
+  // here so AuthModuleLive wires the whole auth surface in one place.
+  CliAuthLive,
+);

--- a/packages/server/src/modules/auth/interface/http/create-token.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/create-token.endpoint.integration.test.ts
@@ -1,0 +1,45 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+// `TestServerLive` provides the super-admin fake CurrentUser; `seedSuperAdminCaller`
+// inserts that user row so the token's user_id FK resolves.
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("POST /auth/tokens (integration)", () => {
+  const { run } = useServerTestRuntime(["auth.api_tokens", "user.users", "platform.roles"], {
+    seedSuperAdminCaller: true,
+  });
+
+  it("mints a token, returns the plaintext + prefix once, and defaults expiry", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const created = yield* client.authTokens.create({ payload: { label: "ci-deploy" } });
+        ok(created.token.startsWith("pat_"));
+        ok(created.token.startsWith(created.prefix));
+        ok(created.prefix.startsWith("pat_"));
+        ok(!created.prefix.includes(created.token.slice(created.prefix.length + 1)));
+        ok(created.expiresAt !== null);
+        ok(typeof created.id === "string" && created.id.length > 0);
+      }),
+    );
+  });
+
+  it("honors an explicit expiresInDays", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const created = yield* client.authTokens.create({
+          payload: { label: "short", expiresInDays: 1 },
+        });
+        ok(created.expiresAt !== null);
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/auth/interface/http/create-token.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/create-token.endpoint.ts
@@ -1,0 +1,33 @@
+import { AuthContract } from "@org/contracts/api/Contracts";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { EnvVars } from "@/common/env-vars.js";
+import { MintApiTokenCommand } from "@/modules/auth/commands/mint-api-token-command.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// Mints a personal access token for the authenticated caller and returns the
+// plaintext exactly once (only its hash is stored). `expiresInDays` falls
+// back to the configured default when the payload omits it.
+export const createTokenEndpoint = (
+  request: EndpointRequest<typeof AuthContract.TokensGroup, "create">,
+) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const env = yield* EnvVars;
+    const commandBus = yield* CommandBus;
+    const { apiToken, token } = yield* commandBus.execute(
+      MintApiTokenCommand.make({
+        userId: currentUser.userId,
+        label: request.payload.label,
+        expiresInDays: request.payload.expiresInDays ?? env.API_TOKEN_DEFAULT_TTL_DAYS,
+      }),
+    );
+    return new AuthContract.CreateApiTokenResponse({
+      id: apiToken.id,
+      token,
+      prefix: apiToken.prefix,
+      expiresAt: apiToken.expiresAt,
+    });
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("AuthLive.tokens.create"));

--- a/packages/server/src/modules/auth/interface/http/device-approve.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/device-approve.endpoint.integration.test.ts
@@ -1,0 +1,44 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+// The fake auth middleware supplies the approving super-admin caller.
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("POST /auth/device/approve (integration)", () => {
+  const { run } = useServerTestRuntime(
+    ["auth.device_grants", "auth.api_tokens", "user.users", "platform.roles"],
+    { seedSuperAdminCaller: true },
+  );
+
+  it("approves a pending grant so the CLI can then exchange it", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { device_code: deviceCode, user_code: userCode } =
+          yield* client.cliAuth.deviceStart();
+        yield* client.authDevice.approve({ payload: { userCode } });
+        // Approval took effect: the exchange now succeeds.
+        const res = yield* client.cliAuth.deviceToken({ payload: { device_code: deviceCode } });
+        ok(res.access_token.startsWith("pat_"));
+      }),
+    );
+  });
+
+  it("fails 404 for an unknown user code", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const error = yield* client.authDevice
+          .approve({ payload: { userCode: "ZZZZ-9999" } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "NotFound");
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/auth/interface/http/device-approve.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/device-approve.endpoint.ts
@@ -1,0 +1,36 @@
+import { type AuthContract } from "@org/contracts/api/Contracts";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { ApproveDeviceGrantCommand } from "@/modules/auth/commands/approve-device-grant-command.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// GUI adapter: the signed-in user approves a CLI device grant by submitting
+// the code they were shown. Maps the device-grant domain errors to HTTP:
+// unknown code → 404, lapsed → 410 Gone.
+export const deviceApproveEndpoint = (
+  request: EndpointRequest<typeof AuthContract.DeviceApprovalGroup, "approve">,
+) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const commandBus = yield* CommandBus;
+    yield* commandBus.execute(
+      ApproveDeviceGrantCommand.make({
+        userCode: request.payload.userCode,
+        userId: currentUser.userId,
+      }),
+    );
+  }).pipe(
+    Effect.catchTag("DeviceGrantNotFound", () =>
+      Effect.fail(
+        new CustomHttpApiError.NotFound({ message: "No pending device request for that code" }),
+      ),
+    ),
+    Effect.catchTag("DeviceGrantExpired", () =>
+      Effect.fail(new CustomHttpApiError.Gone({ message: "That device code has expired" })),
+    ),
+    recoverPersistenceUnavailable,
+    Effect.withSpan("AuthLive.device.approve"),
+  );

--- a/packages/server/src/modules/auth/interface/http/list-tokens.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/list-tokens.endpoint.integration.test.ts
@@ -1,0 +1,43 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("GET /auth/tokens (integration)", () => {
+  const { run } = useServerTestRuntime(["auth.api_tokens", "user.users", "platform.roles"], {
+    seedSuperAdminCaller: true,
+  });
+
+  it("returns the caller's minted tokens without secrets", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const created = yield* client.authTokens.create({ payload: { label: "ci" } });
+        const tokens = yield* client.authTokens.list();
+        deepStrictEqual(tokens.length, 1);
+        const [first] = tokens;
+        ok(first !== undefined);
+        deepStrictEqual(first.id, created.id);
+        deepStrictEqual(first.label, "ci");
+        deepStrictEqual(first.prefix, created.prefix);
+        // The summary shape carries no `token` field — secrets never re-surface.
+        deepStrictEqual("token" in first, false);
+      }),
+    );
+  });
+
+  it("is empty before any token is minted", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        deepStrictEqual((yield* client.authTokens.list()).length, 0);
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/auth/interface/http/list-tokens.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/list-tokens.endpoint.ts
@@ -1,0 +1,31 @@
+import { AuthContract } from "@org/contracts/api/Contracts";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { ListMyApiTokensQuery } from "@/modules/auth/queries/list-my-api-tokens-query.js";
+import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// Lists the caller's active (non-revoked) tokens. Secret-free: only the
+// display `prefix` and metadata are returned.
+export const listTokensEndpoint = (
+  _request: EndpointRequest<typeof AuthContract.TokensGroup, "list">,
+) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const queryBus = yield* QueryBus;
+    const tokens = yield* queryBus.execute(
+      ListMyApiTokensQuery.make({ userId: currentUser.userId }),
+    );
+    return tokens.map(
+      (t) =>
+        new AuthContract.ApiTokenSummary({
+          id: t.id,
+          label: t.label,
+          prefix: t.prefix,
+          expiresAt: t.expiresAt,
+          createdAt: t.createdAt,
+          lastUsedAt: t.lastUsedAt,
+        }),
+    );
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("AuthLive.tokens.list"));

--- a/packages/server/src/modules/auth/interface/http/revoke-token.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/revoke-token.endpoint.integration.test.ts
@@ -1,0 +1,54 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { ApiTokenId } from "@org/contracts/EntityIds";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("DELETE /auth/tokens/:id (integration)", () => {
+  const { run } = useServerTestRuntime(["auth.api_tokens", "user.users", "platform.roles"], {
+    seedSuperAdminCaller: true,
+  });
+
+  it("revokes a token so it drops out of the listing", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const created = yield* client.authTokens.create({ payload: { label: "ci" } });
+        yield* client.authTokens.revoke({ path: { id: created.id } });
+        deepStrictEqual((yield* client.authTokens.list()).length, 0);
+      }),
+    );
+  });
+
+  it("a second revoke (now absent) fails 404 NotFound", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const created = yield* client.authTokens.create({ payload: { label: "ci" } });
+        yield* client.authTokens.revoke({ path: { id: created.id } });
+        const error = yield* client.authTokens
+          .revoke({ path: { id: created.id } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "NotFound");
+      }),
+    );
+  });
+
+  it("revoking an unknown id fails 404 NotFound", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const error = yield* client.authTokens
+          .revoke({ path: { id: ApiTokenId.make("99999999-9999-9999-9999-999999999999") } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "NotFound");
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/auth/interface/http/revoke-token.endpoint.ts
+++ b/packages/server/src/modules/auth/interface/http/revoke-token.endpoint.ts
@@ -1,0 +1,28 @@
+import { type AuthContract } from "@org/contracts/api/Contracts";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { RevokeApiTokenCommand } from "@/modules/auth/commands/revoke-api-token-command.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// Revokes one of the caller's own tokens. The command scopes the revoke to
+// the owner, so a token that isn't the caller's (or doesn't exist) surfaces
+// as `ApiTokenNotFound` → 404 without revealing whether it existed.
+export const revokeTokenEndpoint = (
+  request: EndpointRequest<typeof AuthContract.TokensGroup, "revoke">,
+) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const commandBus = yield* CommandBus;
+    yield* commandBus.execute(
+      RevokeApiTokenCommand.make({ apiTokenId: request.path.id, userId: currentUser.userId }),
+    );
+  }).pipe(
+    Effect.catchTag("ApiTokenNotFound", () =>
+      Effect.fail(new CustomHttpApiError.NotFound({ message: "API token not found" })),
+    ),
+    recoverPersistenceUnavailable,
+    Effect.withSpan("AuthLive.tokens.revoke"),
+  );

--- a/packages/server/src/modules/auth/queries/find-api-token-by-hash-query.ts
+++ b/packages/server/src/modules/auth/queries/find-api-token-by-hash-query.ts
@@ -1,0 +1,34 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type ApiToken } from "@/modules/auth/domain/api-token.aggregate.js";
+import {
+  type ApiTokenExpired,
+  type ApiTokenNotFound,
+  type ApiTokenRevoked,
+} from "@/modules/auth/domain/api-token-errors.js";
+import { type ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+
+// Per-request bearer lookup, dispatched by the auth middleware. The caller
+// hashes the presented token before dispatch, so the raw secret never
+// travels through the bus or a span. Validates lifecycle (revoked /
+// expired) the same way `FindSessionQuery` does for cookies.
+export const FindApiTokenByHashQuery = Schema.TaggedStruct("FindApiTokenByHashQuery", {
+  tokenHash: Schema.String,
+});
+export type FindApiTokenByHashQuery = typeof FindApiTokenByHashQuery.Type;
+
+// Deliberately empty: `tokenHash` is secret-derived and must not land in a span.
+export const findApiTokenByHashQuerySpanAttributes: SpanAttributesExtractor<
+  FindApiTokenByHashQuery
+> = () => ({});
+
+// Raw handler effect — `ApiTokenRepository` is discharged by the wrap in
+// `auth-query-handlers.ts`.
+export type FindApiTokenByHashOutput = Effect.Effect<
+  ApiToken,
+  ApiTokenNotFound | ApiTokenExpired | ApiTokenRevoked | PersistenceUnavailable,
+  ApiTokenRepository
+>;

--- a/packages/server/src/modules/auth/queries/find-api-token-by-hash.test.ts
+++ b/packages/server/src/modules/auth/queries/find-api-token-by-hash.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
+import { ApiToken } from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenExpired, ApiTokenRevoked } from "@/modules/auth/domain/api-token-errors.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/api-token-repository-fake.js";
+import { findApiTokenByHash } from "@/modules/auth/queries/find-api-token-by-hash.js";
+import { FindApiTokenByHashQuery } from "@/modules/auth/queries/find-api-token-by-hash-query.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+const apiTokenId = ApiTokenId.make("11111111-1111-1111-1111-111111111111");
+const userId = UserId.make("22222222-2222-2222-2222-222222222222");
+
+const insert = (opts: { expiresAt: DateTime.Utc | null; revokedAt?: DateTime.Utc }) =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    const now = yield* DateTime.now;
+    yield* repo.insert(
+      ApiToken.make({
+        id: apiTokenId,
+        userId,
+        tokenHash: "hash-A",
+        prefix: "pat_abcd1234",
+        label: "ci",
+        expiresAt: opts.expiresAt,
+        revokedAt: opts.revokedAt ?? null,
+        createdAt: now,
+        lastUsedAt: now,
+      }),
+    );
+  });
+
+const provide = Effect.provide(ApiTokenRepositoryFake);
+const errorOf = (exit: Exit.Exit<unknown, unknown>) =>
+  Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+
+describe("findApiTokenByHash", () => {
+  it.effect("returns an active token", () =>
+    Effect.gen(function* () {
+      const future = DateTime.add(yield* DateTime.now, { days: 90 });
+      yield* insert({ expiresAt: future });
+      const token = yield* findApiTokenByHash(
+        FindApiTokenByHashQuery.make({ tokenHash: "hash-A" }),
+      );
+      deepStrictEqual(token.id, apiTokenId);
+    }).pipe(provide),
+  );
+
+  it.effect("fails ApiTokenNotFound for an unknown hash", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        findApiTokenByHash(FindApiTokenByHashQuery.make({ tokenHash: "missing" })),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+    }).pipe(provide),
+  );
+
+  it.effect("fails ApiTokenRevoked when the token is revoked", () =>
+    Effect.gen(function* () {
+      const now = yield* DateTime.now;
+      yield* insert({ expiresAt: DateTime.add(now, { days: 90 }), revokedAt: now });
+      const exit = yield* Effect.exit(
+        findApiTokenByHash(FindApiTokenByHashQuery.make({ tokenHash: "hash-A" })),
+      );
+      deepStrictEqual(errorOf(exit) instanceof ApiTokenRevoked, true);
+    }).pipe(provide),
+  );
+
+  it.effect("fails ApiTokenExpired when past the expiry instant", () =>
+    Effect.gen(function* () {
+      const past = DateTime.subtract(yield* DateTime.now, { days: 1 });
+      yield* insert({ expiresAt: past });
+      const exit = yield* Effect.exit(
+        findApiTokenByHash(FindApiTokenByHashQuery.make({ tokenHash: "hash-A" })),
+      );
+      deepStrictEqual(errorOf(exit) instanceof ApiTokenExpired, true);
+    }).pipe(provide),
+  );
+});

--- a/packages/server/src/modules/auth/queries/find-api-token-by-hash.ts
+++ b/packages/server/src/modules/auth/queries/find-api-token-by-hash.ts
@@ -1,0 +1,27 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import * as ApiToken from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenExpired, ApiTokenRevoked } from "@/modules/auth/domain/api-token-errors.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import {
+  type FindApiTokenByHashOutput,
+  type FindApiTokenByHashQuery,
+} from "@/modules/auth/queries/find-api-token-by-hash-query.js";
+
+// Looks up a token by hash and validates its lifecycle (revoked / expired).
+// Used by the auth middleware via `QueryBus.execute(...)`; the bus-boundary
+// span (ADR-0012) wraps this at dispatch time.
+export const findApiTokenByHash = (query: FindApiTokenByHashQuery): FindApiTokenByHashOutput =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    const token = yield* repo.findByHash(query.tokenHash);
+    if (token.revokedAt !== null) {
+      return yield* Effect.fail(new ApiTokenRevoked());
+    }
+    const now = yield* DateTime.now;
+    if (ApiToken.isExpired(token, now)) {
+      return yield* Effect.fail(new ApiTokenExpired());
+    }
+    return token;
+  });

--- a/packages/server/src/modules/auth/queries/list-my-api-tokens-query.ts
+++ b/packages/server/src/modules/auth/queries/list-my-api-tokens-query.ts
@@ -1,0 +1,26 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type ApiToken } from "@/modules/auth/domain/api-token.aggregate.js";
+import { type ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// Lists the caller's active (non-revoked) tokens for the management UI.
+export const ListMyApiTokensQuery = Schema.TaggedStruct("ListMyApiTokensQuery", {
+  userId: UserId,
+});
+export type ListMyApiTokensQuery = typeof ListMyApiTokensQuery.Type;
+
+export const listMyApiTokensQuerySpanAttributes: SpanAttributesExtractor<ListMyApiTokensQuery> = (
+  q,
+) => ({ "user.id": q.userId });
+
+// Raw handler effect — `ApiTokenRepository` is discharged by the wrap in
+// `auth-query-handlers.ts`.
+export type ListMyApiTokensOutput = Effect.Effect<
+  ReadonlyArray<ApiToken>,
+  PersistenceUnavailable,
+  ApiTokenRepository
+>;

--- a/packages/server/src/modules/auth/queries/list-my-api-tokens.test.ts
+++ b/packages/server/src/modules/auth/queries/list-my-api-tokens.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import * as ApiToken from "@/modules/auth/domain/api-token.aggregate.js";
+import { ApiTokenId } from "@/modules/auth/domain/api-token-id.js";
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/api-token-repository-fake.js";
+import { listMyApiTokens } from "@/modules/auth/queries/list-my-api-tokens.js";
+import { ListMyApiTokensQuery } from "@/modules/auth/queries/list-my-api-tokens-query.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");
+const idA = ApiTokenId.make("33333333-3333-3333-3333-333333333333");
+const idOther = ApiTokenId.make("44444444-4444-4444-4444-444444444444");
+
+const provide = Effect.provide(ApiTokenRepositoryFake);
+
+describe("listMyApiTokens", () => {
+  it.effect("returns only the caller's tokens", () =>
+    Effect.gen(function* () {
+      const repo = yield* ApiTokenRepository;
+      const now = yield* DateTime.now;
+      const mk = (id: ApiTokenId, owner: UserId) =>
+        ApiToken.mint({
+          id,
+          userId: owner,
+          tokenHash: `hash-${id}`,
+          prefix: "pat_abcd1234",
+          label: "ci",
+          now,
+          expiresAt: DateTime.add(now, { days: 90 }),
+        });
+      yield* repo.insert(mk(idA, userId));
+      yield* repo.insert(mk(idOther, otherUserId));
+      const mine = yield* listMyApiTokens(ListMyApiTokensQuery.make({ userId }));
+      deepStrictEqual(
+        mine.map((t) => t.id),
+        [idA],
+      );
+    }).pipe(provide),
+  );
+});

--- a/packages/server/src/modules/auth/queries/list-my-api-tokens.ts
+++ b/packages/server/src/modules/auth/queries/list-my-api-tokens.ts
@@ -1,0 +1,14 @@
+import * as Effect from "effect/Effect";
+
+import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token-repository.js";
+import {
+  type ListMyApiTokensOutput,
+  type ListMyApiTokensQuery,
+} from "@/modules/auth/queries/list-my-api-tokens-query.js";
+
+// Bus-boundary span (ADR-0012) wraps this at dispatch time.
+export const listMyApiTokens = (query: ListMyApiTokensQuery): ListMyApiTokensOutput =>
+  Effect.gen(function* () {
+    const repo = yield* ApiTokenRepository;
+    return yield* repo.listByUser(query.userId);
+  });

--- a/packages/server/src/modules/organization/interface/cli/find-mine.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/cli/find-mine.endpoint.integration.test.ts
@@ -1,0 +1,45 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const ORG_TABLES = [
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("GET /cli/orgs (integration)", () => {
+  const { run } = useServerTestRuntime(ORG_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("lists the caller's organizations via the CLI surface", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const orgs = yield* client.cliOrganization.listMine();
+        deepStrictEqual(
+          orgs.map((o) => o.id),
+          [orgId],
+        );
+        const [first] = orgs;
+        ok(first !== undefined);
+        deepStrictEqual(first.name, "Acme");
+        // Creator becomes the org admin (Phase 4 grant bundle).
+        ok(typeof first.isAdmin === "boolean");
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/organization/interface/cli/find-mine.endpoint.ts
+++ b/packages/server/src/modules/organization/interface/cli/find-mine.endpoint.ts
@@ -1,0 +1,32 @@
+import { CliOrganizationContract } from "@org/contracts/api/Contracts";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import {
+  FindMyOrganizationsQuery,
+  type FindMyOrganizationsView,
+} from "@/modules/organization/queries/find-my-organizations-query.js";
+import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+const toCli = (view: FindMyOrganizationsView): CliOrganizationContract.CliOrganization =>
+  new CliOrganizationContract.CliOrganization({
+    id: view.id,
+    name: view.name,
+    isAdmin: view.isAdmin,
+  });
+
+// CLI adapter (ADR-0024): same `FindMyOrganizationsQuery` as the GUI's
+// findMine (filters by CurrentUser server-side), mapped to the leaner
+// `CliOrganization` shape.
+export const findMineEndpoint = (
+  _request: EndpointRequest<typeof CliOrganizationContract.Group, "listMine">,
+) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const queryBus = yield* QueryBus;
+    const result = yield* queryBus.execute(
+      FindMyOrganizationsQuery.make({ userId: currentUser.userId }),
+    );
+    return result.organizations.map(toCli);
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("CliOrganizationLive.listMine"));

--- a/packages/server/src/modules/organization/interface/cli/org-cli-live.ts
+++ b/packages/server/src/modules/organization/interface/cli/org-cli-live.ts
@@ -1,0 +1,11 @@
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+
+import { Api } from "@/api.js";
+
+import { findMineEndpoint } from "./find-mine.endpoint.js";
+
+// Registers the CLI-facing organization endpoints (the `cliOrganization`
+// group on CliApi). Sibling to the HTTP org group; dispatches to the same bus.
+export const OrgCliLive = HttpApiBuilder.group(Api, "cliOrganization", (handlers) =>
+  handlers.handle("listMine", findMineEndpoint),
+);

--- a/packages/server/src/modules/organization/organization-module.ts
+++ b/packages/server/src/modules/organization/organization-module.ts
@@ -4,6 +4,7 @@ import { MailerLive } from "@/platform/notifications/mailer-live.js";
 
 import { InvitationMailerLive } from "./infrastructure/external/invitation-mailer-live.js";
 import { OrganizationRepositoryLive } from "./infrastructure/organization-repository-live.js";
+import { OrgCliLive } from "./interface/cli/org-cli-live.js";
 import {
   InvitationLive,
   OrganizationAdminLive,
@@ -23,4 +24,6 @@ export const OrganizationModuleLive = Layer.mergeAll(
   OrganizationLive,
   OrganizationAdminLive,
   InvitationLive,
+  // CLI-facing `listMine` (the `cliOrganization` group on CliApi).
+  OrgCliLive,
 ).pipe(Layer.provide(OrganizationRepositoryLive), Layer.provide(InvitationMailerProvided));

--- a/packages/server/src/modules/todos/commands/complete-todo-command.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo-command.ts
@@ -1,0 +1,32 @@
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-repository.js";
+import { type Todo } from "@/modules/todos/domain/todo.js";
+import { type TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attributable.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+// First-class "mark done" verb (ADR-0024) — distinct from `UpdateTodoCommand`
+// so the CLI can complete a todo without resupplying its title.
+export const CompleteTodoCommand = Schema.TaggedStruct("CompleteTodoCommand", {
+  todoId: TodoId,
+  organizationId: OrganizationId,
+  userId: UserId,
+});
+export type CompleteTodoCommand = typeof CompleteTodoCommand.Type;
+
+export const completeTodoCommandSpanAttributes: SpanAttributesExtractor<CompleteTodoCommand> = (
+  cmd,
+) => ({ "todo.id": cmd.todoId, "organization.id": cmd.organizationId, "user.id": cmd.userId });
+
+// Raw handler effect — `TodosRepository` is discharged by the wrap in
+// `todo-command-handlers.ts`; the bus-registered output type lives there.
+export type CompleteTodoOutput = Effect.Effect<
+  Todo,
+  TodoNotFound | PersistenceUnavailable,
+  TodosRepository
+>;

--- a/packages/server/src/modules/todos/commands/complete-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
+import { TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-repository.js";
+import * as Todo from "@/modules/todos/domain/todo.js";
+import { TodoNotFound } from "@/modules/todos/domain/todo-errors.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { TodosRepositoryFake } from "@/modules/todos/infrastructure/todos-repository-fake.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { completeTodo } from "./complete-todo.js";
+import { CompleteTodoCommand } from "./complete-todo-command.js";
+
+const todoId = TodoId.make("11111111-1111-1111-1111-111111111111");
+const userId = UserId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const otherOrgId = OrganizationId.make("33333333-3333-3333-3333-333333333333");
+const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
+
+const seed = Effect.gen(function* () {
+  const repo = yield* TodosRepository;
+  yield* repo.insert(Todo.create({ id: todoId, organizationId: orgId, title: "Buy milk", now }));
+});
+
+describe("completeTodo", () => {
+  it.effect("marks the todo done, preserving its title", () =>
+    Effect.gen(function* () {
+      yield* seed;
+      const completed = yield* completeTodo(
+        CompleteTodoCommand.make({ todoId, organizationId: orgId, userId }),
+      );
+      deepStrictEqual(completed.completed, true);
+      deepStrictEqual(completed.title, "Buy milk");
+      const stored = yield* (yield* TodosRepository).findById(orgId, todoId);
+      deepStrictEqual(stored.completed, true);
+    }).pipe(Effect.provide(TodosRepositoryFake)),
+  );
+
+  it.effect("fails TodoNotFound for an unknown todo", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        completeTodo(CompleteTodoCommand.make({ todoId, organizationId: orgId, userId })),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        deepStrictEqual(error instanceof TodoNotFound, true);
+      }
+    }).pipe(Effect.provide(TodosRepositoryFake)),
+  );
+
+  it.effect("fails TodoNotFound across a tenant boundary", () =>
+    Effect.gen(function* () {
+      yield* seed;
+      const exit = yield* Effect.exit(
+        completeTodo(CompleteTodoCommand.make({ todoId, organizationId: otherOrgId, userId })),
+      );
+      deepStrictEqual(Exit.isFailure(exit), true);
+    }).pipe(Effect.provide(TodosRepositoryFake)),
+  );
+});

--- a/packages/server/src/modules/todos/commands/complete-todo.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo.ts
@@ -1,0 +1,19 @@
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import {
+  type CompleteTodoCommand,
+  type CompleteTodoOutput,
+} from "@/modules/todos/commands/complete-todo-command.js";
+import { TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-repository.js";
+import * as Todo from "@/modules/todos/domain/todo.js";
+
+export const completeTodo = (cmd: CompleteTodoCommand): CompleteTodoOutput =>
+  Effect.gen(function* () {
+    const repo = yield* TodosRepository;
+    const existing = yield* repo.findById(cmd.organizationId, cmd.todoId);
+    const now = yield* DateTime.now;
+    const completed = Todo.complete(existing, now);
+    yield* repo.update(completed);
+    return completed;
+  });

--- a/packages/server/src/modules/todos/domain/todo.ts
+++ b/packages/server/src/modules/todos/domain/todo.ts
@@ -49,3 +49,17 @@ export const update = (todo: Todo, input: UpdateInput): Todo =>
     createdAt: todo.createdAt,
     updatedAt: input.now,
   });
+
+// Marks the todo done. A first-class verb (not a generic `update`) because
+// the CLI exposes "complete" as its own command and there's no reason to
+// require the title to flip the flag. Idempotent: completing a done todo
+// just re-stamps `updatedAt`.
+export const complete = (todo: Todo, now: DateTime.Utc): Todo =>
+  Todo.make({
+    id: todo.id,
+    organizationId: todo.organizationId,
+    title: todo.title,
+    completed: true,
+    createdAt: todo.createdAt,
+    updatedAt: now,
+  });

--- a/packages/server/src/modules/todos/index.ts
+++ b/packages/server/src/modules/todos/index.ts
@@ -1,3 +1,4 @@
+export { CompleteTodoCommand } from "./commands/complete-todo-command.js";
 export { CreateTodoCommand } from "./commands/create-todo-command.js";
 export { DeleteTodoCommand } from "./commands/delete-todo-command.js";
 export { UpdateTodoCommand } from "./commands/update-todo-command.js";

--- a/packages/server/src/modules/todos/interface/cli/complete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/complete.endpoint.integration.test.ts
@@ -1,0 +1,60 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("POST /cli/orgs/:orgId/todos/:id/complete (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("marks a todo done without resupplying its title", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const created = yield* client.cliTodos.create({
+          path: { orgId },
+          payload: { title: "Buy milk" },
+        });
+        const completed = yield* client.cliTodos.complete({
+          path: { orgId, id: created.id },
+        });
+        deepStrictEqual(completed.completed, true);
+        deepStrictEqual(completed.title, "Buy milk");
+      }),
+    );
+  });
+
+  it("fails CliTodoNotFoundError for an unknown todo", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const ghost = TodoId.make("00000000-0000-0000-0000-000000000000");
+        const error = yield* client.cliTodos
+          .complete({ path: { orgId, id: ghost } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "CliTodoNotFoundError");
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/todos/interface/cli/complete.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/cli/complete.endpoint.ts
@@ -1,0 +1,55 @@
+import { CliTodosContract } from "@org/contracts/api/Contracts";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { CompleteTodoCommand } from "@/modules/todos/commands/complete-todo-command.js";
+import { TodoResource } from "@/modules/todos/policies/todos-policies.js";
+import { Actions } from "@/platform/auth/actions.js";
+import * as Authz from "@/platform/auth/authz.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// CLI adapter (ADR-0024): completing is an update-gated action. The `todo`
+// resolver scopes by (orgId, id), so a missing or cross-tenant todo is
+// NotFound → the CLI's CliTodoNotFoundError.
+export const completeEndpoint = (
+  request: EndpointRequest<typeof CliTodosContract.Group, "complete">,
+) =>
+  Effect.gen(function* () {
+    yield* Authz.hasPermissions(TodoResource, Actions.Update, {
+      organizationId: request.path.orgId,
+      todoId: request.path.id,
+    }).pipe(
+      Effect.catchTag("NotFound", () =>
+        Effect.fail(
+          new CliTodosContract.CliTodoNotFoundError({
+            message: `Todo with id ${request.path.id} not found`,
+          }),
+        ),
+      ),
+    );
+    const commandBus = yield* CommandBus;
+    const currentUser = yield* CurrentUser;
+    const todo = yield* commandBus.execute(
+      CompleteTodoCommand.make({
+        todoId: request.path.id,
+        organizationId: request.path.orgId,
+        userId: currentUser.userId,
+      }),
+    );
+    return new CliTodosContract.CliTodo({
+      id: todo.id,
+      title: todo.title,
+      completed: todo.completed,
+    });
+  }).pipe(
+    Effect.catchTag("TodoNotFound", (err) =>
+      Effect.fail(
+        new CliTodosContract.CliTodoNotFoundError({
+          message: `Todo with id ${err.todoId} not found`,
+        }),
+      ),
+    ),
+    recoverPersistenceUnavailable,
+    Effect.withSpan("CliTodosLive.complete"),
+  );

--- a/packages/server/src/modules/todos/interface/cli/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/create.endpoint.integration.test.ts
@@ -1,0 +1,43 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, ok } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("POST /cli/orgs/:orgId/todos (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("creates a todo via the CLI surface and returns the CliTodo shape", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const todo = yield* client.cliTodos.create({
+          path: { orgId },
+          payload: { title: "Buy milk" },
+        });
+        deepStrictEqual(todo.title, "Buy milk");
+        deepStrictEqual(todo.completed, false);
+        ok(typeof todo.id === "string" && todo.id.length > 0);
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/todos/interface/cli/create.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/cli/create.endpoint.ts
@@ -1,0 +1,35 @@
+import { CliTodosContract } from "@org/contracts/api/Contracts";
+import * as CustomHttpApiError from "@org/contracts/CustomHttpApiError";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { CreateTodoCommand } from "@/modules/todos/commands/create-todo-command.js";
+import { todoMemberCheck } from "@/modules/todos/policies/todos-policies.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// CLI adapter (ADR-0024): same flat membership gate + CreateTodoCommand as
+// the GUI's create endpoint.
+export const createEndpoint = (request: EndpointRequest<typeof CliTodosContract.Group, "create">) =>
+  Effect.gen(function* () {
+    const currentUser = yield* CurrentUser;
+    const allowed = yield* todoMemberCheck(currentUser, { organizationId: request.path.orgId });
+    if (!allowed) {
+      return yield* Effect.fail(
+        new CustomHttpApiError.Forbidden({ message: "Not permitted: todoCollection.create" }),
+      );
+    }
+    const commandBus = yield* CommandBus;
+    const todo = yield* commandBus.execute(
+      CreateTodoCommand.make({
+        title: request.payload.title,
+        organizationId: request.path.orgId,
+        userId: currentUser.userId,
+      }),
+    );
+    return new CliTodosContract.CliTodo({
+      id: todo.id,
+      title: todo.title,
+      completed: todo.completed,
+    });
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("CliTodosLive.create"));

--- a/packages/server/src/modules/todos/interface/cli/list.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/list.endpoint.integration.test.ts
@@ -1,0 +1,46 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("GET /cli/orgs/:orgId/todos (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("lists the org's todos via the CLI surface", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        deepStrictEqual((yield* client.cliTodos.list({ path: { orgId } })).length, 0);
+        const created = yield* client.cliTodos.create({
+          path: { orgId },
+          payload: { title: "Buy milk" },
+        });
+        const todos = yield* client.cliTodos.list({ path: { orgId } });
+        deepStrictEqual(
+          todos.map((t) => t.id),
+          [created.id],
+        );
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/todos/interface/cli/list.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/cli/list.endpoint.ts
@@ -1,0 +1,31 @@
+import { CliTodosContract } from "@org/contracts/api/Contracts";
+import * as Effect from "effect/Effect";
+
+import { TodoCollectionResource } from "@/modules/todos/policies/todos-policies.js";
+import {
+  ListTodosQuery,
+  type ListTodosTodoView,
+} from "@/modules/todos/queries/list-todos-query.js";
+import { Actions } from "@/platform/auth/actions.js";
+import * as Authz from "@/platform/auth/authz.js";
+import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+const toCli = (view: ListTodosTodoView): CliTodosContract.CliTodo =>
+  new CliTodosContract.CliTodo({ id: view.id, title: view.title, completed: view.completed });
+
+// CLI adapter (ADR-0024): same membership gate + ListTodosQuery as the GUI's
+// get endpoint, mapped to the CLI's own `CliTodo` shape.
+export const listEndpoint = (request: EndpointRequest<typeof CliTodosContract.Group, "list">) =>
+  Effect.gen(function* () {
+    yield* Authz.hasPermissions(TodoCollectionResource, Actions.Read, request.path.orgId).pipe(
+      Effect.catchTag("NotFound", () =>
+        Effect.die("Unreachable: todoCollection resolver cannot surface NotFound"),
+      ),
+    );
+    const queryBus = yield* QueryBus;
+    const result = yield* queryBus.execute(
+      ListTodosQuery.make({ organizationId: request.path.orgId }),
+    );
+    return result.todos.map(toCli);
+  }).pipe(recoverPersistenceUnavailable, Effect.withSpan("CliTodosLive.list"));

--- a/packages/server/src/modules/todos/interface/cli/remove.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/remove.endpoint.integration.test.ts
@@ -1,0 +1,57 @@
+import * as HttpApiClient from "@effect/platform/HttpApiClient";
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as Effect from "effect/Effect";
+
+import { Api } from "@/api.js";
+import { TodoId } from "@/modules/todos/domain/todo-id.js";
+import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
+import { hasTestDatabase } from "@/test-utils/test-database.js";
+import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
+
+const TODO_TABLES = [
+  "todos.todos",
+  "organization.organization_roles",
+  "organization.memberships",
+  "organization.organizations",
+  "platform.roles",
+  "user.users",
+] as const;
+
+const suite = hasTestDatabase ? describe.sequential : describe.skip;
+
+suite("DELETE /cli/orgs/:orgId/todos/:id (integration)", () => {
+  const { run } = useServerTestRuntime(TODO_TABLES, {
+    server: TestServerLiveAsMember,
+    seedSuperAdminCaller: true,
+  });
+
+  it("removes a todo so it drops out of the listing", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const created = yield* client.cliTodos.create({
+          path: { orgId },
+          payload: { title: "Buy milk" },
+        });
+        yield* client.cliTodos.remove({ path: { orgId, id: created.id } });
+        deepStrictEqual((yield* client.cliTodos.list({ path: { orgId } })).length, 0);
+      }),
+    );
+  });
+
+  it("fails CliTodoNotFoundError for an unknown todo", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* HttpApiClient.make(Api);
+        const { id: orgId } = yield* client.organization.create({ payload: { name: "Acme" } });
+        const ghost = TodoId.make("00000000-0000-0000-0000-000000000000");
+        const error = yield* client.cliTodos
+          .remove({ path: { orgId, id: ghost } })
+          .pipe(Effect.flip);
+        deepStrictEqual(error._tag, "CliTodoNotFoundError");
+      }),
+    );
+  });
+});

--- a/packages/server/src/modules/todos/interface/cli/remove.endpoint.ts
+++ b/packages/server/src/modules/todos/interface/cli/remove.endpoint.ts
@@ -1,0 +1,47 @@
+import { CliTodosContract } from "@org/contracts/api/Contracts";
+import { CurrentUser } from "@org/contracts/Policy";
+import * as Effect from "effect/Effect";
+
+import { DeleteTodoCommand } from "@/modules/todos/commands/delete-todo-command.js";
+import { TodoResource } from "@/modules/todos/policies/todos-policies.js";
+import { Actions } from "@/platform/auth/actions.js";
+import * as Authz from "@/platform/auth/authz.js";
+import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
+import { type EndpointRequest, recoverPersistenceUnavailable } from "@/platform/http-endpoint.js";
+
+// CLI adapter (ADR-0024): same delete-gated resource + DeleteTodoCommand as
+// the GUI's delete endpoint, with the CLI's own NotFound shape.
+export const removeEndpoint = (request: EndpointRequest<typeof CliTodosContract.Group, "remove">) =>
+  Effect.gen(function* () {
+    yield* Authz.hasPermissions(TodoResource, Actions.Delete, {
+      organizationId: request.path.orgId,
+      todoId: request.path.id,
+    }).pipe(
+      Effect.catchTag("NotFound", () =>
+        Effect.fail(
+          new CliTodosContract.CliTodoNotFoundError({
+            message: `Todo with id ${request.path.id} not found`,
+          }),
+        ),
+      ),
+    );
+    const commandBus = yield* CommandBus;
+    const currentUser = yield* CurrentUser;
+    yield* commandBus.execute(
+      DeleteTodoCommand.make({
+        todoId: request.path.id,
+        organizationId: request.path.orgId,
+        userId: currentUser.userId,
+      }),
+    );
+  }).pipe(
+    Effect.catchTag("TodoNotFound", (err) =>
+      Effect.fail(
+        new CliTodosContract.CliTodoNotFoundError({
+          message: `Todo with id ${err.todoId} not found`,
+        }),
+      ),
+    ),
+    recoverPersistenceUnavailable,
+    Effect.withSpan("CliTodosLive.remove"),
+  );

--- a/packages/server/src/modules/todos/interface/cli/todos-cli-live.ts
+++ b/packages/server/src/modules/todos/interface/cli/todos-cli-live.ts
@@ -1,0 +1,18 @@
+import * as HttpApiBuilder from "@effect/platform/HttpApiBuilder";
+
+import { Api } from "@/api.js";
+
+import { completeEndpoint } from "./complete.endpoint.js";
+import { createEndpoint } from "./create.endpoint.js";
+import { listEndpoint } from "./list.endpoint.js";
+import { removeEndpoint } from "./remove.endpoint.js";
+
+// Registers the CLI-facing todos endpoints (the `cliTodos` group on CliApi).
+// Sibling to `interface/http/todos-live.ts`; both dispatch to the same bus.
+export const TodosCliLive = HttpApiBuilder.group(Api, "cliTodos", (handlers) =>
+  handlers
+    .handle("list", listEndpoint)
+    .handle("create", createEndpoint)
+    .handle("complete", completeEndpoint)
+    .handle("remove", removeEndpoint),
+);

--- a/packages/server/src/modules/todos/todo-command-handlers.ts
+++ b/packages/server/src/modules/todos/todo-command-handlers.ts
@@ -1,6 +1,11 @@
 import { type Database } from "@org/database/index";
 import * as Effect from "effect/Effect";
 
+import { completeTodo } from "@/modules/todos/commands/complete-todo.js";
+import {
+  type CompleteTodoCommand,
+  completeTodoCommandSpanAttributes,
+} from "@/modules/todos/commands/complete-todo-command.js";
 import { createTodo } from "@/modules/todos/commands/create-todo.js";
 import {
   type CreateTodoCommand,
@@ -33,6 +38,11 @@ type UpdateTodoBusOutput = Effect.Effect<
   TodoNotFound | PersistenceUnavailable,
   Database.Database
 >;
+type CompleteTodoBusOutput = Effect.Effect<
+  Todo,
+  TodoNotFound | PersistenceUnavailable,
+  Database.Database
+>;
 
 declare module "@/platform/ddd/ports/command-bus.js" {
   interface CommandRegistry {
@@ -43,6 +53,10 @@ declare module "@/platform/ddd/ports/command-bus.js" {
     UpdateTodoCommand: {
       readonly command: UpdateTodoCommand;
       readonly output: UpdateTodoBusOutput;
+    };
+    CompleteTodoCommand: {
+      readonly command: CompleteTodoCommand;
+      readonly output: CompleteTodoBusOutput;
     };
     DeleteTodoCommand: {
       readonly command: DeleteTodoCommand;
@@ -59,6 +73,11 @@ export const todoCommandHandlers = commandHandlers({
   UpdateTodoCommand: {
     handle: (cmd): UpdateTodoBusOutput => updateTodo(cmd).pipe(Effect.provide(TodosRepositoryLive)),
     spanAttributes: updateTodoCommandSpanAttributes,
+  },
+  CompleteTodoCommand: {
+    handle: (cmd): CompleteTodoBusOutput =>
+      completeTodo(cmd).pipe(Effect.provide(TodosRepositoryLive)),
+    spanAttributes: completeTodoCommandSpanAttributes,
   },
   DeleteTodoCommand: {
     handle: (cmd): DeleteTodoBusOutput => deleteTodo(cmd).pipe(Effect.provide(TodosRepositoryLive)),

--- a/packages/server/src/modules/todos/todos-module.ts
+++ b/packages/server/src/modules/todos/todos-module.ts
@@ -1,6 +1,11 @@
 import * as Layer from "effect/Layer";
 
 import { TodosRepositoryLive } from "./infrastructure/todos-repository-live.js";
+import { TodosCliLive } from "./interface/cli/todos-cli-live.js";
 import { TodosLive } from "./interface/http/todos-live.js";
 
-export const TodosModuleLive = TodosLive.pipe(Layer.provide(TodosRepositoryLive));
+// Both inbound adapters (GUI HTTP + CLI) dispatch to the same bus; the
+// module wires both groups and the repository they share (ADR-0024).
+export const TodosModuleLive = Layer.mergeAll(TodosLive, TodosCliLive).pipe(
+  Layer.provide(TodosRepositoryLive),
+);

--- a/packages/server/src/platform/middlewares/auth-middleware-live.ts
+++ b/packages/server/src/platform/middlewares/auth-middleware-live.ts
@@ -7,10 +7,28 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 import { EnvVars } from "@/common/env-vars.js";
-import { FindSessionQuery, SessionId, TouchSessionCommand } from "@/modules/auth/index.js";
+import {
+  FindApiTokenByHashQuery,
+  FindSessionQuery,
+  hashToken,
+  SessionId,
+  TouchApiTokenCommand,
+  TouchSessionCommand,
+} from "@/modules/auth/index.js";
 import { CookieCodec } from "@/platform/auth/cookie-codec.js";
 import { CommandBus } from "@/platform/ddd/ports/command-bus.js";
 import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
+
+// `Authorization: Bearer <token>` — case-insensitive scheme. Returns the
+// raw token, or null when the header is absent or not a bearer credential.
+const BEARER_PREFIX = /^Bearer\s+/i;
+const readBearer = (authorization: string | undefined): string | null => {
+  if (authorization === undefined) return null;
+  const trimmed = authorization.trim();
+  if (!BEARER_PREFIX.test(trimmed)) return null;
+  const token = trimmed.replace(BEARER_PREFIX, "").trim();
+  return token === "" ? null : token;
+};
 
 // Distinguish "the DB is down" (503, retry) from "your session is bad"
 // (401, log back in). `Effect.mapError(() => Unauthorized)` would collapse
@@ -36,6 +54,31 @@ export const UserAuthMiddlewareLive = Layer.effect(
 
     return Effect.gen(function* () {
       const httpReq = yield* HttpServerRequest.HttpServerRequest;
+
+      // Bearer path (CLI / MCP / CI — ADR-0024): an `Authorization: Bearer`
+      // token takes precedence over the cookie. We hash the presented token
+      // here so the raw secret never travels through the bus or a span,
+      // then resolve it to the same `CurrentUser` the cookie path produces.
+      const bearer = readBearer(httpReq.headers.authorization);
+      if (bearer !== null) {
+        const apiToken = yield* queryBus
+          .execute(FindApiTokenByHashQuery.make({ tokenHash: hashToken(bearer) }))
+          .pipe(Effect.provideService(Database.Database, db), Effect.mapError(toAuthError));
+        // Fire-and-forget last-used stamp; throttled + error-swallowing in the
+        // handler, same rationale as the session touch below.
+        yield* commandBus
+          .execute(
+            TouchApiTokenCommand.make({
+              apiTokenId: apiToken.id,
+              thresholdSeconds: env.API_TOKEN_TOUCH_THRESHOLD_SECONDS,
+            }),
+          )
+          .pipe(Effect.provideService(Database.Database, db));
+        // No browser session for a bearer caller; the token id stands in as
+        // the opaque principal id on `CurrentUser` (Policy.ts unchanged).
+        return { sessionId: apiToken.id, userId: apiToken.userId };
+      }
+
       const cookies = cookie.parse(httpReq.headers.cookie ?? "");
       const raw = cookies[env.SESSION_COOKIE_NAME];
       if (raw === undefined || raw === "")

--- a/packages/web/app/(authed)/device/page.tsx
+++ b/packages/web/app/(authed)/device/page.tsx
@@ -1,0 +1,32 @@
+// Device-approval page (ADR-0024). The CLI's `verification_uri_complete`
+// links here with `?code=XXXX-XXXX`; the (authed) layout guard guarantees a
+// signed-in caller, so approving binds the grant to the right user. Pure
+// client interaction from here — the form posts to `/auth/device/approve`.
+
+import { Card } from "@org/components/primitives/card";
+
+import { ApproveDevice } from "@/features/device/approve-device/approve-device";
+
+export default async function DeviceApprovalPage({
+  searchParams,
+}: {
+  readonly searchParams: Promise<{ readonly code?: string }>;
+}) {
+  const { code } = await searchParams;
+
+  return (
+    <div className="mx-auto w-full max-w-md space-y-4 px-4">
+      <Card className="shadow-md">
+        <Card.Header>
+          <Card.Title className="text-2xl font-semibold">Approve a device</Card.Title>
+        </Card.Header>
+        <Card.Content>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Enter the code shown in your terminal to authorize the CLI on your account.
+          </p>
+          <ApproveDevice initialCode={code ?? ""} />
+        </Card.Content>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/features/device/approve-device/approve-device.presenter.test.tsx
+++ b/packages/web/features/device/approve-device/approve-device.presenter.test.tsx
@@ -1,0 +1,45 @@
+// Presenter test: stubs the mutation hook so we can assert the wiring
+// without a QueryClient. Submitting the form should dispatch the decoded
+// user code; `isApproved` mirrors the mutation's success flag.
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useApproveDevicePresenter } from "./approve-device.presenter";
+
+const mutateAsync = vi.fn();
+let isSuccess = false;
+
+vi.mock("@/services/data-access/use-device-queries", () => ({
+  useApproveDeviceMutation: () => ({ mutateAsync, isSuccess }),
+}));
+
+describe("useApproveDevicePresenter", () => {
+  beforeEach(() => {
+    mutateAsync.mockReset();
+    isSuccess = false;
+  });
+
+  it("submits the decoded user code", async () => {
+    mutateAsync.mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useApproveDevicePresenter(""));
+    result.current.form.setFieldValue("userCode", "ABCD-2345");
+
+    await act(async () => {
+      await result.current.form.handleSubmit();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith({ userCode: "ABCD-2345" });
+  });
+
+  it("prefills the user code from the verification link", () => {
+    const { result } = renderHook(() => useApproveDevicePresenter("WXYZ-2345"));
+    expect(result.current.form.state.values.userCode).toBe("WXYZ-2345");
+  });
+
+  it("reflects the mutation success flag as isApproved", () => {
+    isSuccess = true;
+    const { result } = renderHook(() => useApproveDevicePresenter(""));
+    expect(result.current.isApproved).toBe(true);
+  });
+});

--- a/packages/web/features/device/approve-device/approve-device.presenter.ts
+++ b/packages/web/features/device/approve-device/approve-device.presenter.ts
@@ -1,0 +1,35 @@
+"use client";
+
+// Presenter for ApproveDevice (ADR-0014 Tier 2). Schema-validates the user
+// code and dispatches the approval mutation. Success is read off the
+// mutation so the component can swap to a confirmation; the toast (fired by
+// the hook) covers the transient feedback.
+
+import { AuthContract } from "@org/contracts/api/Contracts";
+import { useForm } from "@tanstack/react-form";
+import * as Schema from "effect/Schema";
+
+import { makeFormOptions } from "@/lib/tanstack-query/make-form-options";
+import { useApproveDeviceMutation } from "@/services/data-access/use-device-queries";
+
+export const useApproveDevicePresenter = (initialCode: string) => {
+  const approveMutation = useApproveDeviceMutation();
+
+  const form = useForm({
+    ...makeFormOptions({
+      schema: AuthContract.DeviceApprovalPayload,
+      defaultValues: { userCode: initialCode },
+      validator: "onSubmit",
+    }),
+    onSubmit: async ({ value }) => {
+      const payload = Schema.decodeSync(AuthContract.DeviceApprovalPayload)(value);
+      try {
+        await approveMutation.mutateAsync({ userCode: payload.userCode });
+      } catch {
+        // Mutation has already surfaced the failure via toast.
+      }
+    },
+  });
+
+  return { form, isApproved: approveMutation.isSuccess };
+};

--- a/packages/web/features/device/approve-device/approve-device.tsx
+++ b/packages/web/features/device/approve-device/approve-device.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@org/components/primitives/button";
+import { Form } from "@org/components/primitives/form";
+import { Input } from "@org/components/primitives/input";
+import { Label } from "@org/components/primitives/label";
+
+import { useApproveDevicePresenter } from "./approve-device.presenter";
+
+export const ApproveDevice: React.FC<{ readonly initialCode: string }> = ({ initialCode }) => {
+  const { form, isApproved } = useApproveDevicePresenter(initialCode);
+
+  if (isApproved) {
+    return (
+      <p data-testid="device-approved" className="text-sm">
+        Device approved — you can return to your terminal. The CLI is now signed in.
+      </p>
+    );
+  }
+
+  return (
+    <Form onSubmit={form.handleSubmit}>
+      <form.Field name="userCode">
+        {(field) => (
+          <Form.Control>
+            <Label htmlFor={field.name}>Device code</Label>
+            <Input
+              id={field.name}
+              value={field.state.value}
+              onChange={(e) => {
+                field.handleChange(e.target.value);
+              }}
+              placeholder="ABCD-2345"
+              data-testid="device-code-input"
+            />
+            <Form.Error error={form.state.errorMap.onSubmit?.userCode} />
+          </Form.Control>
+        )}
+      </form.Field>
+
+      <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+        {([canSubmit, isSubmitting]) => (
+          <Button
+            type="submit"
+            disabled={!canSubmit}
+            className="mt-4 w-full"
+            data-testid="device-approve-submit"
+          >
+            {isSubmitting ? "Approving…" : "Approve device"}
+          </Button>
+        )}
+      </form.Subscribe>
+    </Form>
+  );
+};

--- a/packages/web/services/data-access/device-queries.ts
+++ b/packages/web/services/data-access/device-queries.ts
@@ -1,0 +1,14 @@
+// Device-approval data-access. Server-safe Effect only; the client hook
+// layer in `use-device-queries.ts` wraps it as a mutation. There's nothing
+// to prefetch (the page just renders a form), so no `.server.ts` sibling.
+
+import * as Effect from "effect/Effect";
+
+import { ApiClient } from "@/services/api-client.shared";
+
+// Browser-side approval of a CLI device grant (ADR-0024): bind the grant
+// identified by `userCode` to the signed-in caller.
+export const approveDevice = (args: { readonly userCode: string }) =>
+  Effect.flatMap(ApiClient, ({ client }) =>
+    client.authDevice.approve({ payload: { userCode: args.userCode } }),
+  );

--- a/packages/web/services/data-access/use-device-queries.ts
+++ b/packages/web/services/data-access/use-device-queries.ts
@@ -1,0 +1,20 @@
+"use client";
+
+// Client-side device-approval hook. Pairs with the environment-agnostic
+// Effect in `device-queries.ts`. Toasts on success and echoes the tagged
+// error messages the approve endpoint can surface (unknown / expired code).
+
+import { useEffectMutation } from "@/lib/tanstack-query";
+
+import { approveDevice } from "./device-queries";
+
+export const useApproveDeviceMutation = () =>
+  useEffectMutation({
+    mutationKey: ["DeviceQueries.approve"],
+    mutationFn: approveDevice,
+    toastifySuccess: () => "Device approved — return to your terminal.",
+    toastifyErrors: {
+      NotFound: (error) => error.message,
+      Gone: (error) => error.message,
+    },
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,56 @@ importers:
         specifier: ~5.7.2
         version: 5.7.3
 
+  packages/api-client:
+    dependencies:
+      '@effect/platform':
+        specifier: 0.96.1
+        version: 0.96.1(effect@3.21.2)
+      '@org/contracts':
+        specifier: workspace:^
+        version: link:../contracts/dist
+      effect:
+        specifier: 3.21.2
+        version: 3.21.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+
+  packages/cli:
+    dependencies:
+      '@effect/cli':
+        specifier: 0.75.2
+        version: 0.75.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform':
+        specifier: 0.96.1
+        version: 0.96.1(effect@3.21.2)
+      '@effect/platform-node':
+        specifier: 0.106.0
+        version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer':
+        specifier: 0.49.0
+        version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi':
+        specifier: 0.49.0
+        version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@org/api-client':
+        specifier: workspace:^
+        version: link:../api-client
+      '@org/contracts':
+        specifier: workspace:^
+        version: link:../contracts/dist
+      effect:
+        specifier: 3.21.2
+        version: 3.21.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
+
   packages/components:
     dependencies:
       '@radix-ui/react-checkbox':
@@ -341,6 +391,37 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
+
+  packages/mcp:
+    dependencies:
+      '@effect/platform':
+        specifier: 0.96.1
+        version: 0.96.1(effect@3.21.2)
+      '@effect/platform-node':
+        specifier: 0.106.0
+        version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      '@org/api-client':
+        specifier: workspace:^
+        version: link:../api-client
+      '@org/contracts':
+        specifier: workspace:^
+        version: link:../contracts/dist
+      effect:
+        specifier: 3.21.2
+        version: 3.21.2
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
@@ -866,6 +947,14 @@ packages:
     engines: {node: '>=16.17.1'}
     hasBin: true
 
+  '@effect/cli@0.75.2':
+    resolution: {integrity: sha512-+cMn/ZtFB+jEvgB6phrTT6XyPkIUnmX4G0nUSln7yj3lwyiHQ578Iwr8nHeU1CKEtlh4Xt+mYc0yiT912xu7YA==}
+    peerDependencies:
+      '@effect/platform': 0.96.1
+      '@effect/printer': ^0.49.0
+      '@effect/printer-ansi': ^0.49.0
+      effect: 3.21.2
+
   '@effect/cluster@0.58.2':
     resolution: {integrity: sha512-oxQ3zUhXq0mJA7Y4TliALMP39Bx0LtAIxcqOW1Bdjh6uk+nG7kul/Puw80SwlcYGv3ul50SG+gvSRUTXB8d3JQ==}
     peerDependencies:
@@ -932,6 +1021,18 @@ packages:
     peerDependencies:
       effect: 3.21.2
 
+  '@effect/printer-ansi@0.49.0':
+    resolution: {integrity: sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==}
+    peerDependencies:
+      '@effect/typeclass': ^0.40.0
+      effect: 3.21.2
+
+  '@effect/printer@0.49.0':
+    resolution: {integrity: sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==}
+    peerDependencies:
+      '@effect/typeclass': ^0.40.0
+      effect: 3.21.2
+
   '@effect/rpc@0.75.1':
     resolution: {integrity: sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==}
     peerDependencies:
@@ -943,6 +1044,11 @@ packages:
     peerDependencies:
       '@effect/experimental': 0.60.0
       '@effect/platform': 0.96.1
+      effect: 3.21.2
+
+  '@effect/typeclass@0.40.0':
+    resolution: {integrity: sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==}
+    peerDependencies:
       effect: 3.21.2
 
   '@effect/vitest@0.29.0':
@@ -1206,6 +1312,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1451,6 +1563,16 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mrleebo/prisma-ast@0.14.0':
     resolution: {integrity: sha512-nKouX7rsrzk/5nk6Wayvgqt81tnAbSbPFC5XzRTDc5/tSCrBf/tSMAXEm1CeUznC/ZL664iH5KNwvvmPtJ8jqQ==}
@@ -3176,6 +3298,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -3206,8 +3332,19 @@ packages:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
@@ -3364,6 +3501,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -3398,6 +3539,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3557,6 +3702,18 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -3571,6 +3728,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -3702,6 +3863,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dependency-cruiser@17.3.10:
     resolution: {integrity: sha512-jF5WaIb+O+wLabXrQE7iBY2zYBEW8VlnuuL0+iZPvZHGhTaAYdLk31DI0zkwhcGE8CiHcDwGhMnn3PfOAYnVdQ==}
     engines: {node: ^20.12||^22||>=24}
@@ -3816,6 +3981,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   effect@3.21.2:
     resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
 
@@ -3834,6 +4002,10 @@ packages:
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -3918,6 +4090,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -4142,12 +4317,24 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -4160,6 +4347,16 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -4193,6 +4390,9 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -4228,6 +4428,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
@@ -4271,8 +4475,16 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fp-ts@2.16.9:
     resolution: {integrity: sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-readdir-recursive@1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -4449,6 +4661,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -4470,6 +4686,10 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -4489,6 +4709,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -4536,6 +4760,10 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -4551,6 +4779,14 @@ packages:
     resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
     peerDependencies:
       fp-ts: ^2.5.0
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -4685,6 +4921,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -4828,6 +5067,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5049,6 +5294,14 @@ packages:
   mdast-util-to-string@2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -5067,9 +5320,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -5173,6 +5434,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   next@16.2.6:
     resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
@@ -5285,6 +5550,10 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -5380,6 +5649,10 @@ packages:
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5413,6 +5686,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5515,6 +5791,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-entry-points@1.1.1:
     resolution: {integrity: sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==}
@@ -5704,12 +5984,20 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -5719,6 +6007,14 @@ packages:
 
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -5842,6 +6138,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
@@ -5909,6 +6209,10 @@ packages:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -5980,9 +6284,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@12.0.0:
     resolution: {integrity: sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==}
     engines: {node: '>=18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -6004,6 +6316,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -6357,6 +6672,13 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   tough-cookie@5.1.1:
     resolution: {integrity: sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==}
     engines: {node: '>=16'}
@@ -6428,6 +6750,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -6483,6 +6809,10 @@ packages:
 
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -6543,6 +6873,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -6780,6 +7114,11 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -7216,6 +7555,16 @@ snapshots:
       micromatch: 4.0.8
       pkg-entry-points: 1.1.1
 
+  '@effect/cli@0.75.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+      ini: 4.1.3
+      toml: 3.0.0
+      yaml: 2.7.0
+
   '@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.2)
@@ -7288,6 +7637,17 @@ snapshots:
       msgpackr: 1.11.10
       multipasta: 0.2.7
 
+  '@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      effect: 3.21.2
+
+  '@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      effect: 3.21.2
+
   '@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.2)
@@ -7300,6 +7660,10 @@ snapshots:
       '@effect/platform': 0.96.1(effect@3.21.2)
       effect: 3.21.2
       uuid: 14.0.0
+
+  '@effect/typeclass@0.40.0(effect@3.21.2)':
+    dependencies:
+      effect: 3.21.2
 
   '@effect/vitest@0.29.0(effect@3.21.2)(vitest@3.2.4(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.7.3))(terser@5.46.2)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
@@ -7499,6 +7863,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@humanfs/core@0.19.1': {}
 
@@ -7729,6 +8097,28 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.4
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mrleebo/prisma-ast@0.14.0':
     dependencies:
@@ -9411,6 +9801,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -9433,12 +9828,23 @@ snapshots:
 
   agent-base@7.1.3: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -9610,6 +10016,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   bowser@2.14.1: {}
@@ -9649,6 +10069,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -9817,6 +10239,12 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
@@ -9824,6 +10252,11 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -9940,6 +10373,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
 
   dependency-cruiser@17.3.10:
     dependencies:
@@ -10084,6 +10519,8 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ee-first@1.1.1: {}
+
   effect@3.21.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -10098,6 +10535,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   empathic@2.0.1: {}
+
+  encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -10319,6 +10758,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -10550,8 +10991,8 @@ snapshots:
       '@babel/parser': 7.29.3
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -10749,9 +11190,17 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@8.0.1:
     dependencies:
@@ -10774,6 +11223,44 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-check@3.23.2:
     dependencies:
@@ -10804,6 +11291,8 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -10850,6 +11339,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-my-way-ts@0.1.6: {}
 
@@ -10898,7 +11398,11 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  forwarded@0.2.0: {}
+
   fp-ts@2.16.9: {}
+
+  fresh@2.0.0: {}
 
   fs-readdir-recursive@1.1.0: {}
 
@@ -11091,6 +11595,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.27: {}
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@9.0.2:
@@ -11123,6 +11629,14 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
@@ -11142,6 +11656,10 @@ snapshots:
   husky@9.1.7: {}
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -11180,6 +11698,8 @@ snapshots:
 
   ini@4.1.1: {}
 
+  ini@4.1.3: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -11196,6 +11716,10 @@ snapshots:
   io-ts@2.2.22(fp-ts@2.16.9):
     dependencies:
       fp-ts: 2.16.9
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@1.0.4: {}
 
@@ -11320,6 +11844,8 @@ snapshots:
   is-path-inside@4.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -11488,6 +12014,10 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -11699,6 +12229,10 @@ snapshots:
 
   mdast-util-to-string@2.0.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -11717,9 +12251,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@3.0.0: {}
 
@@ -11846,6 +12386,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
@@ -11964,6 +12506,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obuf@1.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -12092,6 +12638,8 @@ snapshots:
       leac: 0.6.0
       peberminta: 0.9.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.6.0: {}
@@ -12115,6 +12663,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0:
     optional: true
@@ -12216,6 +12766,8 @@ snapshots:
   pidtree@0.6.0: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-entry-points@1.1.1: {}
 
@@ -12360,15 +12912,33 @@ snapshots:
       '@types/node': 25.6.0
       long: 5.2.4
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
   quote-unquote@1.0.0: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -12522,6 +13092,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -12616,6 +13188,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.8.0: {}
 
   run-applescript@7.1.0: {}
@@ -12678,9 +13260,34 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@12.0.0:
     dependencies:
       type-fest: 4.41.0
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   server-only@0.0.1: {}
 
@@ -12709,6 +13316,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -13137,6 +13746,10 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
+  toml@3.0.0: {}
+
   tough-cookie@5.1.1:
     dependencies:
       tldts: 6.1.77
@@ -13209,6 +13822,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -13277,6 +13896,8 @@ snapshots:
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
+
+  unpipe@1.0.0: {}
 
   unplugin@2.3.11:
     dependencies:
@@ -13365,6 +13986,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@20.19.40)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
@@ -13690,9 +14313,13 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
-      zod: 4.3.6
+      zod: 3.25.76
+
+  zod-validation-error@4.0.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/scripts/check-test-parity.mjs
+++ b/scripts/check-test-parity.mjs
@@ -34,6 +34,17 @@ const rules = [
     ],
   },
   {
+    label: "CLI endpoint",
+    requirement: "sibling test",
+    // CLI-facing wire endpoints in `interface/cli/` (ADR-0024) — a separate
+    // inbound adapter from `interface/http/`, dispatching to the same bus.
+    subject: "packages/server/src/modules/*/interface/cli/*.endpoint.ts",
+    candidates: [
+      (f) => f.replace(/\.endpoint\.ts$/, ".endpoint.integration.test.ts"),
+      (f) => f.replace(/\.endpoint\.ts$/, ".endpoint.test.ts"),
+    ],
+  },
+  {
     label: "Event adapter",
     requirement: "sibling test",
     subject: "packages/server/src/modules/*/interface/events/*-event-adapter.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,7 +47,13 @@
       "@org/database/*": ["./packages/database/src/*.js"],
       "@org/database/test/*": ["./packages/database/test/*.js"],
       "@org/jobs": ["./packages/jobs/src/main.js"],
-      "@org/jobs/*": ["./packages/jobs/src/*.js"]
+      "@org/jobs/*": ["./packages/jobs/src/*.js"],
+      "@org/api-client": ["./packages/api-client/src/index.js"],
+      "@org/api-client/*": ["./packages/api-client/src/*.js"],
+      "@org/cli": ["./packages/cli/src/main.js"],
+      "@org/cli/*": ["./packages/cli/src/*.js"],
+      "@org/mcp": ["./packages/mcp/src/main.js"],
+      "@org/mcp/*": ["./packages/mcp/src/*.js"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     { "path": "packages/contracts" },
     { "path": "packages/server" },
     { "path": "packages/database" },
-    { "path": "packages/jobs" }
+    { "path": "packages/jobs" },
+    { "path": "packages/api-client" },
+    { "path": "packages/cli" },
+    { "path": "packages/mcp" }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a **command-line client** (`@org/cli`) and an **MCP server** (`@org/mcp`) for the app, both speaking a dedicated, GUI-decoupled `CliApi` and authenticating with **app-issued bearer tokens**. The BFF stays the source of truth — Zitadel tokens are never exposed; the server mints its own opaque tokens, validated alongside the existing session cookie.

Built in five phases, each gated and verified end-to-end against a running server.

### Server

- **Bearer credentials** — `ApiToken` aggregate + `auth.api_tokens` (V021); `UserAuthMiddleware` accepts `Authorization: Bearer` alongside the cookie, hydrating the same `CurrentUser`. GUI-managed mint/list/revoke endpoints (`/auth/tokens`). Only sha256 hashes are stored.
- **App-native device flow (RFC 8628)** — `DeviceGrant` aggregate + `auth.device_grants` (V022); public `POST /cli/device/start|token`, browser-side `POST /auth/device/approve`, and a Next.js approval page at `/device`.
- **Dedicated `CliApi`** — `cliOrganization`, `cliTodos`, `cliAuth` groups served under `/cli`, with per-module `interface/cli/` adapters that dispatch to the **same command/query bus handlers** as the GUI's `interface/http/`. `complete-todo` added as a first-class domain verb.

### Clients

- **`@org/api-client`** — typed client over `CliApi` (bearer injection) + credential store (`~/.config/org-cli/credentials.json`, mode `0600`) + `APP_API_TOKEN`/`APP_API_URL` config.
- **`@org/cli`** (`@effect/cli`) — `auth login` (device flow) / `--with-token` / `status` / `logout`; `orgs list`; `todos list|create|complete|remove`; `config set-org`.
- **`@org/mcp`** (`@modelcontextprotocol/sdk`, stdio) — tools `list_organizations`, `list_todos`, `create_todo`, `complete_todo`, `remove_todo`, reusing the same client. See `packages/mcp/README.md` for the launch config.

## Architecture

The shared seam is the **command/query bus** (use cases + domain), not the HTTP endpoints. The GUI (`DomainApi`) and CLI/MCP (`CliApi`) are separate inbound adapters over identical handlers, so they evolve independently with only thin IO-mapping duplication. Username/password + MFA from the CLI is intentionally deferred (the device flow covers humans; CI uses PATs).

## Testing

Full gate green: `pnpm check` / `lint` / `lint:deps` / `lint:tests` / `test` + web `typecheck`. Coverage includes the `ApiToken`/`DeviceGrant` aggregates, repos (live + fake), commands/queries, and real `*.endpoint.integration.test.ts` for every HTTP and CLI endpoint. Manually verified end-to-end against a running server: the bearer middleware, PAT mint→use→revoke, the device login flow (start → browser approve → poll → token), all CLI commands (incl. error/exit codes + the `APP_API_TOKEN` CI path), and all MCP tools over stdio (incl. error + no-auth paths).

## Follow-ups (deferred)

- **ADR-0024** documenting the dedicated CLI adapter + bearer/device decisions (the plan referenced it; not yet written).
- **Distribution packaging** — `@org/cli`/`@org/mcp` run via `tsx` like the rest of the monorepo; a publishable `bin` needs the `build-utils` exports pipeline (a repo-wide concern; the server's `start` has the same limitation today).
- **Server-side `auth logout` self-revoke** — currently `logout` clears local creds; tokens are revocable in the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)