### PR TITLE
refactor(server): cardinality-explicit repository vocabulary + lint enforcement

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -245,6 +245,21 @@ module.exports = {
       },
       to: { path: "^packages/server/src/platform/[^/]+-live\\.ts$" },
     },
+    {
+      name: "dumb-repository-live-no-app-collaborators",
+      severity: "error",
+      comment:
+        "ADR-0024: repository Lives are dumb persistence. They map an aggregate to/from rows and nothing more — they must not import the command/query/event-handler use cases, nor the application-tier buses and unit-of-work (CommandBus, QueryBus, DomainEventBus, IntegrationEventBus, UnitOfWork). Publishing events, dispatching commands, and owning the transaction boundary are the use case's job, not the repository's. A repository that reaches for these is smuggling business logic into persistence — move it to the aggregate or the use case. (The eslint `dumb-repository-ports` rule guards the port's method names; this guards what the Live collaborates with.)",
+      from: {
+        path: "^packages/server/src/modules/[^/]+/infrastructure/[^/]+-repository-live\\.ts$",
+      },
+      to: {
+        path: [
+          "^packages/server/src/modules/[^/]+/(commands|queries|event-handlers)/",
+          "^packages/server/src/platform/ddd/ports/(command-bus|query-bus|domain-event-bus|integration-event-bus|unit-of-work|with-unit-of-work)\\.ts$",
+        ],
+      },
+    },
     // ── Web rules (ADR-0014, ADR-0015) ─────────────────────────────────
     // View-tiering and component-library guarantees, ported from the
     // pre-Next SPA (`packages/client/src/`) to the Next App Router

--- a/docs/adr/0024-dumb-repository-ports.md
+++ b/docs/adr/0024-dumb-repository-ports.md
@@ -1,0 +1,64 @@
+# ADR-0024: Repository ports are dumb persistence with a cardinality-explicit vocabulary, enforced by lint
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context and Problem Statement
+
+A repository in this codebase is an outbound port: a `Context.Tag` whose `*RepositoryShape` lives in `domain/ports/repositories/`, with a `Live` implementation in `infrastructure/` that maps an aggregate to and from rows, and a `Fake` counterpart for unit tests. Its job is narrow — persist the current state of an aggregate and fetch it back. The aggregate carries the invariants and the domain verbs (grant, revoke, promote, activate, cancel); the use case orchestrates them and declares the transaction boundary; the repository only knows how to write the resulting state and read it again.
+
+This boundary is easy to state and easy to erode. The recurring failure mode — especially from automated contributors extending the system — is business logic creeping into persistence:
+
+- **Domain verbs on the port.** A method like `creditFunds`, `grantAccess`, or `markAsPaid` appears on the `*RepositoryShape`. It reads as behaviour, not storage. Once it exists on the port, the `Live` must implement it, and domain decisions end up expressed as SQL.
+- **Application collaborators inside the `Live`.** The repository imports a use case (`commands/`, `queries/`, `event-handlers/`), or reaches for the application-tier buses and unit-of-work (`CommandBus`, `QueryBus`, `DomainEventBus`, `IntegrationEventBus`, `UnitOfWork`). Publishing events, dispatching commands, and owning the transaction are the use case's responsibility; a repository that imports them is doing more than persistence.
+
+Prose conventions and review catch some of this, but not deterministically. There is also a second, softer problem: even among legitimately-dumb methods, naming drifted. `findByOrganizationId` returned a single `Subscription` in one module but a collection of `Membership` rows in another; `save`, `insert`, `remove`, and `delete` were mixed without a rule about operation size. A reader could not tell a method's cardinality from its name.
+
+The question is how to make "repositories stay dumb" a mechanical guarantee rather than a habit — and, while we are at it, to standardize the vocabulary so every method names its cardinality.
+
+## Decision
+
+Repository ports speak a fixed, **cardinality-explicit vocabulary**, and two lint rules enforce the boundary at the two points where it erodes. The rules are guardrails, not airtight proofs, but they make the common violations fail the `check:all` gate.
+
+### The vocabulary
+
+Every repository method is one of:
+
+- `insertOne` / `insertMany`
+- `updateOne` / `updateMany`
+- `deleteOne` / `deleteMany`
+- `upsertOne` / `upsertMany` — for aggregates whose persistence reconciles "create or replace" in one step (the former `save`)
+- `findOne` / `findMany`, each optionally followed by an `[<Qualifier>]By<Key>` lookup — `findOneById`, `findOneByEmail`, `findManyByOrganizationId`, `findOneByUserIdAndOrgId`, and with a qualifier `findOneOpenByOrganizationIdAndEmail`
+- `findAll` / `findAll<Qualifier>` — a whole-collection read that takes no lookup key (`findAll`, `findAllActive`)
+
+The `One`/`Many`/`All` size is the point: a caller reads the operation's cardinality off the method name. The same `By<Key>` lookup now disambiguates by cardinality — `findOneByOrganizationId` (the org's subscription) versus `findManyByOrganizationId` (the org's memberships) — where the old `findByOrganizationId` hid it.
+
+Two read shapes, kept distinct: a **keyed** read is `find{One,Many}[<Qualifier>]By<Key>` — it takes a lookup argument, and an optional qualifier (e.g. `Open`) may sit in front of the `By<Key>` clause for a lookup that is also filtered (`findOneOpenByOrganizationIdAndEmail` returns the _open_ invitation for that pair). A **keyless** collection read is `findAll[<Qualifier>]` — no argument, where any qualifier (`findAllActive`) is a built-in filter. Because the qualifier on a keyed find is only allowed ahead of a `By<Key>`, a bare find-and-mutate name like `findOneAndDelete` (no `By`, not a `findAll`) is still rejected.
+
+### 1. The port's method names — eslint `dumb-repository-ports`
+
+A custom flat-config rule (`scripts/eslint-rules/dumb-repository-ports.mjs`), scoped to `packages/server/src/modules/*/domain/ports/repositories/*-repository.ts`. It inspects the `*RepositoryShape` type literal and requires every method name to match the vocabulary above:
+
+```
+^(?:(?:insert|update|delete|upsert)(?:One|Many)|findAll(?:[A-Z][A-Za-z0-9]*)?|find(?:One|Many)(?:(?:[A-Z][A-Za-z0-9]*)?By[A-Z][A-Za-z0-9]*)?)$
+```
+
+Anything else fails — a name that reads as a domain verb, or one that omits the `One`/`Many` size. The message points the contributor either to move the behaviour onto the aggregate or to add the cardinality.
+
+The port is the right enforcement point because the `Live` and `Fake` must structurally satisfy it: constraining the port's surface transitively keeps both implementations dumb. A contributor cannot add `repo.creditFunds(...)` to the `Live` without first declaring it on the shape, where the rule rejects it.
+
+### 2. What the `Live` collaborates with — dependency-cruiser `dumb-repository-live-no-app-collaborators`
+
+The method-name allowlist stops domain-verb _methods_, but logic can still hide _inside_ a `save` body by collaborating with the application ring. A dependency-cruiser rule forbids `infrastructure/*-repository-live.ts` from importing:
+
+- the module's own `commands/`, `queries/`, `event-handlers/` use cases, and
+- the application-tier ports `command-bus`, `query-bus`, `domain-event-bus`, `integration-event-bus`, `unit-of-work`, `with-unit-of-work` under `platform/ddd/ports/`.
+
+A repository that reaches for these is smuggling orchestration into persistence; the fix is to move it to the aggregate or the use case.
+
+## Consequences
+
+- The two highest-frequency forms of logic creep now fail CI deterministically, with messages that name the correct home for the misplaced behaviour.
+- The rules are allowlists by name and import path. A determinedly misleading name (e.g. `findOneAndCredit`) or pure computation inside an `updateOne` body can still pass — these are guardrails against the common case, not a substitute for review. The bound is documented rather than silent.
+- The whole codebase was migrated to the vocabulary in one pass (a type-aware ts-morph rename of every `*RepositoryShape` property and its references), so the rules were introduced against a conforming tree. The only method that did not fit the bare `find{One,Many}By<Key>` shape was `findOpenByOrganizationIdAndEmail` — its `Open` status filter is meaningful and worth keeping in the name. Rather than drop the signal, the grammar allows an optional qualifier ahead of the `By<Key>` clause, and the method became `findOneOpenByOrganizationIdAndEmail`.
+- Reads that legitimately bypass the aggregate (read-side projections) live in `queries/` and address the database directly; they are unaffected, because they are not repositories.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ import sortDestructureKeys from "eslint-plugin-sort-destructure-keys";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import dumbRepositoryPorts from "./scripts/eslint-rules/dumb-repository-ports.mjs";
 import enforceReactNamespace from "./scripts/eslint-rules/enforce-react-namespace.mjs";
 import noDeepRelativeImports from "./scripts/eslint-rules/no-deep-relative-imports.mjs";
 import noEffectNamespaceImports from "./scripts/eslint-rules/no-effect-namespace-imports.mjs";
@@ -87,6 +88,12 @@ export default [
       "no-deep-relative-imports": {
         rules: {
           "no-deep-relative-imports": noDeepRelativeImports,
+        },
+      },
+
+      "dumb-repository-ports": {
+        rules: {
+          "dumb-repository-ports": dumbRepositoryPorts,
         },
       },
     },
@@ -405,6 +412,16 @@ export default [
     files: ["packages/server/**/*.{ts,tsx,js,jsx}"],
     rules: {
       "no-deep-relative-imports/no-deep-relative-imports": "error",
+    },
+  },
+  {
+    // ADR-0024: repository ports are dumb persistence. The `*RepositoryShape`
+    // type may only declare CRUD-shaped methods — domain verbs belong on the
+    // aggregate. Constraining the port transitively keeps Live/Fake dumb,
+    // since both must structurally satisfy it.
+    files: ["packages/server/src/modules/**/domain/ports/repositories/*-repository.ts"],
+    rules: {
+      "dumb-repository-ports/dumb-repository-ports": "error",
     },
   },
   {

--- a/packages/server/src/modules/auth/commands/approve-device-grant.test.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant.test.ts
@@ -30,7 +30,7 @@ describe("approveDeviceGrant", () => {
       );
       yield* approveDeviceGrant(ApproveDeviceGrantCommand.make({ userCode, userId }));
       const repo = yield* DeviceGrantRepository;
-      const grant = yield* repo.findByUserCode(userCode);
+      const grant = yield* repo.findOneByUserCode(userCode);
       deepStrictEqual(grant.status, "approved");
       deepStrictEqual(grant.userId, userId);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/auth/commands/approve-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant.ts
@@ -18,10 +18,10 @@ import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 export const approveDeviceGrant = (cmd: ApproveDeviceGrantCommand): ApproveDeviceGrantOutput =>
   Effect.gen(function* () {
     const repo = yield* DeviceGrantRepository;
-    const grant = yield* repo.findByUserCode(cmd.userCode);
+    const grant = yield* repo.findOneByUserCode(cmd.userCode);
     const now = yield* DateTime.now;
     if (DeviceGrant.isExpired(grant, now)) {
       return yield* Effect.fail(new DeviceGrantExpired());
     }
-    yield* repo.update(DeviceGrant.approve({ grant, userId: cmd.userId, now }));
+    yield* repo.updateOne(DeviceGrant.approve({ grant, userId: cmd.userId, now }));
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/mint-api-token.test.ts
+++ b/packages/server/src/modules/auth/commands/mint-api-token.test.ts
@@ -33,7 +33,7 @@ describe("mintApiToken", () => {
 
       // Round-trips: the minted token resolves by its hash.
       const repo = yield* ApiTokenRepository;
-      const found = yield* repo.findByHash(hashToken(token));
+      const found = yield* repo.findOneByHash(hashToken(token));
       deepStrictEqual(found.id, apiToken.id);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/auth/commands/mint-api-token.ts
+++ b/packages/server/src/modules/auth/commands/mint-api-token.ts
@@ -46,7 +46,7 @@ export const mintApiTokenCore = (
       now,
       expiresAt: DateTime.add(now, { days: input.expiresInDays }),
     });
-    yield* repo.insert(apiToken);
+    yield* repo.insertOne(apiToken);
     yield* Effect.annotateCurrentSpan("user.id", input.userId);
     return { apiToken, token };
   });

--- a/packages/server/src/modules/auth/commands/poll-device-grant.test.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant.test.ts
@@ -59,11 +59,11 @@ describe("pollDeviceGrant", () => {
       deepStrictEqual(apiToken.userId, userId);
       // Minted token is resolvable by its hash…
       const apiTokens = yield* ApiTokenRepository;
-      deepStrictEqual((yield* apiTokens.findByHash(hashToken(token))).id, apiToken.id);
+      deepStrictEqual((yield* apiTokens.findOneByHash(hashToken(token))).id, apiToken.id);
       // …and the grant is consumed: a second poll finds nothing.
       const grants = yield* DeviceGrantRepository;
       deepStrictEqual(
-        Exit.isFailure(yield* Effect.exit(grants.findByCodeHash(hashToken(deviceCode)))),
+        Exit.isFailure(yield* Effect.exit(grants.findOneByCodeHash(hashToken(deviceCode)))),
         true,
       );
       deepStrictEqual(

--- a/packages/server/src/modules/auth/commands/poll-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant.ts
@@ -27,12 +27,12 @@ import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 export const pollDeviceGrant = (cmd: PollDeviceGrantCommand): PollDeviceGrantOutput =>
   Effect.gen(function* () {
     const grants = yield* DeviceGrantRepository;
-    const grant = yield* grants.findByCodeHash(hashToken(cmd.deviceCode));
+    const grant = yield* grants.findOneByCodeHash(hashToken(cmd.deviceCode));
     const now = yield* DateTime.now;
 
     if (DeviceGrant.isExpired(grant, now)) {
       yield* grants
-        .delete(grant.id)
+        .deleteOne(grant.id)
         .pipe(Effect.catchTag("DeviceGrantNotFound", () => Effect.void));
       return yield* Effect.fail(new DeviceGrantExpired());
     }
@@ -45,6 +45,6 @@ export const pollDeviceGrant = (cmd: PollDeviceGrantCommand): PollDeviceGrantOut
       label: "cli",
       expiresInDays: cmd.tokenExpiresInDays,
     });
-    yield* grants.delete(grant.id);
+    yield* grants.deleteOne(grant.id);
     return minted;
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/revoke-api-token.test.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token.test.ts
@@ -28,7 +28,7 @@ describe("revokeApiToken", () => {
       const { apiToken } = yield* mint(userId);
       yield* revokeApiToken(RevokeApiTokenCommand.make({ apiTokenId: apiToken.id, userId }));
       const repo = yield* ApiTokenRepository;
-      deepStrictEqual((yield* repo.findById(apiToken.id)).revokedAt !== null, true);
+      deepStrictEqual((yield* repo.findOneById(apiToken.id)).revokedAt !== null, true);
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -44,7 +44,7 @@ describe("revokeApiToken", () => {
         deepStrictEqual(error instanceof ApiTokenNotFound, true);
       }
       const repo = yield* ApiTokenRepository;
-      deepStrictEqual((yield* repo.findById(apiToken.id)).revokedAt, null);
+      deepStrictEqual((yield* repo.findOneById(apiToken.id)).revokedAt, null);
     }).pipe(Effect.provide(TestLayer)),
   );
 

--- a/packages/server/src/modules/auth/commands/revoke-api-token.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token.ts
@@ -16,9 +16,9 @@ import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 export const revokeApiToken = (cmd: RevokeApiTokenCommand): RevokeApiTokenOutput =>
   Effect.gen(function* () {
     const repo = yield* ApiTokenRepository;
-    const token = yield* repo.findById(cmd.apiTokenId);
+    const token = yield* repo.findOneById(cmd.apiTokenId);
     if (token.userId !== cmd.userId) {
       return yield* Effect.fail(new ApiTokenNotFound());
     }
-    yield* repo.delete(cmd.apiTokenId);
+    yield* repo.deleteOne(cmd.apiTokenId);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/revoke-session.test.ts
+++ b/packages/server/src/modules/auth/commands/revoke-session.test.ts
@@ -27,7 +27,7 @@ const seedSession = () =>
       ttlSeconds: 3600,
       absoluteTtlSeconds: 43200,
     });
-    yield* repo.insert(session);
+    yield* repo.insertOne(session);
   });
 
 const provide = Effect.provide(SessionRepositoryFake);
@@ -39,7 +39,7 @@ describe("revokeSession", () => {
       yield* revokeSession(RevokeSessionCommand.make({ sessionId }));
       const repo = yield* SessionRepository;
       const found = yield* repo
-        .findById(sessionId)
+        .findOneById(sessionId)
         .pipe(Effect.catchTag("SessionNotFound", () => Effect.succeed(null)));
       ok(found !== null);
       ok(Option.isSome(Option.fromNullable(found.revokedAt)));

--- a/packages/server/src/modules/auth/commands/revoke-session.ts
+++ b/packages/server/src/modules/auth/commands/revoke-session.ts
@@ -14,7 +14,7 @@ import { SessionRepository } from "@/modules/auth/domain/ports/repositories/sess
 export const revokeSession = (cmd: RevokeSessionCommand): RevokeSessionOutput =>
   Effect.gen(function* () {
     const repo = yield* SessionRepository;
-    yield* repo.delete(cmd.sessionId).pipe(
+    yield* repo.deleteOne(cmd.sessionId).pipe(
       Effect.catchTag("SessionNotFound", () => Effect.void),
       Effect.catchTag("SessionRevoked", () => Effect.void),
       Effect.catchTag("PersistenceUnavailable", () => Effect.void),

--- a/packages/server/src/modules/auth/commands/sign-in.test.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.test.ts
@@ -46,7 +46,7 @@ describe("signIn", () => {
       const result = yield* signIn(command);
       deepStrictEqual(result.userId, userId);
       const sessions = yield* SessionRepository;
-      const stored = yield* sessions.findById(result.sessionId);
+      const stored = yield* sessions.findOneById(result.sessionId);
       deepStrictEqual(stored.userId, userId);
       deepStrictEqual(stored.subject, subject);
       deepStrictEqual(stored.revokedAt, null);
@@ -62,11 +62,11 @@ describe("signIn", () => {
       deepStrictEqual(result.userId, provisionedUserId);
       // …and the identity is now linked, so a subsequent lookup finds it.
       const identities = yield* AuthIdentityRepository;
-      const linked = yield* identities.findBySubject("new-subject");
+      const linked = yield* identities.findOneBySubject("new-subject");
       deepStrictEqual(linked.userId, provisionedUserId);
       deepStrictEqual(linked.provider, "zitadel");
       const sessions = yield* SessionRepository;
-      const stored = yield* sessions.findById(result.sessionId);
+      const stored = yield* sessions.findOneById(result.sessionId);
       deepStrictEqual(stored.userId, provisionedUserId);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/auth/commands/sign-in.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.ts
@@ -30,7 +30,7 @@ export const signIn = (cmd: SignInCommand): SignInOutput =>
     const sessions = yield* SessionRepository;
     const provisioning = yield* UserProvisioning;
 
-    const userId = yield* identities.findBySubject(cmd.subject).pipe(
+    const userId = yield* identities.findOneBySubject(cmd.subject).pipe(
       Effect.map((identity) => identity.userId),
       // First sign-in for this subject: JIT provision an ordinary user.
       // Requires an email (the `users` row needs one); a verified
@@ -54,7 +54,7 @@ export const signIn = (cmd: SignInCommand): SignInOutput =>
               ),
             ),
           );
-          yield* identities.insert({
+          yield* identities.insertOne({
             subject: cmd.subject,
             userId: newUserId,
             provider: "zitadel",
@@ -74,7 +74,7 @@ export const signIn = (cmd: SignInCommand): SignInOutput =>
       ttlSeconds: cmd.ttlSeconds,
       absoluteTtlSeconds: cmd.absoluteTtlSeconds,
     });
-    yield* sessions.insert(session);
+    yield* sessions.insertOne(session);
     yield* Effect.annotateCurrentSpan("user.id", userId);
     return { sessionId: id, userId };
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/start-device-grant.test.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant.test.ts
@@ -22,7 +22,7 @@ describe("startDeviceGrant", () => {
       ok(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(userCode));
 
       const repo = yield* DeviceGrantRepository;
-      const stored = yield* repo.findByCodeHash(hashToken(deviceCode));
+      const stored = yield* repo.findOneByCodeHash(hashToken(deviceCode));
       deepStrictEqual(stored.status, "pending");
       deepStrictEqual(stored.userId, null);
       deepStrictEqual(stored.userCode, userCode);

--- a/packages/server/src/modules/auth/commands/start-device-grant.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant.ts
@@ -37,6 +37,6 @@ export const startDeviceGrant = (cmd: StartDeviceGrantCommand): StartDeviceGrant
       now,
       ttlSeconds: cmd.ttlSeconds,
     });
-    yield* repo.insert(grant);
+    yield* repo.insertOne(grant);
     return { deviceCode, userCode, expiresAt: grant.expiresAt };
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/auth/commands/touch-api-token.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token.test.ts
@@ -26,7 +26,7 @@ const seed = (lastUsedAt: DateTime.Utc) =>
       now: lastUsedAt,
       expiresAt: DateTime.add(lastUsedAt, { days: 90 }),
     });
-    yield* repo.insert(token);
+    yield* repo.insertOne(token);
     return token;
   });
 
@@ -42,7 +42,7 @@ describe("touchApiToken", () => {
       const before = yield* seed(farPast);
       yield* touchApiToken(cmd);
       const repo = yield* ApiTokenRepository;
-      const after = yield* repo.findById(apiTokenId);
+      const after = yield* repo.findOneById(apiTokenId);
       deepStrictEqual(DateTime.greaterThan(after.lastUsedAt, before.lastUsedAt), true);
       // Fixed expiry: touch must NOT extend it.
       deepStrictEqual(after.expiresAt, before.expiresAt);
@@ -55,7 +55,7 @@ describe("touchApiToken", () => {
       const before = yield* seed(justNow);
       yield* touchApiToken(TouchApiTokenCommand.make({ apiTokenId, thresholdSeconds: 3600 }));
       const repo = yield* ApiTokenRepository;
-      const after = yield* repo.findById(apiTokenId);
+      const after = yield* repo.findOneById(apiTokenId);
       deepStrictEqual(after.lastUsedAt, before.lastUsedAt);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/auth/commands/touch-api-token.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token.ts
@@ -22,7 +22,7 @@ import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api
 export const touchApiToken = (cmd: TouchApiTokenCommand): TouchApiTokenOutput =>
   Effect.gen(function* () {
     const repo = yield* ApiTokenRepository;
-    const token = yield* repo.findById(cmd.apiTokenId).pipe(
+    const token = yield* repo.findOneById(cmd.apiTokenId).pipe(
       Effect.catchTag("ApiTokenNotFound", () => Effect.succeed(null)),
       Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)),
     );
@@ -32,7 +32,7 @@ export const touchApiToken = (cmd: TouchApiTokenCommand): TouchApiTokenOutput =>
     const elapsed = DateTime.distanceDuration(token.lastUsedAt, now);
     if (Duration.lessThan(elapsed, Duration.seconds(cmd.thresholdSeconds))) return;
 
-    yield* repo.update(ApiToken.touch({ token, now })).pipe(
+    yield* repo.updateOne(ApiToken.touch({ token, now })).pipe(
       Effect.catchTag("ApiTokenNotFound", () => Effect.void),
       Effect.catchTag("PersistenceUnavailable", () => Effect.void),
     );

--- a/packages/server/src/modules/auth/commands/touch-session.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.test.ts
@@ -27,7 +27,7 @@ const seedSession = (lastUsedAt: DateTime.Utc) =>
       ttlSeconds: 3600,
       absoluteTtlSeconds: 43200,
     });
-    yield* repo.insert(base);
+    yield* repo.insertOne(base);
     return base;
   });
 
@@ -44,7 +44,7 @@ describe("touchSession", () => {
       const seed = yield* seedSession(farPast);
       yield* touchSession(cmd);
       const repo = yield* SessionRepository;
-      const after = yield* repo.findById(sessionId);
+      const after = yield* repo.findOneById(sessionId);
       deepStrictEqual(DateTime.greaterThan(after.lastUsedAt, seed.lastUsedAt), true);
       deepStrictEqual(DateTime.greaterThan(after.expiresAt, seed.expiresAt), true);
     }).pipe(Effect.provide(SessionRepositoryFake)),
@@ -56,7 +56,7 @@ describe("touchSession", () => {
       const seed = yield* seedSession(justNow);
       yield* touchSession(cmd);
       const repo = yield* SessionRepository;
-      const after = yield* repo.findById(sessionId);
+      const after = yield* repo.findOneById(sessionId);
       deepStrictEqual(after.lastUsedAt, seed.lastUsedAt);
       deepStrictEqual(after.expiresAt, seed.expiresAt);
     }).pipe(Effect.provide(SessionRepositoryFake)),
@@ -73,9 +73,9 @@ describe("touchSession", () => {
       const farPast = DateTime.unsafeMake(new Date("2000-01-01T00:00:00Z"));
       const seed = yield* seedSession(farPast);
       const repo = yield* SessionRepository;
-      yield* repo.delete(sessionId);
+      yield* repo.deleteOne(sessionId);
       yield* touchSession(cmd);
-      const after = yield* repo.findById(sessionId);
+      const after = yield* repo.findOneById(sessionId);
       deepStrictEqual(after.expiresAt, seed.expiresAt);
       deepStrictEqual(after.lastUsedAt, seed.lastUsedAt);
     }).pipe(Effect.provide(SessionRepositoryFake)),

--- a/packages/server/src/modules/auth/commands/touch-session.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.ts
@@ -27,7 +27,7 @@ import * as Session from "@/modules/auth/domain/session.aggregate.js";
 export const touchSession = (cmd: TouchSessionCommand): TouchSessionOutput =>
   Effect.gen(function* () {
     const repo = yield* SessionRepository;
-    const session = yield* repo.findById(cmd.sessionId).pipe(
+    const session = yield* repo.findOneById(cmd.sessionId).pipe(
       Effect.catchTag("SessionNotFound", () => Effect.succeed(null)),
       Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)),
     );
@@ -38,7 +38,7 @@ export const touchSession = (cmd: TouchSessionCommand): TouchSessionOutput =>
     if (Duration.lessThan(elapsed, Duration.seconds(cmd.thresholdSeconds))) return;
 
     const touched = Session.touch({ session, now, ttlSeconds: cmd.ttlSeconds });
-    yield* repo.update(touched).pipe(
+    yield* repo.updateOne(touched).pipe(
       Effect.catchTag("SessionNotFound", () => Effect.void),
       Effect.catchTag("PersistenceUnavailable", () => Effect.void),
     );

--- a/packages/server/src/modules/auth/domain/api-token-errors.ts
+++ b/packages/server/src/modules/auth/domain/api-token-errors.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 
-// Fieldless: raised both by `findById` (revoke path — the caller already
-// holds the id from the request) and by `findByHash` (per-request lookup,
+// Fieldless: raised both by `findOneById` (revoke path — the caller already
+// holds the id from the request) and by `findOneByHash` (per-request lookup,
 // where a miss has no id to report). Keeping it fieldless lets one error
 // serve both without an awkward optional id.
 export class ApiTokenNotFound extends Schema.TaggedError<ApiTokenNotFound>("ApiTokenNotFound")(

--- a/packages/server/src/modules/auth/domain/ports/repositories/api-token-repository.ts
+++ b/packages/server/src/modules/auth/domain/ports/repositories/api-token-repository.ts
@@ -12,27 +12,27 @@ import { type UserId } from "@/platform/ids/user-id.js";
 // aggregate; the soft-delete storage mechanism behind `delete` is an
 // implementation detail.
 export type ApiTokenRepositoryShape = {
-  readonly insert: (token: ApiToken) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findById: (
+  readonly insertOne: (token: ApiToken) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findOneById: (
     id: ApiTokenId,
   ) => Effect.Effect<ApiToken, ApiTokenNotFound | PersistenceUnavailable>;
   // Per-request lookup of the presented bearer (already hashed by the
   // caller — the raw secret never reaches the repository).
-  readonly findByHash: (
+  readonly findOneByHash: (
     tokenHash: string,
   ) => Effect.Effect<ApiToken, ApiTokenNotFound | PersistenceUnavailable>;
   // Active (non-revoked) tokens for the owner's management listing.
-  readonly listByUser: (
+  readonly findManyByUser: (
     userId: UserId,
   ) => Effect.Effect<ReadonlyArray<ApiToken>, PersistenceUnavailable>;
   // Soft-delete via `revoked_at` (SQL `WHERE revoked_at IS NULL`). A
   // re-revoke matches zero rows and surfaces as `ApiTokenNotFound`, same as
   // a genuine miss — both mean "no active token to revoke" to the caller.
   // (`ApiTokenRevoked` is produced by the find-by-hash query, not here.)
-  readonly delete: (
+  readonly deleteOne: (
     id: ApiTokenId,
   ) => Effect.Effect<void, ApiTokenNotFound | PersistenceUnavailable>;
-  readonly update: (
+  readonly updateOne: (
     token: ApiToken,
   ) => Effect.Effect<void, ApiTokenNotFound | PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/auth/domain/ports/repositories/auth-identity-repository.ts
+++ b/packages/server/src/modules/auth/domain/ports/repositories/auth-identity-repository.ts
@@ -12,12 +12,12 @@ export type AuthIdentity = {
 };
 
 export type AuthIdentityRepositoryShape = {
-  readonly findBySubject: (
+  readonly findOneBySubject: (
     subject: string,
   ) => Effect.Effect<AuthIdentity, AuthIdentityNotFound | PersistenceUnavailable>;
   // Links a verified external subject to an app user. Used by JIT
   // provisioning on first OIDC sign-in. Joins the caller's transaction.
-  readonly insert: (identity: AuthIdentity) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly insertOne: (identity: AuthIdentity) => Effect.Effect<void, PersistenceUnavailable>;
 };
 
 export class AuthIdentityRepository extends Context.Tag("AuthIdentityRepository")<

--- a/packages/server/src/modules/auth/domain/ports/repositories/device-grant-repository.ts
+++ b/packages/server/src/modules/auth/domain/ports/repositories/device-grant-repository.ts
@@ -10,18 +10,18 @@ import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistenc
 // codes the flow keys on: device_code_hash (CLI poll) and user_code (browser
 // approve).
 export type DeviceGrantRepositoryShape = {
-  readonly insert: (grant: DeviceGrant) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findByCodeHash: (
+  readonly insertOne: (grant: DeviceGrant) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findOneByCodeHash: (
     deviceCodeHash: string,
   ) => Effect.Effect<DeviceGrant, DeviceGrantNotFound | PersistenceUnavailable>;
-  readonly findByUserCode: (
+  readonly findOneByUserCode: (
     userCode: string,
   ) => Effect.Effect<DeviceGrant, DeviceGrantNotFound | PersistenceUnavailable>;
-  readonly update: (
+  readonly updateOne: (
     grant: DeviceGrant,
   ) => Effect.Effect<void, DeviceGrantNotFound | PersistenceUnavailable>;
   // Consumes a grant (single-use) once its token has been issued.
-  readonly delete: (
+  readonly deleteOne: (
     id: DeviceGrantId,
   ) => Effect.Effect<void, DeviceGrantNotFound | PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/auth/domain/ports/repositories/session-repository.ts
+++ b/packages/server/src/modules/auth/domain/ports/repositories/session-repository.ts
@@ -7,8 +7,8 @@ import { type SessionId } from "@/modules/auth/domain/session-id.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 
 export type SessionRepositoryShape = {
-  readonly insert: (session: Session) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findById: (
+  readonly insertOne: (session: Session) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findOneById: (
     id: SessionId,
   ) => Effect.Effect<Session, SessionNotFound | PersistenceUnavailable>;
   // Soft-deletes the session by stamping `revoked_at`. Named after the
@@ -19,10 +19,10 @@ export type SessionRepositoryShape = {
   // an implementation detail. `SessionRevoked` is reserved for the
   // already-soft-deleted case so the caller can preserve the original
   // `revoked_at` timestamp.
-  readonly delete: (
+  readonly deleteOne: (
     id: SessionId,
   ) => Effect.Effect<void, SessionNotFound | SessionRevoked | PersistenceUnavailable>;
-  readonly update: (
+  readonly updateOne: (
     session: Session,
   ) => Effect.Effect<void, SessionNotFound | PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.test.ts
@@ -33,20 +33,20 @@ const make = (id: ApiTokenId, opts: { userId?: UserId; hash?: string; createdAt?
 const provide = Effect.provide(ApiTokenRepositoryFake);
 
 describe("ApiTokenRepositoryFake", () => {
-  it.effect("insert + findById + findByHash round-trip", () =>
+  it.effect("insert + findOneById + findOneByHash round-trip", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      yield* repo.insert(make(idA, { hash: "hash-A" }));
-      deepStrictEqual((yield* repo.findById(idA)).id, idA);
-      deepStrictEqual((yield* repo.findByHash("hash-A")).id, idA);
+      yield* repo.insertOne(make(idA, { hash: "hash-A" }));
+      deepStrictEqual((yield* repo.findOneById(idA)).id, idA);
+      deepStrictEqual((yield* repo.findOneByHash("hash-A")).id, idA);
     }).pipe(provide),
   );
 
-  it.effect("findById / findByHash fail ApiTokenNotFound when absent", () =>
+  it.effect("findOneById / findOneByHash fail ApiTokenNotFound when absent", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      const byId = yield* Effect.exit(repo.findById(idMissing));
-      const byHash = yield* Effect.exit(repo.findByHash("nope"));
+      const byId = yield* Effect.exit(repo.findOneById(idMissing));
+      const byHash = yield* Effect.exit(repo.findOneByHash("nope"));
       deepStrictEqual(Exit.isFailure(byId), true);
       deepStrictEqual(Exit.isFailure(byHash), true);
       if (Exit.isFailure(byId)) {
@@ -56,13 +56,13 @@ describe("ApiTokenRepositoryFake", () => {
     }).pipe(provide),
   );
 
-  it.effect("listByUser returns only the caller's active tokens, newest first", () =>
+  it.effect("findManyByUser returns only the caller's active tokens, newest first", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      yield* repo.insert(make(idA, { hash: "a", createdAt: now }));
-      yield* repo.insert(make(idB, { hash: "b", createdAt: DateTime.add(now, { hours: 1 }) }));
-      yield* repo.insert(make(idMissing, { userId: otherUserId, hash: "c" }));
-      const mine = yield* repo.listByUser(userId);
+      yield* repo.insertOne(make(idA, { hash: "a", createdAt: now }));
+      yield* repo.insertOne(make(idB, { hash: "b", createdAt: DateTime.add(now, { hours: 1 }) }));
+      yield* repo.insertOne(make(idMissing, { userId: otherUserId, hash: "c" }));
+      const mine = yield* repo.findManyByUser(userId);
       deepStrictEqual(
         mine.map((t) => t.id),
         [idB, idA],
@@ -70,14 +70,14 @@ describe("ApiTokenRepositoryFake", () => {
     }).pipe(provide),
   );
 
-  it.effect("delete soft-revokes; a second delete fails NotFound; listByUser hides it", () =>
+  it.effect("delete soft-revokes; a second delete fails NotFound; findManyByUser hides it", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      yield* repo.insert(make(idA, { hash: "a" }));
-      yield* repo.delete(idA);
-      deepStrictEqual((yield* repo.findById(idA)).revokedAt !== null, true);
-      deepStrictEqual((yield* repo.listByUser(userId)).length, 0);
-      const second = yield* Effect.exit(repo.delete(idA));
+      yield* repo.insertOne(make(idA, { hash: "a" }));
+      yield* repo.deleteOne(idA);
+      deepStrictEqual((yield* repo.findOneById(idA)).revokedAt !== null, true);
+      deepStrictEqual((yield* repo.findManyByUser(userId)).length, 0);
+      const second = yield* Effect.exit(repo.deleteOne(idA));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(provide),
   );
@@ -86,13 +86,13 @@ describe("ApiTokenRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
       const seed = make(idA, { hash: "a" });
-      yield* repo.insert(seed);
+      yield* repo.insertOne(seed);
       const later = DateTime.add(now, { hours: 2 });
-      yield* repo.update(ApiToken.touch({ token: seed, now: later }));
-      deepStrictEqual((yield* repo.findById(idA)).lastUsedAt, later);
+      yield* repo.updateOne(ApiToken.touch({ token: seed, now: later }));
+      deepStrictEqual((yield* repo.findOneById(idA)).lastUsedAt, later);
 
-      yield* repo.delete(idA);
-      const exit = yield* Effect.exit(repo.update(ApiToken.touch({ token: seed, now: later })));
+      yield* repo.deleteOne(idA);
+      const exit = yield* Effect.exit(repo.updateOne(ApiToken.touch({ token: seed, now: later })));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-fake.ts
@@ -18,10 +18,10 @@ export const ApiTokenRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<ApiTokenId, ApiToken>());
 
-    const insert = (token: ApiToken): Effect.Effect<void> =>
+    const insertOne = (token: ApiToken): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(token.id, token));
 
-    const findById = (id: ApiTokenId): Effect.Effect<ApiToken, ApiTokenNotFound> =>
+    const findOneById = (id: ApiTokenId): Effect.Effect<ApiToken, ApiTokenNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         Option.match(HashMap.get(m, id), {
           onNone: () => Effect.fail(new ApiTokenNotFound()),
@@ -29,14 +29,14 @@ export const ApiTokenRepositoryFake = Layer.effect(
         }),
       );
 
-    const findByHash = (tokenHash: string): Effect.Effect<ApiToken, ApiTokenNotFound> =>
+    const findOneByHash = (tokenHash: string): Effect.Effect<ApiToken, ApiTokenNotFound> =>
       Effect.flatMap(Ref.get(store), (m) => {
         const match = Array.from(HashMap.values(m)).find((t) => t.tokenHash === tokenHash);
         return match === undefined ? Effect.fail(new ApiTokenNotFound()) : Effect.succeed(match);
       });
 
     // Active (non-revoked) tokens, newest first — mirrors the live SQL.
-    const listByUser = (userId: UserId): Effect.Effect<ReadonlyArray<ApiToken>> =>
+    const findManyByUser = (userId: UserId): Effect.Effect<ReadonlyArray<ApiToken>> =>
       Effect.map(Ref.get(store), (m) =>
         Array.from(HashMap.values(m))
           .filter((t) => t.userId === userId && t.revokedAt === null)
@@ -61,7 +61,7 @@ export const ApiTokenRepositoryFake = Layer.effect(
       });
 
     // Mirrors the live impl: only updates rows where revoked_at IS NULL.
-    const update = (token: ApiToken): Effect.Effect<void, ApiTokenNotFound> =>
+    const updateOne = (token: ApiToken): Effect.Effect<void, ApiTokenNotFound> =>
       Effect.gen(function* () {
         const m = yield* Ref.get(store);
         const existing = HashMap.get(m, token.id);
@@ -75,12 +75,12 @@ export const ApiTokenRepositoryFake = Layer.effect(
       });
 
     return ApiTokenRepository.of({
-      insert,
-      findById,
-      findByHash,
-      listByUser,
-      delete: deleteToken,
-      update,
+      insertOne,
+      findOneById,
+      findOneByHash,
+      findManyByUser,
+      deleteOne: deleteToken,
+      updateOne,
     });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-live.integration.test.ts
@@ -51,25 +51,25 @@ suite("ApiTokenRepositoryLive (integration)", () => {
     );
   });
 
-  it.effect("insert + findById + findByHash round-trip a token through the DB", () =>
+  it.effect("insert + findOneById + findOneByHash round-trip a token through the DB", () =>
     Effect.gen(function* () {
       yield* insertUserRow;
       const repo = yield* ApiTokenRepository;
       const now = yield* DateTime.now;
-      yield* repo.insert(make(idA, "hash-A", now));
-      const byId = yield* repo.findById(idA);
+      yield* repo.insertOne(make(idA, "hash-A", now));
+      const byId = yield* repo.findOneById(idA);
       deepStrictEqual(byId.id, idA);
       deepStrictEqual(byId.userId, userId);
       deepStrictEqual(byId.tokenHash, "hash-A");
       deepStrictEqual(byId.revokedAt, null);
-      deepStrictEqual((yield* repo.findByHash("hash-A")).id, idA);
+      deepStrictEqual((yield* repo.findOneByHash("hash-A")).id, idA);
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findByHash fails ApiTokenNotFound for an unknown hash", () =>
+  it.effect("findOneByHash fails ApiTokenNotFound for an unknown hash", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      const exit = yield* Effect.exit(repo.findByHash("missing"));
+      const exit = yield* Effect.exit(repo.findOneByHash("missing"));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -78,15 +78,15 @@ suite("ApiTokenRepositoryLive (integration)", () => {
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("listByUser returns active tokens newest-first and hides revoked", () =>
+  it.effect("findManyByUser returns active tokens newest-first and hides revoked", () =>
     Effect.gen(function* () {
       yield* insertUserRow;
       const repo = yield* ApiTokenRepository;
       const now = yield* DateTime.now;
-      yield* repo.insert(make(idA, "a", now, now));
-      yield* repo.insert(make(idB, "b", now, DateTime.add(now, { hours: 1 })));
-      yield* repo.delete(idA);
-      const mine = yield* repo.listByUser(userId);
+      yield* repo.insertOne(make(idA, "a", now, now));
+      yield* repo.insertOne(make(idB, "b", now, DateTime.add(now, { hours: 1 })));
+      yield* repo.deleteOne(idA);
+      const mine = yield* repo.findManyByUser(userId);
       deepStrictEqual(
         mine.map((t) => t.id),
         [idB],
@@ -99,10 +99,10 @@ suite("ApiTokenRepositoryLive (integration)", () => {
       yield* insertUserRow;
       const repo = yield* ApiTokenRepository;
       const now = yield* DateTime.now;
-      yield* repo.insert(make(idA, "a", now));
-      yield* repo.delete(idA);
-      deepStrictEqual((yield* repo.findById(idA)).revokedAt !== null, true);
-      const second = yield* Effect.exit(repo.delete(idA));
+      yield* repo.insertOne(make(idA, "a", now));
+      yield* repo.deleteOne(idA);
+      deepStrictEqual((yield* repo.findOneById(idA)).revokedAt !== null, true);
+      const second = yield* Effect.exit(repo.deleteOne(idA));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(Effect.provide(TestLayer)),
   );
@@ -113,10 +113,10 @@ suite("ApiTokenRepositoryLive (integration)", () => {
       const repo = yield* ApiTokenRepository;
       const now = yield* DateTime.now;
       const seed = make(idA, "a", now);
-      yield* repo.insert(seed);
+      yield* repo.insertOne(seed);
       const later = DateTime.add(now, { hours: 2 });
-      yield* repo.update(ApiToken.touch({ token: seed, now: later }));
-      const found = yield* repo.findById(idA);
+      yield* repo.updateOne(ApiToken.touch({ token: seed, now: later }));
+      const found = yield* repo.findOneById(idA);
       deepStrictEqual(found.lastUsedAt, later);
       deepStrictEqual(found.expiresAt, seed.expiresAt);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/auth/infrastructure/api-token-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/api-token-repository-live.ts
@@ -16,7 +16,7 @@ export const ApiTokenRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, token: ApiToken) => {
+    const insertOne = db.makeQuery((execute, token: ApiToken) => {
       const row = ApiTokenMapper.toPersistence(token);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -38,11 +38,11 @@ export const ApiTokenRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.insert"),
+        Effect.withSpan("ApiTokenRepository.insertOne"),
       );
     });
 
-    const findById = db.makeQuery((execute, id: ApiTokenId) =>
+    const findOneById = db.makeQuery((execute, id: ApiTokenId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
           SELECT * FROM auth.api_tokens WHERE id = ${id}
@@ -52,11 +52,11 @@ export const ApiTokenRepositoryLive = Layer.effect(
         Effect.map(ApiTokenMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.findById"),
+        Effect.withSpan("ApiTokenRepository.findOneById"),
       ),
     );
 
-    const findByHash = db.makeQuery((execute, tokenHash: string) =>
+    const findOneByHash = db.makeQuery((execute, tokenHash: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
           SELECT * FROM auth.api_tokens WHERE token_hash = ${tokenHash}
@@ -66,11 +66,11 @@ export const ApiTokenRepositoryLive = Layer.effect(
         Effect.map(ApiTokenMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.findByHash"),
+        Effect.withSpan("ApiTokenRepository.findOneByHash"),
       ),
     );
 
-    const listByUser = db.makeQuery((execute, userId: UserId) =>
+    const findManyByUser = db.makeQuery((execute, userId: UserId) =>
       execute((client) =>
         client.any(sql.type(RowSchemas.ApiTokenRowStd)`
           SELECT * FROM auth.api_tokens
@@ -81,7 +81,7 @@ export const ApiTokenRepositoryLive = Layer.effect(
         Effect.map((rows) => rows.map(ApiTokenMapper.toDomain)),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.listByUser"),
+        Effect.withSpan("ApiTokenRepository.findManyByUser"),
       ),
     );
 
@@ -97,11 +97,11 @@ export const ApiTokenRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.delete"),
+        Effect.withSpan("ApiTokenRepository.deleteOne"),
       ),
     );
 
-    const update = db.makeQuery((execute, token: ApiToken) => {
+    const updateOne = db.makeQuery((execute, token: ApiToken) => {
       const row = ApiTokenMapper.toPersistence(token);
       return execute((client) =>
         client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
@@ -115,17 +115,17 @@ export const ApiTokenRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.update"),
+        Effect.withSpan("ApiTokenRepository.updateOne"),
       );
     });
 
     return ApiTokenRepository.of({
-      insert,
-      findById,
-      findByHash,
-      listByUser,
-      delete: deleteById,
-      update,
+      insertOne,
+      findOneById,
+      findOneByHash,
+      findManyByUser,
+      deleteOne: deleteById,
+      updateOne,
     });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.test.ts
@@ -16,7 +16,7 @@ describe("AuthIdentityRepositoryFake", () => {
   it.effect("returns the seeded identity for a known subject", () =>
     Effect.gen(function* () {
       const repo = yield* AuthIdentityRepository;
-      const found = yield* repo.findBySubject(subject);
+      const found = yield* repo.findOneBySubject(subject);
       deepStrictEqual(found.subject, subject);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.provider, "zitadel");
@@ -28,7 +28,7 @@ describe("AuthIdentityRepositoryFake", () => {
   it.effect("fails AuthIdentityNotFound for an unknown subject", () =>
     Effect.gen(function* () {
       const repo = yield* AuthIdentityRepository;
-      const exit = yield* Effect.exit(repo.findBySubject("missing-sub"));
+      const exit = yield* Effect.exit(repo.findOneBySubject("missing-sub"));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-fake.ts
@@ -22,7 +22,9 @@ export const makeAuthIdentityRepositoryFake = (
       const initial = HashMap.fromIterable(seed.map((i) => [i.subject, i] as const));
       const store = yield* Ref.make(initial);
 
-      const findBySubject = (subject: string): Effect.Effect<AuthIdentity, AuthIdentityNotFound> =>
+      const findOneBySubject = (
+        subject: string,
+      ): Effect.Effect<AuthIdentity, AuthIdentityNotFound> =>
         Effect.flatMap(Ref.get(store), (m) =>
           Option.match(HashMap.get(m, subject), {
             onNone: () => Effect.fail(new AuthIdentityNotFound({ subject })),
@@ -30,10 +32,10 @@ export const makeAuthIdentityRepositoryFake = (
           }),
         );
 
-      const insert = (identity: AuthIdentity): Effect.Effect<void> =>
+      const insertOne = (identity: AuthIdentity): Effect.Effect<void> =>
         Ref.update(store, (m) => HashMap.set(m, identity.subject, identity));
 
-      return AuthIdentityRepository.of({ findBySubject, insert });
+      return AuthIdentityRepository.of({ findOneBySubject, insertOne });
     }),
   );
 

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.integration.test.ts
@@ -40,18 +40,18 @@ suite("AuthIdentityRepositoryLive (integration)", () => {
     await Effect.runPromise(truncate("user.users").pipe(Effect.provide(TestDatabaseLive)));
   });
 
-  it.effect("findBySubject returns the seeded identity", () =>
+  it.effect("findOneBySubject returns the seeded identity", () =>
     Effect.gen(function* () {
       yield* seedUserAndIdentity;
       const repo = yield* AuthIdentityRepository;
-      const found = yield* repo.findBySubject(subject);
+      const found = yield* repo.findOneBySubject(subject);
       deepStrictEqual(found.subject, subject);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.provider, "zitadel");
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("insert links a subject to a user, retrievable via findBySubject", () =>
+  it.effect("insert links a subject to a user, retrievable via findOneBySubject", () =>
     Effect.gen(function* () {
       // Seed only the user row (the FK target); the identity is created via
       // the repository's write path, mirroring JIT provisioning.
@@ -66,19 +66,19 @@ suite("AuthIdentityRepositoryLive (integration)", () => {
         .pipe(Effect.orDie);
 
       const repo = yield* AuthIdentityRepository;
-      yield* repo.insert({ subject: "jit-sub", userId, provider: "zitadel" });
+      yield* repo.insertOne({ subject: "jit-sub", userId, provider: "zitadel" });
 
-      const found = yield* repo.findBySubject("jit-sub");
+      const found = yield* repo.findOneBySubject("jit-sub");
       deepStrictEqual(found.subject, "jit-sub");
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.provider, "zitadel");
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findBySubject fails AuthIdentityNotFound for an unknown subject", () =>
+  it.effect("findOneBySubject fails AuthIdentityNotFound for an unknown subject", () =>
     Effect.gen(function* () {
       const repo = yield* AuthIdentityRepository;
-      const exit = yield* Effect.exit(repo.findBySubject("missing-sub"));
+      const exit = yield* Effect.exit(repo.findOneBySubject("missing-sub"));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/auth-identity-repository-live.ts
@@ -16,7 +16,7 @@ export const AuthIdentityRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const findBySubject = db.makeQuery((execute, subject: string) =>
+    const findOneBySubject = db.makeQuery((execute, subject: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.AuthIdentityRowStd)`
           SELECT * FROM auth.auth_identities WHERE subject = ${subject}
@@ -26,11 +26,11 @@ export const AuthIdentityRepositoryLive = Layer.effect(
         Effect.map(AuthIdentityMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("AuthIdentityRepository.findBySubject"),
+        Effect.withSpan("AuthIdentityRepository.findOneBySubject"),
       ),
     );
 
-    const insert = db.makeQuery((execute, identity: AuthIdentity) =>
+    const insertOne = db.makeQuery((execute, identity: AuthIdentity) =>
       execute((client) =>
         client.query(sql.unsafe`
           INSERT INTO auth.auth_identities (subject, user_id, provider, created_at)
@@ -40,10 +40,10 @@ export const AuthIdentityRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("AuthIdentityRepository.insert"),
+        Effect.withSpan("AuthIdentityRepository.insertOne"),
       ),
     );
 
-    return AuthIdentityRepository.of({ findBySubject, insert });
+    return AuthIdentityRepository.of({ findOneBySubject, insertOne });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.test.ts
@@ -26,7 +26,7 @@ const seed = () =>
       now,
       ttlSeconds: 600,
     });
-    yield* repo.insert(grant);
+    yield* repo.insertOne(grant);
     return grant;
   });
 
@@ -37,15 +37,15 @@ describe("DeviceGrantRepositoryFake", () => {
     Effect.gen(function* () {
       yield* seed();
       const repo = yield* DeviceGrantRepository;
-      deepStrictEqual((yield* repo.findByCodeHash("dc-hash")).id, id);
-      deepStrictEqual((yield* repo.findByUserCode("ABCD-2345")).id, id);
+      deepStrictEqual((yield* repo.findOneByCodeHash("dc-hash")).id, id);
+      deepStrictEqual((yield* repo.findOneByUserCode("ABCD-2345")).id, id);
     }).pipe(provide),
   );
 
   it.effect("lookups fail DeviceGrantNotFound when absent", () =>
     Effect.gen(function* () {
       const repo = yield* DeviceGrantRepository;
-      const exit = yield* Effect.exit(repo.findByUserCode("ZZZZ-9999"));
+      const exit = yield* Effect.exit(repo.findOneByUserCode("ZZZZ-9999"));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -58,8 +58,8 @@ describe("DeviceGrantRepositoryFake", () => {
     Effect.gen(function* () {
       const grant = yield* seed();
       const repo = yield* DeviceGrantRepository;
-      yield* repo.update(DeviceGrant.approve({ grant, userId, now }));
-      const after = yield* repo.findByCodeHash("dc-hash");
+      yield* repo.updateOne(DeviceGrant.approve({ grant, userId, now }));
+      const after = yield* repo.findOneByCodeHash("dc-hash");
       deepStrictEqual(after.status, "approved");
       deepStrictEqual(after.userId, userId);
     }).pipe(provide),
@@ -69,10 +69,10 @@ describe("DeviceGrantRepositoryFake", () => {
     Effect.gen(function* () {
       yield* seed();
       const repo = yield* DeviceGrantRepository;
-      yield* repo.delete(id);
-      const lookup = yield* Effect.exit(repo.findByCodeHash("dc-hash"));
+      yield* repo.deleteOne(id);
+      const lookup = yield* Effect.exit(repo.findOneByCodeHash("dc-hash"));
       deepStrictEqual(Exit.isFailure(lookup), true);
-      const second = yield* Effect.exit(repo.delete(id));
+      const second = yield* Effect.exit(repo.deleteOne(id));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-fake.ts
@@ -14,7 +14,7 @@ export const DeviceGrantRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<DeviceGrantId, DeviceGrant>());
 
-    const insert = (grant: DeviceGrant): Effect.Effect<void> =>
+    const insertOne = (grant: DeviceGrant): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(grant.id, grant));
 
     const findBy = (
@@ -25,12 +25,12 @@ export const DeviceGrantRepositoryFake = Layer.effect(
         return match === undefined ? Effect.fail(new DeviceGrantNotFound()) : Effect.succeed(match);
       });
 
-    const findByCodeHash = (deviceCodeHash: string) =>
+    const findOneByCodeHash = (deviceCodeHash: string) =>
       findBy((g) => g.deviceCodeHash === deviceCodeHash);
 
-    const findByUserCode = (userCode: string) => findBy((g) => g.userCode === userCode);
+    const findOneByUserCode = (userCode: string) => findBy((g) => g.userCode === userCode);
 
-    const update = (grant: DeviceGrant): Effect.Effect<void, DeviceGrantNotFound> =>
+    const updateOne = (grant: DeviceGrant): Effect.Effect<void, DeviceGrantNotFound> =>
       Effect.gen(function* () {
         const m = yield* Ref.get(store);
         if (Option.isNone(HashMap.get(m, grant.id))) {
@@ -49,11 +49,11 @@ export const DeviceGrantRepositoryFake = Layer.effect(
       });
 
     return DeviceGrantRepository.of({
-      insert,
-      findByCodeHash,
-      findByUserCode,
-      update,
-      delete: deleteGrant,
+      insertOne,
+      findOneByCodeHash,
+      findOneByUserCode,
+      updateOne,
+      deleteOne: deleteGrant,
     });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.integration.test.ts
@@ -42,13 +42,13 @@ suite("DeviceGrantRepositoryLive (integration)", () => {
     );
   });
 
-  it.effect("insert + findByCodeHash + findByUserCode round-trip", () =>
+  it.effect("insert + findOneByCodeHash + findOneByUserCode round-trip", () =>
     Effect.gen(function* () {
       const repo = yield* DeviceGrantRepository;
       const now = yield* DateTime.now;
-      yield* repo.insert(start(now));
-      deepStrictEqual((yield* repo.findByCodeHash("dc-hash")).id, id);
-      const byUser = yield* repo.findByUserCode("ABCD-2345");
+      yield* repo.insertOne(start(now));
+      deepStrictEqual((yield* repo.findOneByCodeHash("dc-hash")).id, id);
+      const byUser = yield* repo.findOneByUserCode("ABCD-2345");
       deepStrictEqual(byUser.status, "pending");
       deepStrictEqual(byUser.userId, null);
     }).pipe(Effect.provide(TestLayer)),
@@ -60,9 +60,9 @@ suite("DeviceGrantRepositoryLive (integration)", () => {
       const repo = yield* DeviceGrantRepository;
       const now = yield* DateTime.now;
       const grant = start(now);
-      yield* repo.insert(grant);
-      yield* repo.update(DeviceGrant.approve({ grant, userId, now }));
-      const after = yield* repo.findByCodeHash("dc-hash");
+      yield* repo.insertOne(grant);
+      yield* repo.updateOne(DeviceGrant.approve({ grant, userId, now }));
+      const after = yield* repo.findOneByCodeHash("dc-hash");
       deepStrictEqual(after.status, "approved");
       deepStrictEqual(after.userId, userId);
       deepStrictEqual(after.approvedAt !== null, true);
@@ -73,15 +73,15 @@ suite("DeviceGrantRepositoryLive (integration)", () => {
     Effect.gen(function* () {
       const repo = yield* DeviceGrantRepository;
       const now = yield* DateTime.now;
-      yield* repo.insert(start(now));
-      yield* repo.delete(id);
-      const lookup = yield* Effect.exit(repo.findByCodeHash("dc-hash"));
+      yield* repo.insertOne(start(now));
+      yield* repo.deleteOne(id);
+      const lookup = yield* Effect.exit(repo.findOneByCodeHash("dc-hash"));
       deepStrictEqual(Exit.isFailure(lookup), true);
       if (Exit.isFailure(lookup)) {
         const error = lookup.cause._tag === "Fail" ? lookup.cause.error : null;
         deepStrictEqual(error instanceof DeviceGrantNotFound, true);
       }
-      const second = yield* Effect.exit(repo.delete(id));
+      const second = yield* Effect.exit(repo.deleteOne(id));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/device-grant-repository-live.ts
@@ -15,7 +15,7 @@ export const DeviceGrantRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, grant: DeviceGrant) => {
+    const insertOne = db.makeQuery((execute, grant: DeviceGrant) => {
       const row = DeviceGrantMapper.toPersistence(grant);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -36,11 +36,11 @@ export const DeviceGrantRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.insert"),
+        Effect.withSpan("DeviceGrantRepository.insertOne"),
       );
     });
 
-    const findByCodeHash = db.makeQuery((execute, deviceCodeHash: string) =>
+    const findOneByCodeHash = db.makeQuery((execute, deviceCodeHash: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
           SELECT * FROM auth.device_grants WHERE device_code_hash = ${deviceCodeHash}
@@ -50,11 +50,11 @@ export const DeviceGrantRepositoryLive = Layer.effect(
         Effect.map(DeviceGrantMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.findByCodeHash"),
+        Effect.withSpan("DeviceGrantRepository.findOneByCodeHash"),
       ),
     );
 
-    const findByUserCode = db.makeQuery((execute, userCode: string) =>
+    const findOneByUserCode = db.makeQuery((execute, userCode: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
           SELECT * FROM auth.device_grants WHERE user_code = ${userCode}
@@ -64,11 +64,11 @@ export const DeviceGrantRepositoryLive = Layer.effect(
         Effect.map(DeviceGrantMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.findByUserCode"),
+        Effect.withSpan("DeviceGrantRepository.findOneByUserCode"),
       ),
     );
 
-    const update = db.makeQuery((execute, grant: DeviceGrant) => {
+    const updateOne = db.makeQuery((execute, grant: DeviceGrant) => {
       const row = DeviceGrantMapper.toPersistence(grant);
       return execute((client) =>
         client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
@@ -84,7 +84,7 @@ export const DeviceGrantRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.update"),
+        Effect.withSpan("DeviceGrantRepository.updateOne"),
       );
     });
 
@@ -98,16 +98,16 @@ export const DeviceGrantRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.delete"),
+        Effect.withSpan("DeviceGrantRepository.deleteOne"),
       ),
     );
 
     return DeviceGrantRepository.of({
-      insert,
-      findByCodeHash,
-      findByUserCode,
-      update,
-      delete: deleteById,
+      insertOne,
+      findOneByCodeHash,
+      findOneByUserCode,
+      updateOne,
+      deleteOne: deleteById,
     });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.test.ts
@@ -30,20 +30,20 @@ const makeSession = (id: SessionId) =>
 const provide = Effect.provide(SessionRepositoryFake);
 
 describe("SessionRepositoryFake", () => {
-  it.effect("insert + findById round-trip", () =>
+  it.effect("insert + findOneById round-trip", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      yield* repo.insert(makeSession(idA));
-      const found = yield* repo.findById(idA);
+      yield* repo.insertOne(makeSession(idA));
+      const found = yield* repo.findOneById(idA);
       deepStrictEqual(found.id, idA);
       deepStrictEqual(found.revokedAt, null);
     }).pipe(provide),
   );
 
-  it.effect("findById fails SessionNotFound for an unknown id", () =>
+  it.effect("findOneById fails SessionNotFound for an unknown id", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      const exit = yield* Effect.exit(repo.findById(idMissing));
+      const exit = yield* Effect.exit(repo.findOneById(idMissing));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -55,9 +55,9 @@ describe("SessionRepositoryFake", () => {
   it.effect("delete marks the session as revoked (soft-delete)", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      yield* repo.insert(makeSession(idA));
-      yield* repo.delete(idA);
-      const found = yield* repo.findById(idA);
+      yield* repo.insertOne(makeSession(idA));
+      yield* repo.deleteOne(idA);
+      const found = yield* repo.findOneById(idA);
       deepStrictEqual(found.revokedAt !== null, true);
     }).pipe(provide),
   );
@@ -65,7 +65,7 @@ describe("SessionRepositoryFake", () => {
   it.effect("delete fails SessionNotFound on a missing id", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      const exit = yield* Effect.exit(repo.delete(idMissing));
+      const exit = yield* Effect.exit(repo.deleteOne(idMissing));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(provide),
   );
@@ -73,9 +73,9 @@ describe("SessionRepositoryFake", () => {
   it.effect("delete: a second delete on the same row fails NotFound (matches live impl)", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      yield* repo.insert(makeSession(idA));
-      yield* repo.delete(idA);
-      const exit = yield* Effect.exit(repo.delete(idA));
+      yield* repo.insertOne(makeSession(idA));
+      yield* repo.deleteOne(idA);
+      const exit = yield* Effect.exit(repo.deleteOne(idA));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(provide),
   );
@@ -84,11 +84,11 @@ describe("SessionRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
       const seed = makeSession(idA);
-      yield* repo.insert(seed);
+      yield* repo.insertOne(seed);
       const later = DateTime.add(now, { seconds: 1800 });
       const touched = Session.touch({ session: seed, now: later, ttlSeconds: 3600 });
-      yield* repo.update(touched);
-      const found = yield* repo.findById(idA);
+      yield* repo.updateOne(touched);
+      const found = yield* repo.findOneById(idA);
       deepStrictEqual(found.expiresAt, touched.expiresAt);
       deepStrictEqual(found.lastUsedAt, touched.lastUsedAt);
       deepStrictEqual(found.createdAt, seed.createdAt);
@@ -99,7 +99,7 @@ describe("SessionRepositoryFake", () => {
   it.effect("update fails SessionNotFound on a missing id", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      const exit = yield* Effect.exit(repo.update(makeSession(idMissing)));
+      const exit = yield* Effect.exit(repo.updateOne(makeSession(idMissing)));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -112,11 +112,11 @@ describe("SessionRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
       const seed = makeSession(idA);
-      yield* repo.insert(seed);
-      yield* repo.delete(idA);
+      yield* repo.insertOne(seed);
+      yield* repo.deleteOne(idA);
       const later = DateTime.add(now, { seconds: 1800 });
       const touched = Session.touch({ session: seed, now: later, ttlSeconds: 3600 });
-      const exit = yield* Effect.exit(repo.update(touched));
+      const exit = yield* Effect.exit(repo.updateOne(touched));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-fake.ts
@@ -15,10 +15,10 @@ export const SessionRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<SessionId, Session>());
 
-    const insert = (session: Session): Effect.Effect<void> =>
+    const insertOne = (session: Session): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(session.id, session));
 
-    const findById = (id: SessionId): Effect.Effect<Session, SessionNotFound> =>
+    const findOneById = (id: SessionId): Effect.Effect<Session, SessionNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         Option.match(HashMap.get(m, id), {
           onNone: () => Effect.fail(new SessionNotFound({ sessionId: id })),
@@ -59,7 +59,7 @@ export const SessionRepositoryFake = Layer.effect(
     // Mirrors the live impl: only updates rows where revoked_at IS NULL.
     // A revoked or missing row fails SessionNotFound — callers on the touch
     // path catch and ignore (benign race).
-    const update = (session: Session): Effect.Effect<void, SessionNotFound> =>
+    const updateOne = (session: Session): Effect.Effect<void, SessionNotFound> =>
       Effect.gen(function* () {
         const m = yield* Ref.get(store);
         const existing = HashMap.get(m, session.id);
@@ -84,6 +84,6 @@ export const SessionRepositoryFake = Layer.effect(
         );
       });
 
-    return SessionRepository.of({ insert, findById, delete: deleteSession, update });
+    return SessionRepository.of({ insertOne, findOneById, deleteOne: deleteSession, updateOne });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/session-repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-live.integration.test.ts
@@ -48,14 +48,14 @@ suite("SessionRepositoryLive (integration)", () => {
     await Effect.runPromise(truncate("user.users").pipe(Effect.provide(TestDatabaseLive)));
   });
 
-  it.effect("insert + findById round-trips a Session through the DB", () =>
+  it.effect("insert + findOneById round-trips a Session through the DB", () =>
     Effect.gen(function* () {
       yield* insertUserRow;
       const repo = yield* SessionRepository;
       const now = yield* DateTime.now;
       const session = makeSession(now);
-      yield* repo.insert(session);
-      const found = yield* repo.findById(sessionId);
+      yield* repo.insertOne(session);
+      const found = yield* repo.findOneById(sessionId);
       deepStrictEqual(found.id, sessionId);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.subject, subject);
@@ -63,10 +63,10 @@ suite("SessionRepositoryLive (integration)", () => {
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findById fails SessionNotFound for an unknown id", () =>
+  it.effect("findOneById fails SessionNotFound for an unknown id", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      const exit = yield* Effect.exit(repo.findById(sessionId));
+      const exit = yield* Effect.exit(repo.findOneById(sessionId));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -80,12 +80,12 @@ suite("SessionRepositoryLive (integration)", () => {
       yield* insertUserRow;
       const repo = yield* SessionRepository;
       const now = yield* DateTime.now;
-      yield* repo.insert(makeSession(now));
-      yield* repo.delete(sessionId);
-      const found = yield* repo.findById(sessionId);
+      yield* repo.insertOne(makeSession(now));
+      yield* repo.deleteOne(sessionId);
+      const found = yield* repo.findOneById(sessionId);
       deepStrictEqual(found.revokedAt !== null, true);
 
-      const second = yield* Effect.exit(repo.delete(sessionId));
+      const second = yield* Effect.exit(repo.deleteOne(sessionId));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(Effect.provide(TestLayer)),
   );
@@ -96,11 +96,11 @@ suite("SessionRepositoryLive (integration)", () => {
       const repo = yield* SessionRepository;
       const now = yield* DateTime.now;
       const seed = makeSession(now);
-      yield* repo.insert(seed);
+      yield* repo.insertOne(seed);
       const later = DateTime.add(now, { seconds: 1800 });
       const touched = Session.touch({ session: seed, now: later, ttlSeconds: 3600 });
-      yield* repo.update(touched);
-      const found = yield* repo.findById(sessionId);
+      yield* repo.updateOne(touched);
+      const found = yield* repo.findOneById(sessionId);
       deepStrictEqual(found.expiresAt, touched.expiresAt);
       deepStrictEqual(found.lastUsedAt, touched.lastUsedAt);
       deepStrictEqual(found.absoluteExpiresAt, seed.absoluteExpiresAt);
@@ -113,11 +113,11 @@ suite("SessionRepositoryLive (integration)", () => {
       const repo = yield* SessionRepository;
       const now = yield* DateTime.now;
       const seed = makeSession(now);
-      yield* repo.insert(seed);
-      yield* repo.delete(sessionId);
+      yield* repo.insertOne(seed);
+      yield* repo.deleteOne(sessionId);
       const later = DateTime.add(now, { seconds: 1800 });
       const touched = Session.touch({ session: seed, now: later, ttlSeconds: 3600 });
-      const exit = yield* Effect.exit(repo.update(touched));
+      const exit = yield* Effect.exit(repo.updateOne(touched));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/auth/infrastructure/session-repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/session-repository-live.ts
@@ -15,7 +15,7 @@ export const SessionRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, session: Session) => {
+    const insertOne = db.makeQuery((execute, session: Session) => {
       const row = SessionMapper.toPersistence(session);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -36,11 +36,11 @@ export const SessionRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SessionRepository.insert"),
+        Effect.withSpan("SessionRepository.insertOne"),
       );
     });
 
-    const findById = db.makeQuery((execute, id: SessionId) =>
+    const findOneById = db.makeQuery((execute, id: SessionId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.SessionRowStd)`
           SELECT * FROM auth.sessions WHERE id = ${id}
@@ -50,7 +50,7 @@ export const SessionRepositoryLive = Layer.effect(
         Effect.map(SessionMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SessionRepository.findById"),
+        Effect.withSpan("SessionRepository.findOneById"),
       ),
     );
 
@@ -66,11 +66,11 @@ export const SessionRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SessionRepository.delete"),
+        Effect.withSpan("SessionRepository.deleteOne"),
       ),
     );
 
-    const update = db.makeQuery((execute, session: Session) => {
+    const updateOne = db.makeQuery((execute, session: Session) => {
       const row = SessionMapper.toPersistence(session);
       return execute((client) =>
         client.maybeOne(sql.type(RowSchemas.SessionRowStd)`
@@ -85,10 +85,10 @@ export const SessionRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SessionRepository.update"),
+        Effect.withSpan("SessionRepository.updateOne"),
       );
     });
 
-    return SessionRepository.of({ insert, findById, delete: deleteById, update });
+    return SessionRepository.of({ insertOne, findOneById, deleteOne: deleteById, updateOne });
   }),
 );

--- a/packages/server/src/modules/auth/queries/find-api-token-by-hash.test.ts
+++ b/packages/server/src/modules/auth/queries/find-api-token-by-hash.test.ts
@@ -20,7 +20,7 @@ const insert = (opts: { expiresAt: DateTime.Utc | null; revokedAt?: DateTime.Utc
   Effect.gen(function* () {
     const repo = yield* ApiTokenRepository;
     const now = yield* DateTime.now;
-    yield* repo.insert(
+    yield* repo.insertOne(
       ApiToken.make({
         id: apiTokenId,
         userId,

--- a/packages/server/src/modules/auth/queries/find-api-token-by-hash.ts
+++ b/packages/server/src/modules/auth/queries/find-api-token-by-hash.ts
@@ -15,7 +15,7 @@ import {
 export const findApiTokenByHash = (query: FindApiTokenByHashQuery): FindApiTokenByHashOutput =>
   Effect.gen(function* () {
     const repo = yield* ApiTokenRepository;
-    const token = yield* repo.findByHash(query.tokenHash);
+    const token = yield* repo.findOneByHash(query.tokenHash);
     if (token.revokedAt !== null) {
       return yield* Effect.fail(new ApiTokenRevoked());
     }

--- a/packages/server/src/modules/auth/queries/find-session.test.ts
+++ b/packages/server/src/modules/auth/queries/find-session.test.ts
@@ -29,7 +29,7 @@ const farFuture = DateTime.unsafeMake(new Date("2099-01-01T00:00:00Z"));
 const farFutureLater = DateTime.unsafeMake(new Date("2099-12-31T00:00:00Z"));
 
 const insertSession = (session: Session) =>
-  Effect.flatMap(SessionRepository, (repo) => repo.insert(session));
+  Effect.flatMap(SessionRepository, (repo) => repo.insertOne(session));
 
 const baseFields = {
   id: sessionId,

--- a/packages/server/src/modules/auth/queries/find-session.ts
+++ b/packages/server/src/modules/auth/queries/find-session.ts
@@ -14,7 +14,7 @@ import {
 export const findSession = (query: FindSessionQuery): FindSessionOutput =>
   Effect.gen(function* () {
     const sessions = yield* SessionRepository;
-    const session = yield* sessions.findById(query.sessionId);
+    const session = yield* sessions.findOneById(query.sessionId);
     if (session.revokedAt !== null) {
       return yield* Effect.fail(new SessionRevoked({ sessionId: query.sessionId }));
     }

--- a/packages/server/src/modules/auth/queries/list-my-api-tokens.test.ts
+++ b/packages/server/src/modules/auth/queries/list-my-api-tokens.test.ts
@@ -33,8 +33,8 @@ describe("listMyApiTokens", () => {
           now,
           expiresAt: DateTime.add(now, { days: 90 }),
         });
-      yield* repo.insert(mk(idA, userId));
-      yield* repo.insert(mk(idOther, otherUserId));
+      yield* repo.insertOne(mk(idA, userId));
+      yield* repo.insertOne(mk(idOther, otherUserId));
       const mine = yield* listMyApiTokens(ListMyApiTokensQuery.make({ userId }));
       deepStrictEqual(
         mine.map((t) => t.id),

--- a/packages/server/src/modules/auth/queries/list-my-api-tokens.ts
+++ b/packages/server/src/modules/auth/queries/list-my-api-tokens.ts
@@ -10,5 +10,5 @@ import {
 export const listMyApiTokens = (query: ListMyApiTokensQuery): ListMyApiTokensOutput =>
   Effect.gen(function* () {
     const repo = yield* ApiTokenRepository;
-    return yield* repo.listByUser(query.userId);
+    return yield* repo.findManyByUser(query.userId);
   });

--- a/packages/server/src/modules/billing/commands/cancel-subscription.test.ts
+++ b/packages/server/src/modules/billing/commands/cancel-subscription.test.ts
@@ -42,7 +42,7 @@ const seed = (status = "active") =>
       currentPeriodEnd: null,
       now,
     });
-    yield* repo.insert(subscription);
+    yield* repo.insertOne(subscription);
   });
 
 describe("cancelSubscription", () => {
@@ -57,7 +57,7 @@ describe("cancelSubscription", () => {
       );
       deepStrictEqual(result.status, "canceled");
 
-      const found = yield* repo.findByOrganizationId(acme);
+      const found = yield* repo.findOneByOrganizationId(acme);
       ok(Option.isSome(found));
       if (Option.isSome(found)) deepStrictEqual(found.value.status, "canceled");
 

--- a/packages/server/src/modules/billing/commands/cancel-subscription.ts
+++ b/packages/server/src/modules/billing/commands/cancel-subscription.ts
@@ -25,7 +25,7 @@ export const cancelSubscription = (cmd: CancelSubscriptionCommand): CancelSubscr
     const gateway = yield* BillingGateway;
     const bus = yield* DomainEventBus;
 
-    const found = yield* repo.findByOrganizationId(cmd.organizationId);
+    const found = yield* repo.findOneByOrganizationId(cmd.organizationId);
     if (Option.isNone(found)) {
       return yield* Effect.fail(new SubscriptionNotFound({ organizationId: cmd.organizationId }));
     }
@@ -39,7 +39,7 @@ export const cancelSubscription = (cmd: CancelSubscriptionCommand): CancelSubscr
     const { events, subscription } = Subscription.cancel(existing, now);
 
     yield* Effect.gen(function* () {
-      yield* repo.update(subscription);
+      yield* repo.updateOne(subscription);
       yield* bus.dispatch(events);
     }).pipe(withUnitOfWork);
 

--- a/packages/server/src/modules/billing/commands/ingest-stripe-webhook.test.ts
+++ b/packages/server/src/modules/billing/commands/ingest-stripe-webhook.test.ts
@@ -52,7 +52,7 @@ describe("ingestStripeWebhook", () => {
 
         yield* ingestStripeWebhook(cmd("evt_new"));
 
-        const seen = yield* repo.findByStripeEventId("evt_new");
+        const seen = yield* repo.findOneByStripeEventId("evt_new");
         ok(Option.isSome(seen));
 
         const events = yield* rec.byTag<StripeWebhookIngested>("StripeWebhookIngested");
@@ -74,7 +74,7 @@ describe("ingestStripeWebhook", () => {
         ok(exit.cause.error instanceof InvalidWebhookSignature);
       }
 
-      const seen = yield* repo.findByStripeEventId("evt_bad_sig");
+      const seen = yield* repo.findOneByStripeEventId("evt_bad_sig");
       ok(Option.isNone(seen));
       const events = yield* rec.byTag<StripeWebhookIngested>("StripeWebhookIngested");
       deepStrictEqual(events.length, 0);

--- a/packages/server/src/modules/billing/commands/ingest-stripe-webhook.ts
+++ b/packages/server/src/modules/billing/commands/ingest-stripe-webhook.ts
@@ -23,7 +23,7 @@ import {
 // downstream subscribers (subscription status sync) never fire twice
 // for the same delivery.
 //
-// The repository's `findByStripeEventId` exists for audit/dashboard
+// The repository's `findOneByStripeEventId` exists for audit/dashboard
 // read paths; the write path here intentionally skips it because
 // "find then insert" introduces a race window. Postgres' unique
 // constraint is the arbiter.
@@ -39,7 +39,7 @@ export const ingestStripeWebhook = (cmd: IngestStripeWebhookCommand): IngestStri
     });
 
     yield* Effect.gen(function* () {
-      const claimed = yield* repo.insert(stripeEvent.eventId).pipe(
+      const claimed = yield* repo.insertOne(stripeEvent.eventId).pipe(
         Effect.as(true),
         Effect.catchTag("WebhookEventAlreadyRecorded", () => Effect.succeed(false)),
       );

--- a/packages/server/src/modules/billing/commands/start-subscription.test.ts
+++ b/packages/server/src/modules/billing/commands/start-subscription.test.ts
@@ -41,7 +41,7 @@ describe("startSubscription", () => {
         ok(sub.stripeSubscriptionId.startsWith("sub_test_"));
         deepStrictEqual(sub.status, "active");
 
-        const stored = yield* repo.findByOrganizationId(acme);
+        const stored = yield* repo.findOneByOrganizationId(acme);
         ok(Option.isSome(stored));
 
         const events = yield* rec.byTag<SubscriptionStarted>("SubscriptionStarted");

--- a/packages/server/src/modules/billing/commands/start-subscription.ts
+++ b/packages/server/src/modules/billing/commands/start-subscription.ts
@@ -29,7 +29,7 @@ export const startSubscription = (cmd: StartSubscriptionCommand): StartSubscript
 
     // Idempotency check at the use-case layer: avoid a Stripe-side
     // double-charge if a caller retries POST after a network blip.
-    const existing = yield* repo.findByOrganizationId(cmd.organizationId);
+    const existing = yield* repo.findOneByOrganizationId(cmd.organizationId);
     if (Option.isSome(existing)) {
       return yield* Effect.fail(
         new SubscriptionAlreadyExistsForOrganization({ organizationId: cmd.organizationId }),
@@ -54,7 +54,7 @@ export const startSubscription = (cmd: StartSubscriptionCommand): StartSubscript
     });
 
     yield* Effect.gen(function* () {
-      yield* repo.insert(subscription);
+      yield* repo.insertOne(subscription);
       yield* bus.dispatch(events);
     }).pipe(withUnitOfWork);
 

--- a/packages/server/src/modules/billing/domain/ports/repositories/subscription-repository.ts
+++ b/packages/server/src/modules/billing/domain/ports/repositories/subscription-repository.ts
@@ -8,14 +8,14 @@ import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistenc
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 export type SubscriptionRepositoryShape = {
-  readonly insert: (
+  readonly insertOne: (
     subscription: Subscription,
   ) => Effect.Effect<void, SubscriptionAlreadyExistsForOrganization | PersistenceUnavailable>;
-  readonly update: (subscription: Subscription) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findByOrganizationId: (
+  readonly updateOne: (subscription: Subscription) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findOneByOrganizationId: (
     organizationId: OrganizationId,
   ) => Effect.Effect<Option.Option<Subscription>, PersistenceUnavailable>;
-  readonly findByStripeSubscriptionId: (
+  readonly findOneByStripeSubscriptionId: (
     stripeSubscriptionId: string,
   ) => Effect.Effect<Option.Option<Subscription>, PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/billing/domain/ports/repositories/webhook-event-repository.ts
+++ b/packages/server/src/modules/billing/domain/ports/repositories/webhook-event-repository.ts
@@ -20,10 +20,10 @@ export type WebhookEventRecord = {
 };
 
 export type WebhookEventRepositoryShape = {
-  readonly insert: (
+  readonly insertOne: (
     stripeEventId: string,
   ) => Effect.Effect<void, WebhookEventAlreadyRecorded | PersistenceUnavailable>;
-  readonly findByStripeEventId: (
+  readonly findOneByStripeEventId: (
     stripeEventId: string,
   ) => Effect.Effect<Option.Option<WebhookEventRecord>, PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/billing/event-handlers/sync-subscription-from-stripe-webhook.test.ts
+++ b/packages/server/src/modules/billing/event-handlers/sync-subscription-from-stripe-webhook.test.ts
@@ -43,7 +43,7 @@ const seedSubscription = () =>
       currentPeriodEnd: null,
       now: seedNow,
     });
-    yield* repo.insert(subscription);
+    yield* repo.insertOne(subscription);
   });
 
 const subEvent = (
@@ -73,7 +73,7 @@ const dispatchAndReadStatus = (ingested: StripeWebhookIngested) =>
     const bus = yield* DomainEventBus;
     yield* bus.dispatch([ingested]);
     const repo = yield* SubscriptionRepository;
-    return yield* repo.findByOrganizationId(acme);
+    return yield* repo.findOneByOrganizationId(acme);
   }).pipe(Database.TransactionContext.provide(fakeTransaction), Effect.provide(TestLayer));
 
 describe("SyncSubscriptionFromStripeWebhookLive", () => {
@@ -142,7 +142,7 @@ describe("SyncSubscriptionFromStripeWebhookLive", () => {
       // the Stripe id → drops silently.
       yield* bus.dispatch([StripeWebhookIngested.make({ stripeEvent: subEvent("updated") })]);
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findByOrganizationId(acme);
+      const found = yield* repo.findOneByOrganizationId(acme);
       ok(Option.isNone(found));
     }).pipe(Database.TransactionContext.provide(fakeTransaction), Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/billing/event-handlers/sync-subscription-from-stripe-webhook.ts
+++ b/packages/server/src/modules/billing/event-handlers/sync-subscription-from-stripe-webhook.ts
@@ -39,7 +39,7 @@ export const SyncSubscriptionFromStripeWebhookLive = Layer.effectDiscard(
           case "customer.subscription.created":
           case "customer.subscription.updated":
           case "customer.subscription.deleted": {
-            const found = yield* repo.findByStripeSubscriptionId(
+            const found = yield* repo.findOneByStripeSubscriptionId(
               stripeEvent.subscription.stripeSubscriptionId,
             );
             if (Option.isNone(found)) return;
@@ -53,7 +53,7 @@ export const SyncSubscriptionFromStripeWebhookLive = Layer.effectDiscard(
               currentPeriodEnd: stripeEvent.subscription.currentPeriodEnd,
               now,
             });
-            yield* repo.update(subscription);
+            yield* repo.updateOne(subscription);
             yield* eventBus.dispatch(events);
             return;
           }

--- a/packages/server/src/modules/billing/infrastructure/subscription-repository-fake.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/subscription-repository-fake.test.ts
@@ -35,8 +35,8 @@ describe("SubscriptionRepositoryFake.insert", () => {
   it.effect("stores a subscription and makes it findable by organizationId", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      yield* repo.insert(mk(subA, acme));
-      const found = yield* repo.findByOrganizationId(acme);
+      yield* repo.insertOne(mk(subA, acme));
+      const found = yield* repo.findOneByOrganizationId(acme);
       ok(Option.isSome(found));
       if (Option.isSome(found)) deepStrictEqual(found.value.id, subA);
     }).pipe(provide),
@@ -45,8 +45,8 @@ describe("SubscriptionRepositoryFake.insert", () => {
   it.effect("fails SubscriptionAlreadyExistsForOrganization on duplicate org", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      yield* repo.insert(mk(subA, acme));
-      const exit = yield* Effect.exit(repo.insert(mk(subB, acme, "sub_y")));
+      yield* repo.insertOne(mk(subA, acme));
+      const exit = yield* Effect.exit(repo.insertOne(mk(subB, acme, "sub_y")));
       ok(Exit.isFailure(exit));
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
         ok(exit.cause.error instanceof SubscriptionAlreadyExistsForOrganization);
@@ -57,10 +57,10 @@ describe("SubscriptionRepositoryFake.insert", () => {
   it.effect("allows different organizations to each have their own subscription", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      yield* repo.insert(mk(subA, acme, "sub_a"));
-      yield* repo.insert(mk(subB, beta, "sub_b"));
-      const a = yield* repo.findByOrganizationId(acme);
-      const b = yield* repo.findByOrganizationId(beta);
+      yield* repo.insertOne(mk(subA, acme, "sub_a"));
+      yield* repo.insertOne(mk(subB, beta, "sub_b"));
+      const a = yield* repo.findOneByOrganizationId(acme);
+      const b = yield* repo.findOneByOrganizationId(beta);
       ok(Option.isSome(a) && Option.isSome(b));
     }).pipe(provide),
   );
@@ -71,22 +71,22 @@ describe("SubscriptionRepositoryFake.update", () => {
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
       const sub = mk(subA, acme);
-      yield* repo.insert(sub);
+      yield* repo.insertOne(sub);
       const { subscription: canceled } = Subscription.cancel(sub, now);
-      yield* repo.update(canceled);
-      const found = yield* repo.findByOrganizationId(acme);
+      yield* repo.updateOne(canceled);
+      const found = yield* repo.findOneByOrganizationId(acme);
       ok(Option.isSome(found));
       if (Option.isSome(found)) deepStrictEqual(found.value.status, "canceled");
     }).pipe(provide),
   );
 });
 
-describe("SubscriptionRepositoryFake.findByStripeSubscriptionId", () => {
+describe("SubscriptionRepositoryFake.findOneByStripeSubscriptionId", () => {
   it.effect("returns the subscription that has the matching Stripe id", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      yield* repo.insert(mk(subA, acme, "sub_unique"));
-      const found = yield* repo.findByStripeSubscriptionId("sub_unique");
+      yield* repo.insertOne(mk(subA, acme, "sub_unique"));
+      const found = yield* repo.findOneByStripeSubscriptionId("sub_unique");
       ok(Option.isSome(found));
       if (Option.isSome(found)) deepStrictEqual(found.value.id, subA);
     }).pipe(provide),
@@ -95,17 +95,17 @@ describe("SubscriptionRepositoryFake.findByStripeSubscriptionId", () => {
   it.effect("returns None when no subscription has the given Stripe id", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findByStripeSubscriptionId("sub_does_not_exist");
+      const found = yield* repo.findOneByStripeSubscriptionId("sub_does_not_exist");
       ok(Option.isNone(found));
     }).pipe(provide),
   );
 });
 
-describe("SubscriptionRepositoryFake.findByOrganizationId", () => {
+describe("SubscriptionRepositoryFake.findOneByOrganizationId", () => {
   it.effect("returns None for an org with no subscription", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findByOrganizationId(acme);
+      const found = yield* repo.findOneByOrganizationId(acme);
       ok(Option.isNone(found));
     }).pipe(provide),
   );

--- a/packages/server/src/modules/billing/infrastructure/subscription-repository-fake.ts
+++ b/packages/server/src/modules/billing/infrastructure/subscription-repository-fake.ts
@@ -35,7 +35,7 @@ export const SubscriptionRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<SubscriptionId, Subscription>());
 
-    const insert = (
+    const insertOne = (
       sub: Subscription,
     ): Effect.Effect<void, SubscriptionAlreadyExistsForOrganization> =>
       Effect.flatMap(Ref.get(store), (m) =>
@@ -48,24 +48,24 @@ export const SubscriptionRepositoryFake = Layer.effect(
           : Ref.update(store, HashMap.set(sub.id, sub)),
       );
 
-    const update = (sub: Subscription): Effect.Effect<void> =>
+    const updateOne = (sub: Subscription): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(sub.id, sub));
 
-    const findByOrganizationId = (
+    const findOneByOrganizationId = (
       organizationId: OrganizationId,
     ): Effect.Effect<Option.Option<Subscription>> =>
       Effect.map(Ref.get(store), (m) => findByOrgIn(m, organizationId));
 
-    const findByStripeSubscriptionId = (
+    const findOneByStripeSubscriptionId = (
       stripeSubscriptionId: string,
     ): Effect.Effect<Option.Option<Subscription>> =>
       Effect.map(Ref.get(store), (m) => findByStripeIdIn(m, stripeSubscriptionId));
 
     return SubscriptionRepository.of({
-      insert,
-      update,
-      findByOrganizationId,
-      findByStripeSubscriptionId,
+      insertOne,
+      updateOne,
+      findOneByOrganizationId,
+      findOneByStripeSubscriptionId,
     });
   }),
 );

--- a/packages/server/src/modules/billing/infrastructure/subscription-repository-live.integration.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/subscription-repository-live.integration.test.ts
@@ -68,12 +68,12 @@ suite("SubscriptionRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists and decodes back via findByOrganizationId", () =>
+    it.effect("persists and decodes back via findOneByOrganizationId", () =>
       Effect.gen(function* () {
         yield* seedOrgRow(acme, "Acme");
         const repo = yield* SubscriptionRepository;
-        yield* repo.insert(mk(subA, acme, "sub_acme"));
-        const found = yield* repo.findByOrganizationId(acme);
+        yield* repo.insertOne(mk(subA, acme, "sub_acme"));
+        const found = yield* repo.findOneByOrganizationId(acme);
         ok(Option.isSome(found));
         if (Option.isSome(found)) {
           deepStrictEqual(found.value.id, subA);
@@ -87,8 +87,8 @@ suite("SubscriptionRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgRow(acme, "Acme");
         const repo = yield* SubscriptionRepository;
-        yield* repo.insert(mk(subA, acme, "sub_a"));
-        const exit = yield* Effect.exit(repo.insert(mk(subB, acme, "sub_b")));
+        yield* repo.insertOne(mk(subA, acme, "sub_a"));
+        const exit = yield* Effect.exit(repo.insertOne(mk(subB, acme, "sub_b")));
         ok(Exit.isFailure(exit));
         if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
           ok(exit.cause.error instanceof SubscriptionAlreadyExistsForOrganization);
@@ -103,25 +103,25 @@ suite("SubscriptionRepositoryLive (integration)", () => {
         yield* seedOrgRow(acme, "Acme");
         const repo = yield* SubscriptionRepository;
         const sub = mk(subA, acme, "sub_acme");
-        yield* repo.insert(sub);
+        yield* repo.insertOne(sub);
         const { subscription: canceled } = Subscription.cancel(sub, now);
-        yield* repo.update(canceled);
-        const found = yield* repo.findByOrganizationId(acme);
+        yield* repo.updateOne(canceled);
+        const found = yield* repo.findOneByOrganizationId(acme);
         ok(Option.isSome(found));
         if (Option.isSome(found)) deepStrictEqual(found.value.status, "canceled");
       }).pipe(Effect.provide(TestLayer)),
     );
   });
 
-  describe("findByStripeSubscriptionId", () => {
+  describe("findOneByStripeSubscriptionId", () => {
     it.effect("returns the subscription that has the matching Stripe id (cross-tenant safe)", () =>
       Effect.gen(function* () {
         yield* seedOrgRow(acme, "Acme");
         yield* seedOrgRow(beta, "Beta");
         const repo = yield* SubscriptionRepository;
-        yield* repo.insert(mk(subA, acme, "sub_acme_id"));
-        yield* repo.insert(mk(subB, beta, "sub_beta_id"));
-        const found = yield* repo.findByStripeSubscriptionId("sub_beta_id");
+        yield* repo.insertOne(mk(subA, acme, "sub_acme_id"));
+        yield* repo.insertOne(mk(subB, beta, "sub_beta_id"));
+        const found = yield* repo.findOneByStripeSubscriptionId("sub_beta_id");
         ok(Option.isSome(found));
         if (Option.isSome(found)) {
           deepStrictEqual(found.value.id, subB);
@@ -133,7 +133,7 @@ suite("SubscriptionRepositoryLive (integration)", () => {
     it.effect("returns None when no subscription matches", () =>
       Effect.gen(function* () {
         const repo = yield* SubscriptionRepository;
-        const found = yield* repo.findByStripeSubscriptionId("sub_unknown");
+        const found = yield* repo.findOneByStripeSubscriptionId("sub_unknown");
         ok(Option.isNone(found));
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/billing/infrastructure/subscription-repository-live.ts
+++ b/packages/server/src/modules/billing/infrastructure/subscription-repository-live.ts
@@ -16,7 +16,7 @@ export const SubscriptionRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, sub: Subscription) => {
+    const insertOne = db.makeQuery((execute, sub: Subscription) => {
       const row = SubscriptionMapper.toPersistence(sub);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -53,11 +53,11 @@ export const SubscriptionRepositoryLive = Layer.effect(
             : Effect.die(e),
         ),
         translatePersistenceUnavailable,
-        Effect.withSpan("SubscriptionRepository.insert"),
+        Effect.withSpan("SubscriptionRepository.insertOne"),
       );
     });
 
-    const update = db.makeQuery((execute, sub: Subscription) => {
+    const updateOne = db.makeQuery((execute, sub: Subscription) => {
       const row = SubscriptionMapper.toPersistence(sub);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -74,11 +74,11 @@ export const SubscriptionRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SubscriptionRepository.update"),
+        Effect.withSpan("SubscriptionRepository.updateOne"),
       );
     });
 
-    const findByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
+    const findOneByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.SubscriptionRowStd)`
           SELECT * FROM billing.subscriptions WHERE organization_id = ${organizationId}
@@ -89,11 +89,11 @@ export const SubscriptionRepositoryLive = Layer.effect(
         ),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SubscriptionRepository.findByOrganizationId"),
+        Effect.withSpan("SubscriptionRepository.findOneByOrganizationId"),
       ),
     );
 
-    const findByStripeSubscriptionId = db.makeQuery((execute, stripeSubscriptionId: string) =>
+    const findOneByStripeSubscriptionId = db.makeQuery((execute, stripeSubscriptionId: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.SubscriptionRowStd)`
           SELECT * FROM billing.subscriptions WHERE stripe_subscription_id = ${stripeSubscriptionId}
@@ -104,15 +104,15 @@ export const SubscriptionRepositoryLive = Layer.effect(
         ),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SubscriptionRepository.findByStripeSubscriptionId"),
+        Effect.withSpan("SubscriptionRepository.findOneByStripeSubscriptionId"),
       ),
     );
 
     return SubscriptionRepository.of({
-      insert,
-      update,
-      findByOrganizationId,
-      findByStripeSubscriptionId,
+      insertOne,
+      updateOne,
+      findOneByOrganizationId,
+      findOneByStripeSubscriptionId,
     });
   }),
 );

--- a/packages/server/src/modules/billing/infrastructure/webhook-event-repository-fake.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/webhook-event-repository-fake.test.ts
@@ -14,8 +14,8 @@ describe("WebhookEventRepositoryFake.insert", () => {
   it.effect("persists the event id and makes it findable", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      yield* repo.insert("evt_abc");
-      const found = yield* repo.findByStripeEventId("evt_abc");
+      yield* repo.insertOne("evt_abc");
+      const found = yield* repo.findOneByStripeEventId("evt_abc");
       ok(Option.isSome(found));
       if (Option.isSome(found)) deepStrictEqual(found.value.stripeEventId, "evt_abc");
     }).pipe(provide),
@@ -24,8 +24,8 @@ describe("WebhookEventRepositoryFake.insert", () => {
   it.effect("fails WebhookEventAlreadyRecorded on a duplicate insert", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      yield* repo.insert("evt_abc");
-      const exit = yield* Effect.exit(repo.insert("evt_abc"));
+      yield* repo.insertOne("evt_abc");
+      const exit = yield* Effect.exit(repo.insertOne("evt_abc"));
       ok(Exit.isFailure(exit));
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
         ok(exit.cause.error instanceof WebhookEventAlreadyRecorded);
@@ -36,20 +36,20 @@ describe("WebhookEventRepositoryFake.insert", () => {
   it.effect("treats distinct event ids independently", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      yield* repo.insert("evt_a");
-      yield* repo.insert("evt_b");
-      const a = yield* repo.findByStripeEventId("evt_a");
-      const b = yield* repo.findByStripeEventId("evt_b");
+      yield* repo.insertOne("evt_a");
+      yield* repo.insertOne("evt_b");
+      const a = yield* repo.findOneByStripeEventId("evt_a");
+      const b = yield* repo.findOneByStripeEventId("evt_b");
       ok(Option.isSome(a) && Option.isSome(b));
     }).pipe(provide),
   );
 });
 
-describe("WebhookEventRepositoryFake.findByStripeEventId", () => {
+describe("WebhookEventRepositoryFake.findOneByStripeEventId", () => {
   it.effect("returns None when no event has been recorded for the id", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      const found = yield* repo.findByStripeEventId("evt_unknown");
+      const found = yield* repo.findOneByStripeEventId("evt_unknown");
       ok(Option.isNone(found));
     }).pipe(provide),
   );

--- a/packages/server/src/modules/billing/infrastructure/webhook-event-repository-fake.ts
+++ b/packages/server/src/modules/billing/infrastructure/webhook-event-repository-fake.ts
@@ -16,7 +16,7 @@ export const WebhookEventRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<string, WebhookEventRecord>());
 
-    const insert = (stripeEventId: string): Effect.Effect<void, WebhookEventAlreadyRecorded> =>
+    const insertOne = (stripeEventId: string): Effect.Effect<void, WebhookEventAlreadyRecorded> =>
       Effect.flatMap(Ref.get(store), (m) =>
         HashMap.has(m, stripeEventId)
           ? Effect.fail(new WebhookEventAlreadyRecorded({ stripeEventId }))
@@ -25,11 +25,11 @@ export const WebhookEventRepositoryFake = Layer.effect(
             ),
       );
 
-    const findByStripeEventId = (
+    const findOneByStripeEventId = (
       stripeEventId: string,
     ): Effect.Effect<Option.Option<WebhookEventRecord>> =>
       Effect.map(Ref.get(store), (m) => HashMap.get(m, stripeEventId));
 
-    return WebhookEventRepository.of({ insert, findByStripeEventId });
+    return WebhookEventRepository.of({ insertOne, findOneByStripeEventId });
   }),
 );

--- a/packages/server/src/modules/billing/infrastructure/webhook-event-repository-live.integration.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/webhook-event-repository-live.integration.test.ts
@@ -21,11 +21,11 @@ suite("WebhookEventRepositoryLive (integration)", () => {
     );
   });
 
-  it.effect("inserts an event id and decodes it back via findByStripeEventId", () =>
+  it.effect("inserts an event id and decodes it back via findOneByStripeEventId", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      yield* repo.insert("evt_test_1");
-      const found = yield* repo.findByStripeEventId("evt_test_1");
+      yield* repo.insertOne("evt_test_1");
+      const found = yield* repo.findOneByStripeEventId("evt_test_1");
       ok(Option.isSome(found));
       if (Option.isSome(found)) deepStrictEqual(found.value.stripeEventId, "evt_test_1");
     }).pipe(Effect.provide(TestLayer)),
@@ -36,8 +36,8 @@ suite("WebhookEventRepositoryLive (integration)", () => {
     () =>
       Effect.gen(function* () {
         const repo = yield* WebhookEventRepository;
-        yield* repo.insert("evt_test_dup");
-        const exit = yield* Effect.exit(repo.insert("evt_test_dup"));
+        yield* repo.insertOne("evt_test_dup");
+        const exit = yield* Effect.exit(repo.insertOne("evt_test_dup"));
         ok(Exit.isFailure(exit));
         if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
           ok(exit.cause.error instanceof WebhookEventAlreadyRecorded);
@@ -48,7 +48,7 @@ suite("WebhookEventRepositoryLive (integration)", () => {
   it.effect("returns None for an unrecorded event id", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      const found = yield* repo.findByStripeEventId("evt_does_not_exist");
+      const found = yield* repo.findOneByStripeEventId("evt_does_not_exist");
       ok(Option.isNone(found));
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/billing/infrastructure/webhook-event-repository-live.ts
+++ b/packages/server/src/modules/billing/infrastructure/webhook-event-repository-live.ts
@@ -19,7 +19,7 @@ export const WebhookEventRepositoryLive = Layer.effect(
     // `WebhookEventAlreadyRecorded` to short-circuit duplicate
     // deliveries — same shape as wallet/subscription's
     // `*AlreadyExists` errors.
-    const insert = db.makeQuery((execute, stripeEventId: string) =>
+    const insertOne = db.makeQuery((execute, stripeEventId: string) =>
       execute((client) =>
         client.query(sql.unsafe`
           INSERT INTO billing.webhook_events (stripe_event_id)
@@ -33,11 +33,11 @@ export const WebhookEventRepositoryLive = Layer.effect(
             : Effect.die(e),
         ),
         translatePersistenceUnavailable,
-        Effect.withSpan("WebhookEventRepository.insert"),
+        Effect.withSpan("WebhookEventRepository.insertOne"),
       ),
     );
 
-    const findByStripeEventId = db.makeQuery((execute, stripeEventId: string) =>
+    const findOneByStripeEventId = db.makeQuery((execute, stripeEventId: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.WebhookEventRowStd)`
           SELECT * FROM billing.webhook_events WHERE stripe_event_id = ${stripeEventId}
@@ -48,10 +48,10 @@ export const WebhookEventRepositoryLive = Layer.effect(
         ),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("WebhookEventRepository.findByStripeEventId"),
+        Effect.withSpan("WebhookEventRepository.findOneByStripeEventId"),
       ),
     );
 
-    return WebhookEventRepository.of({ insert, findByStripeEventId });
+    return WebhookEventRepository.of({ insertOne, findOneByStripeEventId });
   }),
 );

--- a/packages/server/src/modules/billing/queries/find-subscription-by-organization.test.ts
+++ b/packages/server/src/modules/billing/queries/find-subscription-by-organization.test.ts
@@ -34,7 +34,7 @@ describe("findSubscriptionByOrganization", () => {
           currentPeriodEnd: null,
           now,
         });
-        yield* repo.insert(subscription);
+        yield* repo.insertOne(subscription);
 
         const result = yield* findSubscriptionByOrganization(
           FindSubscriptionByOrganizationQuery.make({ organizationId: acme }),

--- a/packages/server/src/modules/billing/queries/find-subscription-by-organization.ts
+++ b/packages/server/src/modules/billing/queries/find-subscription-by-organization.ts
@@ -16,7 +16,7 @@ export const findSubscriptionByOrganization = (
 ): FindSubscriptionByOrganizationOutput =>
   Effect.gen(function* () {
     const repo = yield* SubscriptionRepository;
-    const found = yield* repo.findByOrganizationId(query.organizationId);
+    const found = yield* repo.findOneByOrganizationId(query.organizationId);
     return Option.map(found, (sub) => ({
       id: sub.id,
       organizationId: sub.organizationId,

--- a/packages/server/src/modules/organization/commands/accept-invitation.test.ts
+++ b/packages/server/src/modules/organization/commands/accept-invitation.test.ts
@@ -61,17 +61,17 @@ describe("acceptInvitation", () => {
       const inv = yield* InvitationRepository;
       const members = yield* MembershipRepository;
       const rec = yield* RecordedEvents;
-      yield* inv.insert(seed());
+      yield* inv.insertOne(seed());
 
       const orgId = yield* acceptInvitation(
         AcceptInvitationCommand.make({ token: "tok-abc", userId }),
       );
       deepStrictEqual(orgId, organizationId);
 
-      const updated = yield* inv.findById(invitationId);
+      const updated = yield* inv.findOneById(invitationId);
       deepStrictEqual(updated.acceptedAt !== null, true);
 
-      const membership = yield* members.findByUserIdAndOrgId(userId, organizationId);
+      const membership = yield* members.findOneByUserIdAndOrgId(userId, organizationId);
       deepStrictEqual(membership.userId, userId);
 
       const tags = (yield* rec.all).map((e) => e._tag);
@@ -104,7 +104,7 @@ describe("acceptInvitation", () => {
       const inv = yield* InvitationRepository;
       const accepted = Invitation.accept(seed(), { userId, now });
       if (Either.isLeft(accepted)) throw new Error("expected Right");
-      yield* inv.insert(accepted.right.invitation);
+      yield* inv.insertOne(accepted.right.invitation);
 
       const exit = yield* Effect.exit(
         acceptInvitation(AcceptInvitationCommand.make({ token: "tok-abc", userId })),
@@ -122,7 +122,7 @@ describe("acceptInvitation", () => {
       const inv = yield* InvitationRepository;
       const revoked = Invitation.revoke(seed(), { now });
       if (Either.isLeft(revoked)) throw new Error("expected Right");
-      yield* inv.insert(revoked.right.invitation);
+      yield* inv.insertOne(revoked.right.invitation);
 
       const exit = yield* Effect.exit(
         acceptInvitation(AcceptInvitationCommand.make({ token: "tok-abc", userId })),
@@ -149,7 +149,7 @@ describe("acceptInvitation", () => {
         expiresAt: DateTime.unsafeMake(new Date("2020-01-01T00:00:00Z")),
         now: DateTime.unsafeMake(new Date("2019-12-01T00:00:00Z")),
       }).invitation;
-      yield* inv.insert(expired);
+      yield* inv.insertOne(expired);
 
       const exit = yield* Effect.exit(
         acceptInvitation(AcceptInvitationCommand.make({ token: "tok-abc", userId })),
@@ -165,7 +165,7 @@ describe("acceptInvitation", () => {
   it.effect("rejects with SuperAdminCannotOwnOrganization when caller is a super-admin", () =>
     Effect.gen(function* () {
       const inv = yield* InvitationRepository;
-      yield* inv.insert(seed());
+      yield* inv.insertOne(seed());
 
       const exit = yield* Effect.exit(
         acceptInvitation(

--- a/packages/server/src/modules/organization/commands/accept-invitation.ts
+++ b/packages/server/src/modules/organization/commands/accept-invitation.ts
@@ -29,15 +29,15 @@ export const acceptInvitation = (cmd: AcceptInvitationCommand): AcceptInvitation
     const bus = yield* DomainEventBus;
     const now = yield* DateTime.now;
 
-    const invitation = yield* invRepo.findByToken(cmd.token);
+    const invitation = yield* invRepo.findOneByToken(cmd.token);
     const result = yield* Invitation.accept(invitation, { userId: cmd.userId, now });
     yield* Effect.annotateCurrentSpan("invitation.id", invitation.id);
     yield* Effect.annotateCurrentSpan("organization.id", invitation.organizationId);
 
-    yield* invRepo.update(result.invitation);
-    yield* memberRepo.insert(result.membership);
+    yield* invRepo.updateOne(result.invitation);
+    yield* memberRepo.insertOne(result.membership);
     yield* bus.dispatch(result.events);
-    // Concurrent revoke between findByToken and update would surface as
+    // Concurrent revoke between findOneByToken and update would surface as
     // InvitationNotFound from `update` — treat as a defect (the token
     // was valid moments ago; the operator should look at the trace).
     // For normal use, the aggregate's accept() catches expired/revoked.

--- a/packages/server/src/modules/organization/commands/create-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/create-organization.test.ts
@@ -43,7 +43,7 @@ describe("createOrganization", () => {
       const id = yield* createOrganization(
         CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
       );
-      const stored = yield* repo.findById(id);
+      const stored = yield* repo.findOneById(id);
       deepStrictEqual(stored.name, "Acme");
       const events = yield* rec.byTag<OrganizationCreated>("OrganizationCreated");
       deepStrictEqual(events.length, 1);
@@ -61,7 +61,7 @@ describe("createOrganization", () => {
       const id = yield* createOrganization(
         CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
       );
-      const membership = yield* memberships.findByUserIdAndOrgId(actorUserId, id);
+      const membership = yield* memberships.findOneByUserIdAndOrgId(actorUserId, id);
       deepStrictEqual(membership.userId, actorUserId);
       deepStrictEqual(membership.organizationId, id);
       const events = yield* rec.byTag<MembershipCreated>("MembershipCreated");
@@ -82,7 +82,7 @@ describe("createOrganization", () => {
         const id = yield* createOrganization(
           CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
         );
-        const roles = yield* orgRolesRepo.findByUserIdAndOrgId(actorUserId, id);
+        const roles = yield* orgRolesRepo.findOneByUserIdAndOrgId(actorUserId, id);
         deepStrictEqual(
           roles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
           [{ role: "admin", issuedBy: actorUserId }],

--- a/packages/server/src/modules/organization/commands/create-organization.ts
+++ b/packages/server/src/modules/organization/commands/create-organization.ts
@@ -69,9 +69,9 @@ export const createOrganization = (cmd: CreateOrganizationCommand): CreateOrgani
     }
     const grantResult = grantEither.right;
 
-    yield* orgRepo.insert(organization);
-    yield* memberRepo.insert(membership);
-    yield* orgRolesRepo.save(grantResult.organizationRoles);
+    yield* orgRepo.insertOne(organization);
+    yield* memberRepo.insertOne(membership);
+    yield* orgRolesRepo.upsertOne(grantResult.organizationRoles);
     yield* bus.dispatch([...orgEvents, ...memberEvents, ...grantResult.events]);
     return id;
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/grant-organization-role.test.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role.test.ts
@@ -43,7 +43,7 @@ describe("grantOrganizationRole", () => {
         }),
       );
 
-      const roles = yield* repo.findByUserIdAndOrgId(targetId, orgId);
+      const roles = yield* repo.findOneByUserIdAndOrgId(targetId, orgId);
       deepStrictEqual(
         roles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
         [{ role: "admin", issuedBy: actorId }],

--- a/packages/server/src/modules/organization/commands/grant-organization-role.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role.ts
@@ -29,9 +29,9 @@ export const grantOrganizationRole = (
     const repo = yield* OrganizationRolesRepository;
     const bus = yield* DomainEventBus;
 
-    const aggregate = yield* repo.findByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+    const aggregate = yield* repo.findOneByUserIdAndOrgId(cmd.userId, cmd.organizationId);
     const result = yield* OrganizationRoles.grantRole(aggregate, cmd.role, cmd.actorUserId);
 
-    yield* repo.save(result.organizationRoles);
+    yield* repo.upsertOne(result.organizationRoles);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/invite-user.test.ts
+++ b/packages/server/src/modules/organization/commands/invite-user.test.ts
@@ -41,7 +41,7 @@ describe("inviteUser", () => {
           actorUserId,
         }),
       );
-      const stored = yield* repo.findById(id);
+      const stored = yield* repo.findOneById(id);
       deepStrictEqual(stored.organizationId, organizationId);
       deepStrictEqual(stored.inviteeEmail, "alice@example.com");
       ok(stored.token.length > 0);
@@ -79,13 +79,13 @@ describe("inviteUser", () => {
         });
 
       const firstId = yield* inviteUser(make());
-      const firstToken = (yield* repo.findById(firstId)).token;
+      const firstToken = (yield* repo.findOneById(firstId)).token;
 
       const secondId = yield* inviteUser(make());
 
       // Same invitation row (dedup), with a rotated token.
       deepStrictEqual(secondId, firstId);
-      const all = yield* repo.findByOrganizationId(organizationId);
+      const all = yield* repo.findManyByOrganizationId(organizationId);
       deepStrictEqual(all.length, 1);
       ok(all[0]?.token !== firstToken, "token should be rotated on reissue");
 

--- a/packages/server/src/modules/organization/commands/invite-user.ts
+++ b/packages/server/src/modules/organization/commands/invite-user.ts
@@ -29,7 +29,7 @@ export const inviteUser = (cmd: InviteUserCommand): InviteUserOutput =>
       // Invite-again-becomes-resend: if an open invite already exists for
       // this (org, email), reissue it (fresh token + expiry) instead of
       // creating a duplicate row, so the pending list stays one-per-email.
-      const existing = yield* repo.findOpenByOrganizationIdAndEmail(
+      const existing = yield* repo.findOneOpenByOrganizationIdAndEmail(
         cmd.organizationId,
         cmd.inviteeEmail,
       );
@@ -43,7 +43,7 @@ export const inviteUser = (cmd: InviteUserCommand): InviteUserOutput =>
         // concurrent delete — a defect, not a caller-visible error (keeps
         // InviteUser's failure channel to PersistenceUnavailable).
         yield* repo
-          .update(result.right.invitation)
+          .updateOne(result.right.invitation)
           .pipe(Effect.catchTag("InvitationNotFound", Effect.die));
         yield* bus.dispatch(result.right.events);
         return existing.id;
@@ -57,7 +57,7 @@ export const inviteUser = (cmd: InviteUserCommand): InviteUserOutput =>
         expiresAt,
         now,
       });
-      yield* repo.insert(invitation);
+      yield* repo.insertOne(invitation);
       yield* bus.dispatch(events);
       return id;
     }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/leave-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/leave-organization.test.ts
@@ -44,7 +44,7 @@ describe("leaveOrganization", () => {
 
       yield* leaveOrganization(LeaveOrganizationCommand.make({ userId, organizationId: orgId }));
 
-      const exit = yield* Effect.exit(memberships.findByUserIdAndOrgId(userId, orgId));
+      const exit = yield* Effect.exit(memberships.findOneByUserIdAndOrgId(userId, orgId));
       deepStrictEqual(Exit.isFailure(exit), true);
 
       const events = yield* rec.byTag<MembershipRevoked>("MembershipRevoked");

--- a/packages/server/src/modules/organization/commands/leave-organization.ts
+++ b/packages/server/src/modules/organization/commands/leave-organization.ts
@@ -13,8 +13,8 @@ export const leaveOrganization = (cmd: LeaveOrganizationCommand): LeaveOrganizat
   Effect.gen(function* () {
     const repo = yield* MembershipRepository;
     const bus = yield* DomainEventBus;
-    const membership = yield* repo.findByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+    const membership = yield* repo.findOneByUserIdAndOrgId(cmd.userId, cmd.organizationId);
     const { events } = Membership.revoke(membership);
-    yield* repo.delete(cmd.userId, cmd.organizationId);
+    yield* repo.deleteOne(cmd.userId, cmd.organizationId);
     yield* bus.dispatch(events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/remove-member.test.ts
+++ b/packages/server/src/modules/organization/commands/remove-member.test.ts
@@ -50,7 +50,7 @@ describe("removeMember", () => {
         organizationId: orgId,
         now: DateTime.unsafeMake(new Date("2026-02-01T00:00:00Z")),
       });
-      yield* memberships.insert(secondMember);
+      yield* memberships.insertOne(secondMember);
 
       yield* removeMember(
         RemoveMemberCommand.make({
@@ -60,7 +60,7 @@ describe("removeMember", () => {
         }),
       );
 
-      const exit = yield* Effect.exit(memberships.findByUserIdAndOrgId(otherUserId, orgId));
+      const exit = yield* Effect.exit(memberships.findOneByUserIdAndOrgId(otherUserId, orgId));
       deepStrictEqual(Exit.isFailure(exit), true);
 
       const events = yield* rec.byTag<MembershipRevoked>("MembershipRevoked");

--- a/packages/server/src/modules/organization/commands/remove-member.ts
+++ b/packages/server/src/modules/organization/commands/remove-member.ts
@@ -13,8 +13,8 @@ export const removeMember = (cmd: RemoveMemberCommand): RemoveMemberOutput =>
   Effect.gen(function* () {
     const repo = yield* MembershipRepository;
     const bus = yield* DomainEventBus;
-    const membership = yield* repo.findByUserIdAndOrgId(cmd.targetUserId, cmd.organizationId);
+    const membership = yield* repo.findOneByUserIdAndOrgId(cmd.targetUserId, cmd.organizationId);
     const { events } = Membership.revoke(membership);
-    yield* repo.delete(cmd.targetUserId, cmd.organizationId);
+    yield* repo.deleteOne(cmd.targetUserId, cmd.organizationId);
     yield* bus.dispatch(events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/resend-invitation.test.ts
+++ b/packages/server/src/modules/organization/commands/resend-invitation.test.ts
@@ -66,11 +66,11 @@ describe("resendInvitation", () => {
       const repo = yield* InvitationRepository;
       const rec = yield* RecordedEvents;
       const sent = yield* SentInvitations;
-      yield* repo.insert(seedInvitation());
+      yield* repo.insertOne(seedInvitation());
 
       yield* resendInvitation(cmd);
 
-      const stored = yield* repo.findById(invitationId);
+      const stored = yield* repo.findOneById(invitationId);
       ok(stored.token !== "tok-original", "token should be rotated");
       ok(DateTime.greaterThan(stored.expiresAt, originalExpiry), "expiry should be pushed out");
       deepStrictEqual(stored.acceptedAt, null);
@@ -94,7 +94,7 @@ describe("resendInvitation", () => {
       const repo = yield* InvitationRepository;
       const revoked = Invitation.revoke(seedInvitation(), { now: issuedAt });
       if (Either.isLeft(revoked)) throw new Error("expected Right");
-      yield* repo.insert(revoked.right.invitation);
+      yield* repo.insertOne(revoked.right.invitation);
 
       const exit = yield* Effect.exit(resendInvitation(cmd));
       deepStrictEqual(Exit.isFailure(exit), true);
@@ -110,7 +110,7 @@ describe("resendInvitation", () => {
       const repo = yield* InvitationRepository;
       const accepted = Invitation.accept(seedInvitation(), { userId: actorUserId, now: issuedAt });
       if (Either.isLeft(accepted)) throw new Error("expected Right");
-      yield* repo.insert(accepted.right.invitation);
+      yield* repo.insertOne(accepted.right.invitation);
 
       const exit = yield* Effect.exit(resendInvitation(cmd));
       deepStrictEqual(Exit.isFailure(exit), true);

--- a/packages/server/src/modules/organization/commands/resend-invitation.ts
+++ b/packages/server/src/modules/organization/commands/resend-invitation.ts
@@ -27,9 +27,9 @@ export const resendInvitation = (cmd: ResendInvitationCommand): ResendInvitation
     const expiresAt = DateTime.add(now, { seconds: cmd.ttlSeconds });
 
     const reissued = yield* Effect.gen(function* () {
-      const invitation = yield* repo.findById(cmd.invitationId);
+      const invitation = yield* repo.findOneById(cmd.invitationId);
       const result = yield* Invitation.reissue(invitation, { token, expiresAt, now });
-      yield* repo.update(result.invitation);
+      yield* repo.updateOne(result.invitation);
       yield* bus.dispatch(result.events);
       return result.invitation;
     }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/restore-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/restore-organization.test.ts
@@ -46,7 +46,7 @@ describe("restoreOrganization", () => {
       );
       yield* softDeleteOrganization(SoftDeleteOrganizationCommand.make({ organizationId: id }));
       yield* restoreOrganization(RestoreOrganizationCommand.make({ organizationId: id }));
-      const stored = yield* repo.findById(id);
+      const stored = yield* repo.findOneById(id);
       deepStrictEqual(stored.deletedAt, null);
       const events = yield* rec.byTag<OrganizationRestored>("OrganizationRestored");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/restore-organization.ts
+++ b/packages/server/src/modules/organization/commands/restore-organization.ts
@@ -16,9 +16,9 @@ export const restoreOrganization = (cmd: RestoreOrganizationCommand): RestoreOrg
     const bus = yield* DomainEventBus;
     const now = yield* DateTime.now;
     // Restore is the one write path that needs to load the tombstoned
-    // row; the default `findById` filters it out.
-    const organization = yield* repo.findByIdIncludingDeleted(cmd.organizationId);
+    // row; the default `findOneById` filters it out.
+    const organization = yield* repo.findOneByIdIncludingDeleted(cmd.organizationId);
     const result = yield* Organization.restore(organization, { now });
-    yield* repo.update(result.organization);
+    yield* repo.updateOne(result.organization);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/revoke-invitation.test.ts
+++ b/packages/server/src/modules/organization/commands/revoke-invitation.test.ts
@@ -47,11 +47,11 @@ describe("revokeInvitation", () => {
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
       const rec = yield* RecordedEvents;
-      yield* repo.insert(seed());
+      yield* repo.insertOne(seed());
 
       yield* revokeInvitation(RevokeInvitationCommand.make({ invitationId, actorUserId }));
 
-      const updated = yield* repo.findById(invitationId);
+      const updated = yield* repo.findOneById(invitationId);
       deepStrictEqual(updated.revokedAt !== null, true);
 
       const events = yield* rec.byTag<InvitationRevoked>("InvitationRevoked");
@@ -80,7 +80,7 @@ describe("revokeInvitation", () => {
       const repo = yield* InvitationRepository;
       const accepted = Invitation.accept(seed(), { userId, now });
       if (Either.isLeft(accepted)) throw new Error("expected Right");
-      yield* repo.insert(accepted.right.invitation);
+      yield* repo.insertOne(accepted.right.invitation);
 
       const exit = yield* Effect.exit(
         revokeInvitation(RevokeInvitationCommand.make({ invitationId, actorUserId })),
@@ -98,7 +98,7 @@ describe("revokeInvitation", () => {
       const repo = yield* InvitationRepository;
       const revoked = Invitation.revoke(seed(), { now });
       if (Either.isLeft(revoked)) throw new Error("expected Right");
-      yield* repo.insert(revoked.right.invitation);
+      yield* repo.insertOne(revoked.right.invitation);
 
       const exit = yield* Effect.exit(
         revokeInvitation(RevokeInvitationCommand.make({ invitationId, actorUserId })),

--- a/packages/server/src/modules/organization/commands/revoke-invitation.ts
+++ b/packages/server/src/modules/organization/commands/revoke-invitation.ts
@@ -15,8 +15,8 @@ export const revokeInvitation = (cmd: RevokeInvitationCommand): RevokeInvitation
     const repo = yield* InvitationRepository;
     const bus = yield* DomainEventBus;
     const now = yield* DateTime.now;
-    const invitation = yield* repo.findById(cmd.invitationId);
+    const invitation = yield* repo.findOneById(cmd.invitationId);
     const result = yield* Invitation.revoke(invitation, { now });
-    yield* repo.update(result.invitation);
+    yield* repo.updateOne(result.invitation);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/revoke-organization-role.test.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role.test.ts
@@ -50,7 +50,7 @@ describe("revokeOrganizationRole", () => {
         }),
       );
 
-      const roles = yield* repo.findByUserIdAndOrgId(targetId, orgId);
+      const roles = yield* repo.findOneByUserIdAndOrgId(targetId, orgId);
       deepStrictEqual([...roles.roles], []);
 
       const events = yield* rec.byTag<OrganizationRoleRevoked>("OrganizationRoleRevoked");

--- a/packages/server/src/modules/organization/commands/revoke-organization-role.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role.ts
@@ -16,9 +16,9 @@ export const revokeOrganizationRole = (
     const repo = yield* OrganizationRolesRepository;
     const bus = yield* DomainEventBus;
 
-    const aggregate = yield* repo.findByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+    const aggregate = yield* repo.findOneByUserIdAndOrgId(cmd.userId, cmd.organizationId);
     const result = yield* OrganizationRoles.revokeRole(aggregate, cmd.role);
 
-    yield* repo.save(result.organizationRoles);
+    yield* repo.upsertOne(result.organizationRoles);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/commands/soft-delete-organization.test.ts
+++ b/packages/server/src/modules/organization/commands/soft-delete-organization.test.ts
@@ -40,7 +40,7 @@ describe("softDeleteOrganization", () => {
         CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
       );
       yield* softDeleteOrganization(SoftDeleteOrganizationCommand.make({ organizationId: id }));
-      const stored = yield* repo.findByIdIncludingDeleted(id);
+      const stored = yield* repo.findOneByIdIncludingDeleted(id);
       deepStrictEqual(stored.deletedAt !== null, true);
       const events = yield* rec.byTag<OrganizationSoftDeleted>("OrganizationSoftDeleted");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/soft-delete-organization.ts
+++ b/packages/server/src/modules/organization/commands/soft-delete-organization.ts
@@ -17,14 +17,14 @@ export const softDeleteOrganization = (
     const repo = yield* OrganizationRepository;
     const bus = yield* DomainEventBus;
     const now = yield* DateTime.now;
-    // `findById` filters out tombstoned rows; if the org is already
+    // `findOneById` filters out tombstoned rows; if the org is already
     // soft-deleted the use case returns the same `OrganizationNotFound`
     // a missing org would — same outward contract, simpler invariant
     // surface. The aggregate's `OrganizationAlreadyDeleted` covers the
     // race where two concurrent soft-deletes both observe the row as
     // active and then race the update.
-    const organization = yield* repo.findById(cmd.organizationId);
+    const organization = yield* repo.findOneById(cmd.organizationId);
     const result = yield* Organization.softDelete(organization, { now });
-    yield* repo.update(result.organization);
+    yield* repo.updateOne(result.organization);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/organization/domain/organization-roles.aggregate.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles.aggregate.ts
@@ -42,7 +42,7 @@ export type Result = {
 };
 
 // Factory for the "no roles yet" case — used by the command handler
-// when the repo's `findByUserIdAndOrgId` returns nothing.
+// when the repo's `findOneByUserIdAndOrgId` returns nothing.
 export const empty = (userId: UserId, organizationId: OrganizationId): OrganizationRoles =>
   OrganizationRoles.make({ userId, organizationId, roles: [] });
 

--- a/packages/server/src/modules/organization/domain/ports/repositories/invitation-repository.ts
+++ b/packages/server/src/modules/organization/domain/ports/repositories/invitation-repository.ts
@@ -19,29 +19,31 @@ import { type OrganizationId } from "@/platform/ids/organization-id.js";
 // InvitationNotFound when the row is missing (likely a concurrent
 // delete; commands treat this as a 404).
 //
-// `findByToken` is the read path for the anonymous accept endpoint
+// `findOneByToken` is the read path for the anonymous accept endpoint
 // (the caller doesn't know the invitation id, only the token).
 //
-// `findByOrganizationId` backs the pending-invitations list (the handler
-// filters/derives status). `findOpenByOrganizationIdAndEmail` backs the
-// invite-again-becomes-resend dedup: at most one open invite per
-// (org, email) once dedup is in force; returns the most recent open one
-// (or null) so the command can reissue instead of creating a duplicate.
+// `findManyByOrganizationId` backs the pending-invitations list (the handler
+// filters/derives status). `findOneOpenByOrganizationIdAndEmail` backs the
+// invite-again-becomes-resend dedup: the `Open` qualifier (ADR-0024 permits a
+// qualifier in front of the `By<Key>` clause) says it returns only the OPEN
+// invitation — at most one open invite per (org, email) once dedup is in force —
+// i.e. the most recent open one (or null), so the command can reissue instead
+// of creating a duplicate.
 export type InvitationRepositoryShape = {
-  readonly insert: (invitation: Invitation) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly update: (
+  readonly insertOne: (invitation: Invitation) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly updateOne: (
     invitation: Invitation,
   ) => Effect.Effect<void, InvitationNotFound | PersistenceUnavailable>;
-  readonly findById: (
+  readonly findOneById: (
     id: InvitationId,
   ) => Effect.Effect<Invitation, InvitationNotFound | PersistenceUnavailable>;
-  readonly findByToken: (
+  readonly findOneByToken: (
     token: string,
   ) => Effect.Effect<Invitation, InvitationTokenNotFound | PersistenceUnavailable>;
-  readonly findByOrganizationId: (
+  readonly findManyByOrganizationId: (
     organizationId: OrganizationId,
   ) => Effect.Effect<ReadonlyArray<Invitation>, PersistenceUnavailable>;
-  readonly findOpenByOrganizationIdAndEmail: (
+  readonly findOneOpenByOrganizationIdAndEmail: (
     organizationId: OrganizationId,
     inviteeEmail: string,
   ) => Effect.Effect<Invitation | null, PersistenceUnavailable>;

--- a/packages/server/src/modules/organization/domain/ports/repositories/membership-repository.ts
+++ b/packages/server/src/modules/organization/domain/ports/repositories/membership-repository.ts
@@ -16,16 +16,16 @@ import { type UserId } from "@/platform/ids/user-id.js";
 // — `RemoveMember`/`LeaveOrganization` rely on that to surface a 404 to
 // callers asking to remove a non-existent member.
 export type MembershipRepositoryShape = {
-  readonly insert: (membership: Membership) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly delete: (
+  readonly insertOne: (membership: Membership) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly deleteOne: (
     userId: UserId,
     organizationId: OrganizationId,
   ) => Effect.Effect<void, MembershipNotFound | PersistenceUnavailable>;
-  readonly findByUserIdAndOrgId: (
+  readonly findOneByUserIdAndOrgId: (
     userId: UserId,
     organizationId: OrganizationId,
   ) => Effect.Effect<Membership, MembershipNotFound | PersistenceUnavailable>;
-  readonly findByOrganizationId: (
+  readonly findManyByOrganizationId: (
     organizationId: OrganizationId,
   ) => Effect.Effect<ReadonlyArray<Membership>, PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/organization/domain/ports/repositories/organization-repository.ts
+++ b/packages/server/src/modules/organization/domain/ports/repositories/organization-repository.ts
@@ -6,8 +6,8 @@ import { type OrganizationNotFound } from "@/modules/organization/domain/organiz
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
-// Single-aggregate persistence port. `findById` filters out soft-deleted
-// rows by default; `findByIdIncludingDeleted` is the explicit opt-in for
+// Single-aggregate persistence port. `findOneById` filters out soft-deleted
+// rows by default; `findOneByIdIncludingDeleted` is the explicit opt-in for
 // the restore code path (the resource resolver registered for the
 // `organization` resource uses this so policy checks can see deleted
 // orgs without callers having to maintain two `resource` keys).
@@ -15,14 +15,14 @@ import { type OrganizationId } from "@/platform/ids/organization-id.js";
 // `update` covers both write paths (rename + soft-delete + restore) —
 // the aggregate produces the new state and the repo just persists.
 export type OrganizationRepositoryShape = {
-  readonly insert: (organization: Organization) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly update: (
+  readonly insertOne: (organization: Organization) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly updateOne: (
     organization: Organization,
   ) => Effect.Effect<void, OrganizationNotFound | PersistenceUnavailable>;
-  readonly findById: (
+  readonly findOneById: (
     id: OrganizationId,
   ) => Effect.Effect<Organization, OrganizationNotFound | PersistenceUnavailable>;
-  readonly findByIdIncludingDeleted: (
+  readonly findOneByIdIncludingDeleted: (
     id: OrganizationId,
   ) => Effect.Effect<Organization, OrganizationNotFound | PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/organization/domain/ports/repositories/organization-roles-repository.ts
+++ b/packages/server/src/modules/organization/domain/ports/repositories/organization-roles-repository.ts
@@ -10,14 +10,14 @@ import { type UserId } from "@/platform/ids/user-id.js";
 // (uniqueness, "revoke only what's held"); the repository only knows
 // how to save and fetch the resulting state.
 //
-// `findByUserIdAndOrgId` returns an empty `OrganizationRoles` aggregate
+// `findOneByUserIdAndOrgId` returns an empty `OrganizationRoles` aggregate
 // if no rows are stored — the absence of any rows is a valid "no roles
 // yet" state, not a NotFound condition. Mirrors `RolesRepository`.
 export type OrganizationRolesRepositoryShape = {
-  readonly save: (
+  readonly upsertOne: (
     organizationRoles: OrganizationRoles,
   ) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findByUserIdAndOrgId: (
+  readonly findOneByUserIdAndOrgId: (
     userId: UserId,
     organizationId: OrganizationId,
   ) => Effect.Effect<OrganizationRoles, PersistenceUnavailable>;

--- a/packages/server/src/modules/organization/infrastructure/invitation-repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/invitation-repository-fake.test.ts
@@ -36,29 +36,29 @@ const seed = (): Invitation.Invitation =>
 const provide = Effect.provide(InvitationRepositoryFake);
 
 describe("InvitationRepositoryFake", () => {
-  it.effect("findById round-trips an inserted invitation", () =>
+  it.effect("findOneById round-trips an inserted invitation", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      yield* repo.insert(seed());
-      const found = yield* repo.findById(invitationId);
+      yield* repo.insertOne(seed());
+      const found = yield* repo.findOneById(invitationId);
       deepStrictEqual(found.id, invitationId);
       deepStrictEqual(found.token, "tok-abc");
     }).pipe(provide),
   );
 
-  it.effect("findByToken returns the matching invitation", () =>
+  it.effect("findOneByToken returns the matching invitation", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      yield* repo.insert(seed());
-      const found = yield* repo.findByToken("tok-abc");
+      yield* repo.insertOne(seed());
+      const found = yield* repo.findOneByToken("tok-abc");
       deepStrictEqual(found.id, invitationId);
     }).pipe(provide),
   );
 
-  it.effect("findById fails InvitationNotFound when absent", () =>
+  it.effect("findOneById fails InvitationNotFound when absent", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      const exit = yield* Effect.exit(repo.findById(invitationId));
+      const exit = yield* Effect.exit(repo.findOneById(invitationId));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -67,10 +67,10 @@ describe("InvitationRepositoryFake", () => {
     }).pipe(provide),
   );
 
-  it.effect("findByToken fails InvitationTokenNotFound when no row matches", () =>
+  it.effect("findOneByToken fails InvitationTokenNotFound when no row matches", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      const exit = yield* Effect.exit(repo.findByToken("missing"));
+      const exit = yield* Effect.exit(repo.findOneByToken("missing"));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -82,11 +82,11 @@ describe("InvitationRepositoryFake", () => {
   it.effect("update persists state transitions", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      yield* repo.insert(seed());
+      yield* repo.insertOne(seed());
       const accepted = Invitation.accept(seed(), { userId, now });
       if (Either.isLeft(accepted)) throw new Error("expected Right");
-      yield* repo.update(accepted.right.invitation);
-      const found = yield* repo.findById(invitationId);
+      yield* repo.updateOne(accepted.right.invitation);
+      const found = yield* repo.findOneById(invitationId);
       deepStrictEqual(found.acceptedAt !== null, true);
     }).pipe(provide),
   );
@@ -94,7 +94,7 @@ describe("InvitationRepositoryFake", () => {
   it.effect("update fails InvitationNotFound when the row is missing", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      const exit = yield* Effect.exit(repo.update(seed()));
+      const exit = yield* Effect.exit(repo.updateOne(seed()));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/organization/infrastructure/invitation-repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/invitation-repository-fake.ts
@@ -18,17 +18,17 @@ export const InvitationRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<InvitationId, Invitation>());
 
-    const insert = (invitation: Invitation): Effect.Effect<void> =>
+    const insertOne = (invitation: Invitation): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(invitation.id, invitation));
 
-    const update = (invitation: Invitation): Effect.Effect<void, InvitationNotFound> =>
+    const updateOne = (invitation: Invitation): Effect.Effect<void, InvitationNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         HashMap.has(m, invitation.id)
           ? Ref.update(store, HashMap.set(invitation.id, invitation))
           : Effect.fail(new InvitationNotFound({ invitationId: invitation.id })),
       );
 
-    const findById = (id: InvitationId): Effect.Effect<Invitation, InvitationNotFound> =>
+    const findOneById = (id: InvitationId): Effect.Effect<Invitation, InvitationNotFound> =>
       Effect.flatMap(Ref.get(store), (m) => {
         const found = HashMap.get(m, id);
         return found._tag === "Some"
@@ -36,7 +36,7 @@ export const InvitationRepositoryFake = Layer.effect(
           : Effect.fail(new InvitationNotFound({ invitationId: id }));
       });
 
-    const findByToken = (token: string): Effect.Effect<Invitation, InvitationTokenNotFound> =>
+    const findOneByToken = (token: string): Effect.Effect<Invitation, InvitationTokenNotFound> =>
       Effect.flatMap(Ref.get(store), (m) => {
         for (const inv of HashMap.values(m)) {
           if (inv.token === token) return Effect.succeed(inv);
@@ -48,7 +48,7 @@ export const InvitationRepositoryFake = Layer.effect(
     const byCreatedAtDesc = (a: Invitation, b: Invitation): number =>
       DateTime.toEpochMillis(b.createdAt) - DateTime.toEpochMillis(a.createdAt);
 
-    const findByOrganizationId = (
+    const findManyByOrganizationId = (
       organizationId: OrganizationId,
     ): Effect.Effect<ReadonlyArray<Invitation>> =>
       Effect.map(Ref.get(store), (m) =>
@@ -57,7 +57,7 @@ export const InvitationRepositoryFake = Layer.effect(
           .sort(byCreatedAtDesc),
       );
 
-    const findOpenByOrganizationIdAndEmail = (
+    const findOneOpenByOrganizationIdAndEmail = (
       organizationId: OrganizationId,
       inviteeEmail: string,
     ): Effect.Effect<Invitation | null> =>
@@ -74,12 +74,12 @@ export const InvitationRepositoryFake = Layer.effect(
       });
 
     return InvitationRepository.of({
-      insert,
-      update,
-      findById,
-      findByToken,
-      findByOrganizationId,
-      findOpenByOrganizationIdAndEmail,
+      insertOne,
+      updateOne,
+      findOneById,
+      findOneByToken,
+      findManyByOrganizationId,
+      findOneOpenByOrganizationIdAndEmail,
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/invitation-repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/invitation-repository-live.integration.test.ts
@@ -63,24 +63,24 @@ suite("InvitationRepositoryLive (integration)", () => {
     );
   });
 
-  describe("insert + findById + findByToken", () => {
+  describe("insert + findOneById + findOneByToken", () => {
     it.effect("round-trips an inserted invitation by id and by token", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
-        const byId = yield* repo.findById(invitationId);
+        yield* repo.insertOne(seed());
+        const byId = yield* repo.findOneById(invitationId);
         deepStrictEqual(byId.id, invitationId);
-        const byToken = yield* repo.findByToken("tok-abc");
+        const byToken = yield* repo.findOneByToken("tok-abc");
         deepStrictEqual(byToken.id, invitationId);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findById fails InvitationNotFound for an unknown id", () =>
+    it.effect("findOneById fails InvitationNotFound for an unknown id", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        const exit = yield* Effect.exit(repo.findById(invitationId));
+        const exit = yield* Effect.exit(repo.findOneById(invitationId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -89,11 +89,11 @@ suite("InvitationRepositoryLive (integration)", () => {
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findByToken fails InvitationTokenNotFound for an unknown token", () =>
+    it.effect("findOneByToken fails InvitationTokenNotFound for an unknown token", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        const exit = yield* Effect.exit(repo.findByToken("missing"));
+        const exit = yield* Effect.exit(repo.findOneByToken("missing"));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -108,11 +108,11 @@ suite("InvitationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
+        yield* repo.insertOne(seed());
         const accepted = Invitation.accept(seed(), { userId, now });
         if (Either.isLeft(accepted)) throw new Error("expected Right");
-        yield* repo.update(accepted.right.invitation);
-        const found = yield* repo.findById(invitationId);
+        yield* repo.updateOne(accepted.right.invitation);
+        const found = yield* repo.findOneById(invitationId);
         deepStrictEqual(found.acceptedAt !== null, true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -121,7 +121,7 @@ suite("InvitationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
+        yield* repo.insertOne(seed());
         const newExpiresAt = DateTime.unsafeMake(new Date("2026-02-01T00:00:00Z"));
         const reissued = Invitation.reissue(seed(), {
           token: "tok-rotated",
@@ -129,10 +129,10 @@ suite("InvitationRepositoryLive (integration)", () => {
           now,
         });
         if (Either.isLeft(reissued)) throw new Error("expected Right");
-        yield* repo.update(reissued.right.invitation);
+        yield* repo.updateOne(reissued.right.invitation);
 
         // The new token must resolve...
-        const byNew = yield* repo.findByToken("tok-rotated");
+        const byNew = yield* repo.findOneByToken("tok-rotated");
         deepStrictEqual(byNew.id, invitationId);
         deepStrictEqual(
           DateTime.toEpochMillis(byNew.expiresAt),
@@ -140,7 +140,7 @@ suite("InvitationRepositoryLive (integration)", () => {
         );
 
         // ...and the old token must no longer resolve.
-        const exit = yield* Effect.exit(repo.findByToken("tok-abc"));
+        const exit = yield* Effect.exit(repo.findOneByToken("tok-abc"));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -153,7 +153,7 @@ suite("InvitationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        const exit = yield* Effect.exit(repo.update(seed()));
+        const exit = yield* Effect.exit(repo.updateOne(seed()));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -163,14 +163,14 @@ suite("InvitationRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findByOrganizationId", () => {
+  describe("findManyByOrganizationId", () => {
     const secondId = InvitationId.make("44444444-4444-4444-4444-444444444445");
 
     it.effect("returns all invitations for the org, newest first", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
+        yield* repo.insertOne(seed());
         const later = Invitation.issue({
           id: secondId,
           organizationId: orgId,
@@ -179,8 +179,8 @@ suite("InvitationRepositoryLive (integration)", () => {
           expiresAt,
           now: DateTime.unsafeMake(new Date("2026-01-02T00:00:00Z")),
         }).invitation;
-        yield* repo.insert(later);
-        const all = yield* repo.findByOrganizationId(orgId);
+        yield* repo.insertOne(later);
+        const all = yield* repo.findManyByOrganizationId(orgId);
         deepStrictEqual(all.length, 2);
         // ORDER BY created_at DESC → bob (later) first.
         deepStrictEqual(all[0]?.id, secondId);
@@ -192,19 +192,19 @@ suite("InvitationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        const all = yield* repo.findByOrganizationId(orgId);
+        const all = yield* repo.findManyByOrganizationId(orgId);
         deepStrictEqual(all.length, 0);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
 
-  describe("findOpenByOrganizationIdAndEmail", () => {
+  describe("findOneOpenByOrganizationIdAndEmail", () => {
     it.effect("finds an open invitation by (org, email)", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
-        const found = yield* repo.findOpenByOrganizationIdAndEmail(orgId, "alice@example.com");
+        yield* repo.insertOne(seed());
+        const found = yield* repo.findOneOpenByOrganizationIdAndEmail(orgId, "alice@example.com");
         deepStrictEqual(found?.id, invitationId);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -213,11 +213,11 @@ suite("InvitationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
+        yield* repo.insertOne(seed());
         const revoked = Invitation.revoke(seed(), { now });
         if (Either.isLeft(revoked)) throw new Error("expected Right");
-        yield* repo.update(revoked.right.invitation);
-        const found = yield* repo.findOpenByOrganizationIdAndEmail(orgId, "alice@example.com");
+        yield* repo.updateOne(revoked.right.invitation);
+        const found = yield* repo.findOneOpenByOrganizationIdAndEmail(orgId, "alice@example.com");
         deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -226,8 +226,8 @@ suite("InvitationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        yield* repo.insert(seed());
-        const found = yield* repo.findOpenByOrganizationIdAndEmail(orgId, "nobody@example.com");
+        yield* repo.insertOne(seed());
+        const found = yield* repo.findOneOpenByOrganizationIdAndEmail(orgId, "nobody@example.com");
         deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/organization/infrastructure/invitation-repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/invitation-repository-live.ts
@@ -18,7 +18,7 @@ export const InvitationRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, invitation: Invitation) => {
+    const insertOne = db.makeQuery((execute, invitation: Invitation) => {
       const row = InvitationMapper.toPersistence(invitation);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -41,11 +41,11 @@ export const InvitationRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.insert"),
+        Effect.withSpan("InvitationRepository.insertOne"),
       );
     });
 
-    const update = db.makeQuery((execute, invitation: Invitation) => {
+    const updateOne = db.makeQuery((execute, invitation: Invitation) => {
       const row = InvitationMapper.toPersistence(invitation);
       return execute((client) =>
         // Persist the whole mutable aggregate, not a hand-picked subset.
@@ -67,11 +67,11 @@ export const InvitationRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.update"),
+        Effect.withSpan("InvitationRepository.updateOne"),
       );
     });
 
-    const findById = db.makeQuery((execute, id: InvitationId) =>
+    const findOneById = db.makeQuery((execute, id: InvitationId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.InvitationRowStd)`
           SELECT * FROM "organization".invitations WHERE id = ${id}
@@ -81,11 +81,11 @@ export const InvitationRepositoryLive = Layer.effect(
         Effect.map(InvitationMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.findById"),
+        Effect.withSpan("InvitationRepository.findOneById"),
       ),
     );
 
-    const findByToken = db.makeQuery((execute, token: string) =>
+    const findOneByToken = db.makeQuery((execute, token: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.InvitationRowStd)`
           SELECT * FROM "organization".invitations WHERE token = ${token}
@@ -95,11 +95,11 @@ export const InvitationRepositoryLive = Layer.effect(
         Effect.map(InvitationMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.findByToken"),
+        Effect.withSpan("InvitationRepository.findOneByToken"),
       ),
     );
 
-    const findByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
+    const findManyByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
       execute((client) =>
         client.any(sql.type(RowSchemas.InvitationRowStd)`
           SELECT * FROM "organization".invitations
@@ -110,11 +110,11 @@ export const InvitationRepositoryLive = Layer.effect(
         Effect.map((rows) => rows.map(InvitationMapper.toDomain)),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.findByOrganizationId"),
+        Effect.withSpan("InvitationRepository.findManyByOrganizationId"),
       ),
     );
 
-    const findOpenByOrganizationIdAndEmail = db.makeQuery(
+    const findOneOpenByOrganizationIdAndEmail = db.makeQuery(
       (execute, args: { organizationId: OrganizationId; inviteeEmail: string }) =>
         execute((client) =>
           client.maybeOne(sql.type(RowSchemas.InvitationRowStd)`
@@ -130,18 +130,18 @@ export const InvitationRepositoryLive = Layer.effect(
           Effect.map((row) => (row === null ? null : InvitationMapper.toDomain(row))),
           Effect.catchTag("DatabaseError", Effect.die),
           translatePersistenceUnavailable,
-          Effect.withSpan("InvitationRepository.findOpenByOrganizationIdAndEmail"),
+          Effect.withSpan("InvitationRepository.findOneOpenByOrganizationIdAndEmail"),
         ),
     );
 
     return InvitationRepository.of({
-      insert,
-      update,
-      findById,
-      findByToken,
-      findByOrganizationId,
-      findOpenByOrganizationIdAndEmail: (organizationId, inviteeEmail) =>
-        findOpenByOrganizationIdAndEmail({ organizationId, inviteeEmail }),
+      insertOne,
+      updateOne,
+      findOneById,
+      findOneByToken,
+      findManyByOrganizationId,
+      findOneOpenByOrganizationIdAndEmail: (organizationId, inviteeEmail) =>
+        findOneOpenByOrganizationIdAndEmail({ organizationId, inviteeEmail }),
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/membership-repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/membership-repository-fake.test.ts
@@ -19,12 +19,12 @@ const now = DateTime.unsafeMake(new Date("2026-01-01T00:00:00Z"));
 const provide = Effect.provide(MembershipRepositoryFake);
 
 describe("MembershipRepositoryFake", () => {
-  it.effect("findByUserIdAndOrgId round-trips an inserted membership", () =>
+  it.effect("findOneByUserIdAndOrgId round-trips an inserted membership", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = Membership.create({ userId, organizationId, now });
-      yield* repo.insert(membership);
-      const found = yield* repo.findByUserIdAndOrgId(userId, organizationId);
+      yield* repo.insertOne(membership);
+      const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.organizationId, organizationId);
     }).pipe(provide),
@@ -34,17 +34,17 @@ describe("MembershipRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = Membership.create({ userId, organizationId, now });
-      yield* repo.insert(membership);
-      yield* repo.insert(membership);
-      const found = yield* repo.findByUserIdAndOrgId(userId, organizationId);
+      yield* repo.insertOne(membership);
+      yield* repo.insertOne(membership);
+      const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
       deepStrictEqual(found.userId, userId);
     }).pipe(provide),
   );
 
-  it.effect("findByUserIdAndOrgId fails MembershipNotFound when absent", () =>
+  it.effect("findOneByUserIdAndOrgId fails MembershipNotFound when absent", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
-      const exit = yield* Effect.exit(repo.findByUserIdAndOrgId(userId, organizationId));
+      const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(userId, organizationId));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -57,9 +57,9 @@ describe("MembershipRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = Membership.create({ userId, organizationId, now });
-      yield* repo.insert(membership);
-      yield* repo.delete(userId, organizationId);
-      const exit = yield* Effect.exit(repo.findByUserIdAndOrgId(userId, organizationId));
+      yield* repo.insertOne(membership);
+      yield* repo.deleteOne(userId, organizationId);
+      const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(userId, organizationId));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(provide),
   );
@@ -67,7 +67,7 @@ describe("MembershipRepositoryFake", () => {
   it.effect("delete fails MembershipNotFound when no row exists", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
-      const exit = yield* Effect.exit(repo.delete(userId, organizationId));
+      const exit = yield* Effect.exit(repo.deleteOne(userId, organizationId));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -80,8 +80,8 @@ describe("MembershipRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = Membership.create({ userId, organizationId, now });
-      yield* repo.insert(membership);
-      const exit = yield* Effect.exit(repo.findByUserIdAndOrgId(otherUserId, organizationId));
+      yield* repo.insertOne(membership);
+      const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(otherUserId, organizationId));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/organization/infrastructure/membership-repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/membership-repository-fake.ts
@@ -20,7 +20,7 @@ export const MembershipRepositoryFake = Layer.effect(
     const store = yield* Ref.make(HashMap.empty<string, Membership>());
 
     // Idempotent — mirrors the Live's ON CONFLICT DO NOTHING.
-    const insert = (membership: Membership): Effect.Effect<void> =>
+    const insertOne = (membership: Membership): Effect.Effect<void> =>
       Ref.update(store, (m) => {
         const k = key(membership.userId, membership.organizationId);
         return HashMap.has(m, k) ? m : HashMap.set(m, k, membership);
@@ -38,7 +38,7 @@ export const MembershipRepositoryFake = Layer.effect(
         return Ref.update(store, HashMap.remove(k));
       });
 
-    const findByUserIdAndOrgId = (
+    const findOneByUserIdAndOrgId = (
       userId: UserId,
       organizationId: OrganizationId,
     ): Effect.Effect<Membership, MembershipNotFound> =>
@@ -49,7 +49,7 @@ export const MembershipRepositoryFake = Layer.effect(
           : Effect.fail(new MembershipNotFound({ userId, organizationId }));
       });
 
-    const findByOrganizationId = (
+    const findManyByOrganizationId = (
       organizationId: OrganizationId,
     ): Effect.Effect<ReadonlyArray<Membership>> =>
       Effect.map(Ref.get(store), (m) =>
@@ -57,10 +57,10 @@ export const MembershipRepositoryFake = Layer.effect(
       );
 
     return MembershipRepository.of({
-      insert,
-      delete: deleteRow,
-      findByUserIdAndOrgId,
-      findByOrganizationId,
+      insertOne,
+      deleteOne: deleteRow,
+      findOneByUserIdAndOrgId,
+      findManyByOrganizationId,
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/membership-repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/membership-repository-live.integration.test.ts
@@ -57,14 +57,14 @@ suite("MembershipRepositoryLive (integration)", () => {
     );
   });
 
-  describe("insert + findByUserIdAndOrgId", () => {
+  describe("insert + findOneByUserIdAndOrgId", () => {
     it.effect("round-trips an inserted membership", () =>
       Effect.gen(function* () {
         yield* seedFks;
         const repo = yield* MembershipRepository;
         const { membership } = Membership.create({ userId, organizationId, now });
-        yield* repo.insert(membership);
-        const found = yield* repo.findByUserIdAndOrgId(userId, organizationId);
+        yield* repo.insertOne(membership);
+        const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
         deepStrictEqual(found.userId, userId);
         deepStrictEqual(found.organizationId, organizationId);
       }).pipe(Effect.provide(TestLayer)),
@@ -75,18 +75,18 @@ suite("MembershipRepositoryLive (integration)", () => {
         yield* seedFks;
         const repo = yield* MembershipRepository;
         const { membership } = Membership.create({ userId, organizationId, now });
-        yield* repo.insert(membership);
-        yield* repo.insert(membership);
-        const found = yield* repo.findByUserIdAndOrgId(userId, organizationId);
+        yield* repo.insertOne(membership);
+        yield* repo.insertOne(membership);
+        const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
         deepStrictEqual(found.userId, userId);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findByUserIdAndOrgId fails MembershipNotFound for an unknown pair", () =>
+    it.effect("findOneByUserIdAndOrgId fails MembershipNotFound for an unknown pair", () =>
       Effect.gen(function* () {
         yield* seedFks;
         const repo = yield* MembershipRepository;
-        const exit = yield* Effect.exit(repo.findByUserIdAndOrgId(otherUserId, organizationId));
+        const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(otherUserId, organizationId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -102,9 +102,9 @@ suite("MembershipRepositoryLive (integration)", () => {
         yield* seedFks;
         const repo = yield* MembershipRepository;
         const { membership } = Membership.create({ userId, organizationId, now });
-        yield* repo.insert(membership);
-        yield* repo.delete(userId, organizationId);
-        const exit = yield* Effect.exit(repo.findByUserIdAndOrgId(userId, organizationId));
+        yield* repo.insertOne(membership);
+        yield* repo.deleteOne(userId, organizationId);
+        const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(userId, organizationId));
         deepStrictEqual(Exit.isFailure(exit), true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -113,7 +113,7 @@ suite("MembershipRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedFks;
         const repo = yield* MembershipRepository;
-        const exit = yield* Effect.exit(repo.delete(userId, organizationId));
+        const exit = yield* Effect.exit(repo.deleteOne(userId, organizationId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/organization/infrastructure/membership-repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/membership-repository-live.ts
@@ -18,7 +18,7 @@ export const MembershipRepositoryLive = Layer.effect(
     // Idempotent: re-driving a create for an existing (userId, orgId)
     // pair is a no-op (PK conflict ignored). Lets upstream commands
     // treat membership creation as safe to retry.
-    const insert = db.makeQuery((execute, membership: Membership) => {
+    const insertOne = db.makeQuery((execute, membership: Membership) => {
       const row = MembershipMapper.toPersistence(membership);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -34,7 +34,7 @@ export const MembershipRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("MembershipRepository.insert"),
+        Effect.withSpan("MembershipRepository.insertOne"),
       );
     });
 
@@ -61,11 +61,11 @@ export const MembershipRepositoryLive = Layer.effect(
           ),
           Effect.catchTag("DatabaseError", Effect.die),
           translatePersistenceUnavailable,
-          Effect.withSpan("MembershipRepository.delete"),
+          Effect.withSpan("MembershipRepository.deleteOne"),
         ),
     );
 
-    const findByUserIdAndOrgId = db.makeQuery(
+    const findOneByUserIdAndOrgId = db.makeQuery(
       (execute, args: { userId: UserId; organizationId: OrganizationId }) =>
         execute((client) =>
           client.maybeOne(sql.type(RowSchemas.MembershipRowStd)`
@@ -86,31 +86,32 @@ export const MembershipRepositoryLive = Layer.effect(
           ),
           Effect.catchTag("DatabaseError", Effect.die),
           translatePersistenceUnavailable,
-          Effect.withSpan("MembershipRepository.findByUserIdAndOrgId"),
+          Effect.withSpan("MembershipRepository.findOneByUserIdAndOrgId"),
         ),
     );
 
-    const findByOrganizationId = db.makeQuery((execute, args: { organizationId: OrganizationId }) =>
-      execute((client) =>
-        client.any(sql.type(RowSchemas.MembershipRowStd)`
+    const findManyByOrganizationId = db.makeQuery(
+      (execute, args: { organizationId: OrganizationId }) =>
+        execute((client) =>
+          client.any(sql.type(RowSchemas.MembershipRowStd)`
             SELECT * FROM "organization".memberships
             WHERE organization_id = ${args.organizationId}
             ORDER BY created_at ASC
           `),
-      ).pipe(
-        Effect.map((rows) => rows.map(MembershipMapper.toDomain)),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("MembershipRepository.findByOrganizationId"),
-      ),
+        ).pipe(
+          Effect.map((rows) => rows.map(MembershipMapper.toDomain)),
+          Effect.catchTag("DatabaseError", Effect.die),
+          translatePersistenceUnavailable,
+          Effect.withSpan("MembershipRepository.findManyByOrganizationId"),
+        ),
     );
 
     return MembershipRepository.of({
-      insert,
-      delete: (userId, organizationId) => deleteRow({ userId, organizationId }),
-      findByUserIdAndOrgId: (userId, organizationId) =>
-        findByUserIdAndOrgId({ userId, organizationId }),
-      findByOrganizationId: (organizationId) => findByOrganizationId({ organizationId }),
+      insertOne,
+      deleteOne: (userId, organizationId) => deleteRow({ userId, organizationId }),
+      findOneByUserIdAndOrgId: (userId, organizationId) =>
+        findOneByUserIdAndOrgId({ userId, organizationId }),
+      findManyByOrganizationId: (organizationId) => findManyByOrganizationId({ organizationId }),
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/organization-repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-repository-fake.test.ts
@@ -18,26 +18,26 @@ const later = DateTime.unsafeMake(new Date("2026-02-01T00:00:00Z"));
 const provide = Effect.provide(OrganizationRepositoryFake);
 
 describe("OrganizationRepositoryFake", () => {
-  it.effect("findById round-trips an inserted org", () =>
+  it.effect("findOneById round-trips an inserted org", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = Organization.create({ id, name: "Acme", now });
-      yield* repo.insert(organization);
-      const found = yield* repo.findById(id);
+      yield* repo.insertOne(organization);
+      const found = yield* repo.findOneById(id);
       deepStrictEqual(found.id, id);
       deepStrictEqual(found.name, "Acme");
     }).pipe(provide),
   );
 
-  it.effect("findById hides soft-deleted rows", () =>
+  it.effect("findOneById hides soft-deleted rows", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = Organization.create({ id, name: "Acme", now });
-      yield* repo.insert(organization);
+      yield* repo.insertOne(organization);
       const deletedEither = Organization.softDelete(organization, { now: later });
       if (Either.isLeft(deletedEither)) throw new Error("expected Right");
-      yield* repo.update(deletedEither.right.organization);
-      const exit = yield* Effect.exit(repo.findById(id));
+      yield* repo.updateOne(deletedEither.right.organization);
+      const exit = yield* Effect.exit(repo.findOneById(id));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -46,15 +46,15 @@ describe("OrganizationRepositoryFake", () => {
     }).pipe(provide),
   );
 
-  it.effect("findByIdIncludingDeleted returns soft-deleted rows", () =>
+  it.effect("findOneByIdIncludingDeleted returns soft-deleted rows", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = Organization.create({ id, name: "Acme", now });
-      yield* repo.insert(organization);
+      yield* repo.insertOne(organization);
       const deletedEither = Organization.softDelete(organization, { now: later });
       if (Either.isLeft(deletedEither)) throw new Error("expected Right");
-      yield* repo.update(deletedEither.right.organization);
-      const found = yield* repo.findByIdIncludingDeleted(id);
+      yield* repo.updateOne(deletedEither.right.organization);
+      const found = yield* repo.findOneByIdIncludingDeleted(id);
       deepStrictEqual(found.deletedAt !== null, true);
     }).pipe(provide),
   );
@@ -63,7 +63,7 @@ describe("OrganizationRepositoryFake", () => {
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = Organization.create({ id, name: "Acme", now });
-      const exit = yield* Effect.exit(repo.update(organization));
+      const exit = yield* Effect.exit(repo.updateOne(organization));
       deepStrictEqual(Exit.isFailure(exit), true);
       if (Exit.isFailure(exit)) {
         const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/organization/infrastructure/organization-repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-repository-fake.ts
@@ -13,17 +13,17 @@ export const OrganizationRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<OrganizationId, Organization>());
 
-    const insert = (organization: Organization): Effect.Effect<void> =>
+    const insertOne = (organization: Organization): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(organization.id, organization));
 
-    const update = (organization: Organization): Effect.Effect<void, OrganizationNotFound> =>
+    const updateOne = (organization: Organization): Effect.Effect<void, OrganizationNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         HashMap.has(m, organization.id)
           ? Ref.update(store, HashMap.set(organization.id, organization))
           : Effect.fail(new OrganizationNotFound({ organizationId: organization.id })),
       );
 
-    const findById = (id: OrganizationId): Effect.Effect<Organization, OrganizationNotFound> =>
+    const findOneById = (id: OrganizationId): Effect.Effect<Organization, OrganizationNotFound> =>
       Effect.flatMap(Ref.get(store), (m) => {
         const found = HashMap.get(m, id);
         if (found._tag === "None" || found.value.deletedAt !== null) {
@@ -32,7 +32,7 @@ export const OrganizationRepositoryFake = Layer.effect(
         return Effect.succeed(found.value);
       });
 
-    const findByIdIncludingDeleted = (
+    const findOneByIdIncludingDeleted = (
       id: OrganizationId,
     ): Effect.Effect<Organization, OrganizationNotFound> =>
       Effect.flatMap(Ref.get(store), (m) => {
@@ -42,6 +42,11 @@ export const OrganizationRepositoryFake = Layer.effect(
           : Effect.fail(new OrganizationNotFound({ organizationId: id }));
       });
 
-    return OrganizationRepository.of({ insert, update, findById, findByIdIncludingDeleted });
+    return OrganizationRepository.of({
+      insertOne,
+      updateOne,
+      findOneById,
+      findOneByIdIncludingDeleted,
+    });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/organization-repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-repository-live.integration.test.ts
@@ -29,23 +29,23 @@ suite("OrganizationRepositoryLive (integration)", () => {
     );
   });
 
-  describe("insert + findById", () => {
+  describe("insert + findOneById", () => {
     it.effect("round-trips an inserted org", () =>
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
         const { organization } = Organization.create({ id, name: "Acme", now });
-        yield* repo.insert(organization);
-        const found = yield* repo.findById(id);
+        yield* repo.insertOne(organization);
+        const found = yield* repo.findOneById(id);
         deepStrictEqual(found.id, id);
         deepStrictEqual(found.name, "Acme");
         deepStrictEqual(found.deletedAt, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findById fails OrganizationNotFound for an unknown id", () =>
+    it.effect("findOneById fails OrganizationNotFound for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
-        const exit = yield* Effect.exit(repo.findById(id));
+        const exit = yield* Effect.exit(repo.findOneById(id));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -56,19 +56,19 @@ suite("OrganizationRepositoryLive (integration)", () => {
   });
 
   describe("update (soft-delete tombstone)", () => {
-    it.effect("findById hides a soft-deleted row; findByIdIncludingDeleted returns it", () =>
+    it.effect("findOneById hides a soft-deleted row; findOneByIdIncludingDeleted returns it", () =>
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
         const { organization } = Organization.create({ id, name: "Acme", now });
-        yield* repo.insert(organization);
+        yield* repo.insertOne(organization);
         const deletedEither = Organization.softDelete(organization, { now: later });
         if (Either.isLeft(deletedEither)) throw new Error("expected Right");
-        yield* repo.update(deletedEither.right.organization);
+        yield* repo.updateOne(deletedEither.right.organization);
 
-        const hiddenExit = yield* Effect.exit(repo.findById(id));
+        const hiddenExit = yield* Effect.exit(repo.findOneById(id));
         deepStrictEqual(Exit.isFailure(hiddenExit), true);
 
-        const visible = yield* repo.findByIdIncludingDeleted(id);
+        const visible = yield* repo.findOneByIdIncludingDeleted(id);
         deepStrictEqual(visible.deletedAt !== null, true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -77,7 +77,7 @@ suite("OrganizationRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
         const { organization } = Organization.create({ id, name: "Acme", now });
-        const exit = yield* Effect.exit(repo.update(organization));
+        const exit = yield* Effect.exit(repo.updateOne(organization));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;

--- a/packages/server/src/modules/organization/infrastructure/organization-repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-repository-live.ts
@@ -14,7 +14,7 @@ export const OrganizationRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, organization: Organization) => {
+    const insertOne = db.makeQuery((execute, organization: Organization) => {
       const row = OrganizationMapper.toPersistence(organization);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -31,11 +31,11 @@ export const OrganizationRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRepository.insert"),
+        Effect.withSpan("OrganizationRepository.insertOne"),
       );
     });
 
-    const update = db.makeQuery((execute, organization: Organization) => {
+    const updateOne = db.makeQuery((execute, organization: Organization) => {
       const row = OrganizationMapper.toPersistence(organization);
       return execute((client) =>
         client.maybeOne(sql.type(RowSchemas.OrganizationRowStd)`
@@ -51,14 +51,14 @@ export const OrganizationRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRepository.update"),
+        Effect.withSpan("OrganizationRepository.updateOne"),
       );
     });
 
-    // findById hides soft-deleted rows so consumers (commands, the
+    // findOneById hides soft-deleted rows so consumers (commands, the
     // resource resolver registered for active-only flows) don't have to
     // remember to filter on `deleted_at IS NULL` themselves.
-    const findById = db.makeQuery((execute, id: OrganizationId) =>
+    const findOneById = db.makeQuery((execute, id: OrganizationId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.OrganizationRowStd)`
           SELECT * FROM "organization".organizations
@@ -69,7 +69,7 @@ export const OrganizationRepositoryLive = Layer.effect(
         Effect.map(OrganizationMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRepository.findById"),
+        Effect.withSpan("OrganizationRepository.findOneById"),
       ),
     );
 
@@ -78,7 +78,7 @@ export const OrganizationRepositoryLive = Layer.effect(
     // port level documents that callers had to actively ask for
     // tombstones — same shape as the `with-deleted` boolean would
     // collapse to, but more discoverable.
-    const findByIdIncludingDeleted = db.makeQuery((execute, id: OrganizationId) =>
+    const findOneByIdIncludingDeleted = db.makeQuery((execute, id: OrganizationId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.OrganizationRowStd)`
           SELECT * FROM "organization".organizations WHERE id = ${id}
@@ -88,10 +88,15 @@ export const OrganizationRepositoryLive = Layer.effect(
         Effect.map(OrganizationMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRepository.findByIdIncludingDeleted"),
+        Effect.withSpan("OrganizationRepository.findOneByIdIncludingDeleted"),
       ),
     );
 
-    return OrganizationRepository.of({ insert, update, findById, findByIdIncludingDeleted });
+    return OrganizationRepository.of({
+      insertOne,
+      updateOne,
+      findOneById,
+      findOneByIdIncludingDeleted,
+    });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.test.ts
@@ -21,20 +21,20 @@ describe("OrganizationRolesRepositoryFake", () => {
   it.effect("returns an empty aggregate for a previously-unseen (user, org) pair", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRolesRepository;
-      const roles = yield* repo.findByUserIdAndOrgId(userId, orgId);
+      const roles = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
       deepStrictEqual(roles.userId, userId);
       deepStrictEqual(roles.organizationId, orgId);
       deepStrictEqual([...roles.roles], []);
     }).pipe(Effect.provide(OrganizationRolesRepositoryFake)),
   );
 
-  it.effect("round-trips a saved aggregate via findByUserIdAndOrgId", () =>
+  it.effect("round-trips a saved aggregate via findOneByUserIdAndOrgId", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRolesRepository;
       const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
       if (Either.isLeft(granted)) throw new Error("expected Right");
-      yield* repo.save(granted.right.organizationRoles);
-      const fetched = yield* repo.findByUserIdAndOrgId(userId, orgId);
+      yield* repo.upsertOne(granted.right.organizationRoles);
+      const fetched = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
       deepStrictEqual(
         fetched.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
         [{ role: "admin", issuedBy }],

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-fake.ts
@@ -25,7 +25,7 @@ export const OrganizationRolesRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<string, OrganizationRoles>());
 
-    const save = (organizationRoles: OrganizationRoles): Effect.Effect<void> =>
+    const upsertOne = (organizationRoles: OrganizationRoles): Effect.Effect<void> =>
       Ref.update(
         store,
         HashMap.set(
@@ -34,7 +34,7 @@ export const OrganizationRolesRepositoryFake = Layer.effect(
         ),
       );
 
-    const findByUserIdAndOrgId = (
+    const findOneByUserIdAndOrgId = (
       userId: UserId,
       organizationId: OrganizationId,
     ): Effect.Effect<OrganizationRoles> =>
@@ -43,6 +43,6 @@ export const OrganizationRolesRepositoryFake = Layer.effect(
         return found._tag === "Some" ? found.value : emptyOrgRoles(userId, organizationId);
       });
 
-    return OrganizationRolesRepository.of({ save, findByUserIdAndOrgId });
+    return OrganizationRolesRepository.of({ upsertOne, findOneByUserIdAndOrgId });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.integration.test.ts
@@ -66,12 +66,12 @@ suite("OrganizationRolesRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findByUserIdAndOrgId", () => {
+  describe("findOneByUserIdAndOrgId", () => {
     it.effect("returns an empty aggregate when no rows exist", () =>
       Effect.gen(function* () {
         yield* seedFixtures;
         const repo = yield* OrganizationRolesRepository;
-        const roles = yield* repo.findByUserIdAndOrgId(userId, orgId);
+        const roles = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
         deepStrictEqual(roles.userId, userId);
         deepStrictEqual(roles.organizationId, orgId);
         deepStrictEqual([...roles.roles], []);
@@ -86,8 +86,8 @@ suite("OrganizationRolesRepositoryLive (integration)", () => {
         const repo = yield* OrganizationRolesRepository;
         const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
         if (Either.isLeft(granted)) throw new Error("expected Right");
-        yield* repo.save(granted.right.organizationRoles);
-        const fetched = yield* repo.findByUserIdAndOrgId(userId, orgId);
+        yield* repo.upsertOne(granted.right.organizationRoles);
+        const fetched = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
         deepStrictEqual(
           fetched.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
           [{ role: "admin", issuedBy }],
@@ -101,11 +101,11 @@ suite("OrganizationRolesRepositoryLive (integration)", () => {
         const repo = yield* OrganizationRolesRepository;
         const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
         if (Either.isLeft(granted)) throw new Error("expected Right");
-        yield* repo.save(granted.right.organizationRoles);
+        yield* repo.upsertOne(granted.right.organizationRoles);
         const revoked = revokeRole(granted.right.organizationRoles, "admin");
         if (Either.isLeft(revoked)) throw new Error("expected Right");
-        yield* repo.save(revoked.right.organizationRoles);
-        const fetched = yield* repo.findByUserIdAndOrgId(userId, orgId);
+        yield* repo.upsertOne(revoked.right.organizationRoles);
+        const fetched = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
         deepStrictEqual([...fetched.roles], []);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/organization-roles-repository-live.ts
@@ -48,7 +48,7 @@ export const OrganizationRolesRepositoryLive = Layer.effect(
         }
       });
 
-    const save = (organizationRoles: OrganizationRoles) =>
+    const upsertOne = (organizationRoles: OrganizationRoles) =>
       Effect.serviceOption(Database.TransactionContext).pipe(
         Effect.flatMap((existing) =>
           Option.isSome(existing)
@@ -61,10 +61,10 @@ export const OrganizationRolesRepositoryLive = Layer.effect(
         ),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRolesRepository.save"),
+        Effect.withSpan("OrganizationRolesRepository.upsertOne"),
       );
 
-    const findByUserIdAndOrgId = db.makeQuery(
+    const findOneByUserIdAndOrgId = db.makeQuery(
       (execute, args: { userId: UserId; organizationId: OrganizationId }) =>
         execute((client) =>
           client.any(sql.type(RowSchemas.OrganizationRoleRowStd)`
@@ -79,14 +79,14 @@ export const OrganizationRolesRepositoryLive = Layer.effect(
           ),
           Effect.catchTag("DatabaseError", Effect.die),
           translatePersistenceUnavailable,
-          Effect.withSpan("OrganizationRolesRepository.findByUserIdAndOrgId"),
+          Effect.withSpan("OrganizationRolesRepository.findOneByUserIdAndOrgId"),
         ),
     );
 
     return OrganizationRolesRepository.of({
-      save,
-      findByUserIdAndOrgId: (userId, organizationId) =>
-        findByUserIdAndOrgId({ userId, organizationId }),
+      upsertOne,
+      findOneByUserIdAndOrgId: (userId, organizationId) =>
+        findOneByUserIdAndOrgId({ userId, organizationId }),
     });
   }),
 );

--- a/packages/server/src/modules/organization/interface/http/soft-delete.endpoint.ts
+++ b/packages/server/src/modules/organization/interface/http/soft-delete.endpoint.ts
@@ -35,7 +35,7 @@ export const softDeleteEndpoint = (
       ),
     ),
     // `OrganizationAlreadyDeleted` is unreachable in practice: the
-    // command's `findById` filters tombstoned rows, so a double-delete
+    // command's `findOneById` filters tombstoned rows, so a double-delete
     // surfaces as `OrganizationNotFound` above. The aggregate-level
     // invariant remains as defense in depth; if it does fire, treat it
     // as a not-found at the wire (same outward effect).

--- a/packages/server/src/modules/organization/organization-role-service-live.ts
+++ b/packages/server/src/modules/organization/organization-role-service-live.ts
@@ -23,7 +23,7 @@ export const OrganizationRoleServiceLive = Layer.effect(
     const repo = yield* OrganizationRolesRepository;
     return OrganizationRoleService.of({
       findOrganizationPermissions: (userId, organizationId) =>
-        repo.findByUserIdAndOrgId(userId, organizationId).pipe(
+        repo.findOneByUserIdAndOrgId(userId, organizationId).pipe(
           Effect.map((aggregate) => ({
             userId: aggregate.userId,
             organizationId: aggregate.organizationId,

--- a/packages/server/src/modules/organization/policies/organization-resource-resolver.ts
+++ b/packages/server/src/modules/organization/policies/organization-resource-resolver.ts
@@ -29,7 +29,7 @@ export const OrganizationResolverEntryLive = Layer.effect(
   Effect.gen(function* () {
     const repo = yield* OrganizationRepository;
     return (id) =>
-      repo.findByIdIncludingDeleted(id).pipe(
+      repo.findOneByIdIncludingDeleted(id).pipe(
         Effect.catchTag("OrganizationNotFound", () =>
           Effect.fail(new CustomHttpApiError.NotFound()),
         ),

--- a/packages/server/src/modules/organization/queries/find-all-organizations.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-all-organizations.integration.test.ts
@@ -33,12 +33,12 @@ suite("findAllOrganizations (integration)", () => {
   it.effect("hides soft-deleted orgs by default", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
-      yield* repo.insert(Organization.create({ id: acmeId, name: "Acme", now }).organization);
+      yield* repo.insertOne(Organization.create({ id: acmeId, name: "Acme", now }).organization);
       const { organization: betaOrg } = Organization.create({ id: beta, name: "Beta", now });
-      yield* repo.insert(betaOrg);
+      yield* repo.insertOne(betaOrg);
       const deletedEither = Organization.softDelete(betaOrg, { now: later });
       if (Either.isLeft(deletedEither)) throw new Error("expected Right");
-      yield* repo.update(deletedEither.right.organization);
+      yield* repo.updateOne(deletedEither.right.organization);
 
       const result = yield* findAllOrganizations(
         FindAllOrganizationsQuery.make({ page: 1, pageSize: 10, includeDeleted: false }),
@@ -51,12 +51,12 @@ suite("findAllOrganizations (integration)", () => {
   it.effect("returns tombstoned rows when includeDeleted is true", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
-      yield* repo.insert(Organization.create({ id: acmeId, name: "Acme", now }).organization);
+      yield* repo.insertOne(Organization.create({ id: acmeId, name: "Acme", now }).organization);
       const { organization: betaOrg } = Organization.create({ id: beta, name: "Beta", now });
-      yield* repo.insert(betaOrg);
+      yield* repo.insertOne(betaOrg);
       const deletedEither = Organization.softDelete(betaOrg, { now: later });
       if (Either.isLeft(deletedEither)) throw new Error("expected Right");
-      yield* repo.update(deletedEither.right.organization);
+      yield* repo.updateOne(deletedEither.right.organization);
 
       const result = yield* findAllOrganizations(
         FindAllOrganizationsQuery.make({ page: 1, pageSize: 10, includeDeleted: true }),

--- a/packages/server/src/modules/organization/queries/find-membership.test.ts
+++ b/packages/server/src/modules/organization/queries/find-membership.test.ts
@@ -29,7 +29,7 @@ describe("findMembership", () => {
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = Membership.create({ userId, organizationId: orgId, now });
-      yield* repo.insert(membership);
+      yield* repo.insertOne(membership);
       const result = yield* findMembership(
         FindMembershipQuery.make({ userId, organizationId: orgId }),
       );

--- a/packages/server/src/modules/organization/queries/find-membership.ts
+++ b/packages/server/src/modules/organization/queries/find-membership.ts
@@ -12,7 +12,7 @@ import {
 export const findMembership = (query: FindMembershipQuery): FindMembershipOutput =>
   Effect.gen(function* () {
     const repo = yield* MembershipRepository;
-    return yield* repo.findByUserIdAndOrgId(query.userId, query.organizationId).pipe(
+    return yield* repo.findOneByUserIdAndOrgId(query.userId, query.organizationId).pipe(
       Effect.map(() => ({ isMember: true })),
       Effect.catchTag("MembershipNotFound", () => Effect.succeed({ isMember: false })),
     );

--- a/packages/server/src/modules/organization/queries/find-my-organizations.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-my-organizations.integration.test.ts
@@ -60,13 +60,13 @@ suite("findMyOrganizations (integration)", () => {
       yield* seedUsers;
       const orgs = yield* OrganizationRepository;
       const memberships = yield* MembershipRepository;
-      yield* orgs.insert(Organization.create({ id: acmeId, name: "Acme", now }).organization);
-      yield* orgs.insert(Organization.create({ id: betaId, name: "Beta", now }).organization);
-      yield* memberships.insert(
+      yield* orgs.insertOne(Organization.create({ id: acmeId, name: "Acme", now }).organization);
+      yield* orgs.insertOne(Organization.create({ id: betaId, name: "Beta", now }).organization);
+      yield* memberships.insertOne(
         Membership.create({ userId: aliceId, organizationId: acmeId, now }).membership,
       );
       // Bob is a member of Beta, not Acme — must not leak into Alice's view.
-      yield* memberships.insert(
+      yield* memberships.insertOne(
         Membership.create({ userId: bobId, organizationId: betaId, now }).membership,
       );
 
@@ -83,12 +83,12 @@ suite("findMyOrganizations (integration)", () => {
       yield* seedUsers;
       const orgs = yield* OrganizationRepository;
       const memberships = yield* MembershipRepository;
-      yield* orgs.insert(Organization.create({ id: acmeId, name: "Acme", now }).organization);
-      yield* orgs.insert(Organization.create({ id: betaId, name: "Beta", now }).organization);
-      yield* memberships.insert(
+      yield* orgs.insertOne(Organization.create({ id: acmeId, name: "Acme", now }).organization);
+      yield* orgs.insertOne(Organization.create({ id: betaId, name: "Beta", now }).organization);
+      yield* memberships.insertOne(
         Membership.create({ userId: aliceId, organizationId: acmeId, now }).membership,
       );
-      yield* memberships.insert(
+      yield* memberships.insertOne(
         Membership.create({ userId: aliceId, organizationId: betaId, now }).membership,
       );
       // Alice holds the `admin` role in Acme only.
@@ -124,13 +124,13 @@ suite("findMyOrganizations (integration)", () => {
       const orgs = yield* OrganizationRepository;
       const memberships = yield* MembershipRepository;
       const { organization: acme } = Organization.create({ id: acmeId, name: "Acme", now });
-      yield* orgs.insert(acme);
-      yield* memberships.insert(
+      yield* orgs.insertOne(acme);
+      yield* memberships.insertOne(
         Membership.create({ userId: aliceId, organizationId: acmeId, now }).membership,
       );
       const deleted = Organization.softDelete(acme, { now });
       if (deleted._tag !== "Right") throw new Error("expected Right");
-      yield* orgs.update(deleted.right.organization);
+      yield* orgs.updateOne(deleted.right.organization);
 
       const result = yield* findMyOrganizations(FindMyOrganizationsQuery.make({ userId: aliceId }));
       deepStrictEqual([...result.organizations], []);

--- a/packages/server/src/modules/organization/queries/find-organization-memberships.test.ts
+++ b/packages/server/src/modules/organization/queries/find-organization-memberships.test.ts
@@ -53,7 +53,7 @@ const seedAdmin = (userId: UserId, organizationId: OrganizationId) =>
       issuer,
     );
     if (Either.isRight(granted)) {
-      yield* rolesRepo.save(granted.right.organizationRoles);
+      yield* rolesRepo.upsertOne(granted.right.organizationRoles);
     }
   });
 
@@ -61,9 +61,9 @@ describe("findOrganizationMemberships", () => {
   it.effect("returns only the requested org's members, enriched with email", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
-      yield* repo.insert(seed(userA, orgA));
-      yield* repo.insert(seed(userB, orgA));
-      yield* repo.insert(seed(userC, orgB));
+      yield* repo.insertOne(seed(userA, orgA));
+      yield* repo.insertOne(seed(userB, orgA));
+      yield* repo.insertOne(seed(userC, orgB));
 
       const result = yield* findOrganizationMemberships(
         FindOrganizationMembershipsQuery.make({ organizationId: orgA }),
@@ -79,8 +79,8 @@ describe("findOrganizationMemberships", () => {
   it.effect("flags admins via isAdmin and leaves plain members false", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
-      yield* repo.insert(seed(userA, orgA));
-      yield* repo.insert(seed(userB, orgA));
+      yield* repo.insertOne(seed(userA, orgA));
+      yield* repo.insertOne(seed(userB, orgA));
       yield* seedAdmin(userA, orgA);
 
       const result = yield* findOrganizationMemberships(
@@ -104,9 +104,9 @@ describe("findOrganizationMemberships", () => {
   it.effect("skips members whose user record is missing from the lookup", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
-      yield* repo.insert(seed(userA, orgA));
+      yield* repo.insertOne(seed(userA, orgA));
       const orphanedUser = UserId.make("99999999-9999-9999-9999-999999999999");
-      yield* repo.insert(seed(orphanedUser, orgA));
+      yield* repo.insertOne(seed(orphanedUser, orgA));
 
       const result = yield* findOrganizationMemberships(
         FindOrganizationMembershipsQuery.make({ organizationId: orgA }),

--- a/packages/server/src/modules/organization/queries/find-organization-memberships.ts
+++ b/packages/server/src/modules/organization/queries/find-organization-memberships.ts
@@ -16,7 +16,7 @@ export const findOrganizationMemberships = (
     const repo = yield* MembershipRepository;
     const usersLookup = yield* UsersLookup;
     const rolesRepo = yield* OrganizationRolesRepository;
-    const memberships = yield* repo.findByOrganizationId(query.organizationId);
+    const memberships = yield* repo.findManyByOrganizationId(query.organizationId);
     const users = yield* usersLookup.findByIds(memberships.map((m) => m.userId));
     // Preserve membership order (DB-sorted by createdAt). Skip any
     // user the lookup couldn't find (a hard inconsistency we don't
@@ -24,13 +24,13 @@ export const findOrganizationMemberships = (
     const byId = new Map(users.map((u) => [u.userId, u]));
     // Per-member role lookup for the `isAdmin` flag. N+1 over the
     // roster, but member lists are small and bounded; if this ever
-    // needs to scale, add a `findByOrganizationId` batch read to
+    // needs to scale, add a `findManyByOrganizationId` batch read to
     // `OrganizationRolesRepository`.
     const rows = yield* Effect.forEach(memberships, (m) =>
       Effect.gen(function* () {
         const user = byId.get(m.userId);
         if (user === undefined) return [];
-        const roles = yield* rolesRepo.findByUserIdAndOrgId(m.userId, query.organizationId);
+        const roles = yield* rolesRepo.findOneByUserIdAndOrgId(m.userId, query.organizationId);
         return [
           {
             userId: m.userId,

--- a/packages/server/src/modules/organization/queries/find-pending-invitations.test.ts
+++ b/packages/server/src/modules/organization/queries/find-pending-invitations.test.ts
@@ -53,19 +53,19 @@ describe("findPendingInvitations", () => {
         otherOrgId,
       );
 
-      yield* repo.insert(pending);
-      yield* repo.insert(expired);
-      yield* repo.insert(toRevoke);
-      yield* repo.insert(toAccept);
-      yield* repo.insert(otherOrg);
+      yield* repo.insertOne(pending);
+      yield* repo.insertOne(expired);
+      yield* repo.insertOne(toRevoke);
+      yield* repo.insertOne(toAccept);
+      yield* repo.insertOne(otherOrg);
 
       const revoked = Invitation.revoke(toRevoke, { now: issuedAt });
       if (Either.isLeft(revoked)) throw new Error("expected Right");
-      yield* repo.update(revoked.right.invitation);
+      yield* repo.updateOne(revoked.right.invitation);
 
       const accepted = Invitation.accept(toAccept, { userId, now: issuedAt });
       if (Either.isLeft(accepted)) throw new Error("expected Right");
-      yield* repo.update(accepted.right.invitation);
+      yield* repo.updateOne(accepted.right.invitation);
 
       const result = yield* findPendingInvitations(
         FindPendingInvitationsQuery.make({ organizationId: orgId }),

--- a/packages/server/src/modules/organization/queries/find-pending-invitations.ts
+++ b/packages/server/src/modules/organization/queries/find-pending-invitations.ts
@@ -14,7 +14,7 @@ export const findPendingInvitations = (
   Effect.gen(function* () {
     const repo = yield* InvitationRepository;
     const now = yield* DateTime.now;
-    const all = yield* repo.findByOrganizationId(query.organizationId);
+    const all = yield* repo.findManyByOrganizationId(query.organizationId);
     // Only open invitations belong on the pending list; accepted invitees
     // are members and revoked ones are gone. Status (pending/expired) is
     // derived against `now` so the UI can offer resend on lapsed invites.

--- a/packages/server/src/modules/organization/queries/find-user-organization-roles.test.ts
+++ b/packages/server/src/modules/organization/queries/find-user-organization-roles.test.ts
@@ -35,7 +35,7 @@ describe("findUserOrganizationRoles", () => {
       const repo = yield* OrganizationRolesRepository;
       const granted = grantRole(emptyOrgRoles(userId, orgId), "admin", issuedBy);
       if (Either.isLeft(granted)) throw new Error("expected Right");
-      yield* repo.save(granted.right.organizationRoles);
+      yield* repo.upsertOne(granted.right.organizationRoles);
       const result = yield* findUserOrganizationRoles(
         FindUserOrganizationRolesQuery.make({ userId, organizationId: orgId }),
       );

--- a/packages/server/src/modules/organization/queries/find-user-organization-roles.ts
+++ b/packages/server/src/modules/organization/queries/find-user-organization-roles.ts
@@ -15,7 +15,7 @@ export const findUserOrganizationRoles = (
 ): FindUserOrganizationRolesOutput =>
   Effect.gen(function* () {
     const repo = yield* OrganizationRolesRepository;
-    const aggregate = yield* repo.findByUserIdAndOrgId(query.userId, query.organizationId);
+    const aggregate = yield* repo.findOneByUserIdAndOrgId(query.userId, query.organizationId);
     return {
       userId: aggregate.userId,
       organizationId: aggregate.organizationId,

--- a/packages/server/src/modules/role/commands/grant-role.test.ts
+++ b/packages/server/src/modules/role/commands/grant-role.test.ts
@@ -29,7 +29,7 @@ describe("grantRole", () => {
         GrantRoleCommand.make({ userId: targetId, role: "super_admin", actorUserId: actorId }),
       );
 
-      const roles = yield* repo.findByUserId(targetId);
+      const roles = yield* repo.findOneByUserId(targetId);
       deepStrictEqual([...roles.roles], ["super_admin"]);
 
       const events = yield* rec.byTag<RoleGranted>("RoleGranted");

--- a/packages/server/src/modules/role/commands/grant-role.ts
+++ b/packages/server/src/modules/role/commands/grant-role.ts
@@ -22,9 +22,9 @@ export const grantRole = (cmd: GrantRoleCommand): GrantRoleOutput =>
     const repo = yield* RolesRepository;
     const bus = yield* DomainEventBus;
 
-    const aggregate = yield* repo.findByUserId(cmd.userId);
+    const aggregate = yield* repo.findOneByUserId(cmd.userId);
     const result = yield* Roles.grant(aggregate, cmd.role);
 
-    yield* repo.save(result.roles);
+    yield* repo.upsertOne(result.roles);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/role/commands/revoke-role.test.ts
+++ b/packages/server/src/modules/role/commands/revoke-role.test.ts
@@ -32,7 +32,7 @@ describe("revokeRole", () => {
       );
       yield* revokeRole(RevokeRoleCommand.make({ userId: targetId, role: "super_admin" }));
 
-      const roles = yield* repo.findByUserId(targetId);
+      const roles = yield* repo.findOneByUserId(targetId);
       deepStrictEqual([...roles.roles], []);
 
       const events = yield* rec.byTag<RoleRevoked>("RoleRevoked");

--- a/packages/server/src/modules/role/commands/revoke-role.ts
+++ b/packages/server/src/modules/role/commands/revoke-role.ts
@@ -14,9 +14,9 @@ export const revokeRole = (cmd: RevokeRoleCommand): RevokeRoleOutput =>
     const repo = yield* RolesRepository;
     const bus = yield* DomainEventBus;
 
-    const aggregate = yield* repo.findByUserId(cmd.userId);
+    const aggregate = yield* repo.findOneByUserId(cmd.userId);
     const result = yield* Roles.revoke(aggregate, cmd.role);
 
-    yield* repo.save(result.roles);
+    yield* repo.upsertOne(result.roles);
     yield* bus.dispatch(result.events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/role/domain/ports/repositories/roles-repository.ts
+++ b/packages/server/src/modules/role/domain/ports/repositories/roles-repository.ts
@@ -8,12 +8,12 @@ import { type UserId } from "@/platform/ids/user-id.js";
 // Dumb persistence port. The aggregate carries the invariants; the
 // repository only knows how to save and fetch the resulting state.
 //
-// `findByUserId` returns an empty `Roles` aggregate if no roles are
+// `findOneByUserId` returns an empty `Roles` aggregate if no roles are
 // stored — the absence of any rows is a valid "no roles granted yet"
 // state, not a NotFound condition.
 export type RolesRepositoryShape = {
-  readonly save: (roles: Roles) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findByUserId: (userId: UserId) => Effect.Effect<Roles, PersistenceUnavailable>;
+  readonly upsertOne: (roles: Roles) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly findOneByUserId: (userId: UserId) => Effect.Effect<Roles, PersistenceUnavailable>;
 };
 
 export class RolesRepository extends Context.Tag("RolesRepository")<

--- a/packages/server/src/modules/role/domain/roles.aggregate.ts
+++ b/packages/server/src/modules/role/domain/roles.aggregate.ts
@@ -23,7 +23,7 @@ export type Result = {
 };
 
 // Factory for the "no roles yet" case — used by the command handler
-// when `findByUserId` returns nothing and we still want to apply a
+// when `findOneByUserId` returns nothing and we still want to apply a
 // grant rather than fail.
 export const empty = (userId: UserId): Roles => Roles.make({ userId, roles: [] });
 

--- a/packages/server/src/modules/role/infrastructure/roles-repository-fake.test.ts
+++ b/packages/server/src/modules/role/infrastructure/roles-repository-fake.test.ts
@@ -15,19 +15,19 @@ describe("RolesRepositoryFake", () => {
   it.effect("returns an empty aggregate for a previously-unseen user", () =>
     Effect.gen(function* () {
       const repo = yield* RolesRepository;
-      const roles = yield* repo.findByUserId(userId);
+      const roles = yield* repo.findOneByUserId(userId);
       deepStrictEqual(roles.userId, userId);
       deepStrictEqual([...roles.roles], []);
     }).pipe(Effect.provide(RolesRepositoryFake)),
   );
 
-  it.effect("round-trips a saved aggregate via findByUserId", () =>
+  it.effect("round-trips a saved aggregate via findOneByUserId", () =>
     Effect.gen(function* () {
       const repo = yield* RolesRepository;
       const granted = grant(emptyRoles(userId), "super_admin");
       if (Either.isLeft(granted)) throw new Error("expected Right");
-      yield* repo.save(granted.right.roles);
-      const fetched = yield* repo.findByUserId(userId);
+      yield* repo.upsertOne(granted.right.roles);
+      const fetched = yield* repo.findOneByUserId(userId);
       deepStrictEqual([...fetched.roles], ["super_admin"]);
     }).pipe(Effect.provide(RolesRepositoryFake)),
   );

--- a/packages/server/src/modules/role/infrastructure/roles-repository-fake.ts
+++ b/packages/server/src/modules/role/infrastructure/roles-repository-fake.ts
@@ -15,15 +15,15 @@ export const RolesRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<UserId, Roles>());
 
-    const save = (roles: Roles): Effect.Effect<void> =>
+    const upsertOne = (roles: Roles): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(roles.userId, roles));
 
-    const findByUserId = (userId: UserId): Effect.Effect<Roles> =>
+    const findOneByUserId = (userId: UserId): Effect.Effect<Roles> =>
       Effect.map(Ref.get(store), (m) => {
         const found = HashMap.get(m, userId);
         return found._tag === "Some" ? found.value : emptyRoles(userId);
       });
 
-    return RolesRepository.of({ save, findByUserId });
+    return RolesRepository.of({ upsertOne, findOneByUserId });
   }),
 );

--- a/packages/server/src/modules/role/infrastructure/roles-repository-live.integration.test.ts
+++ b/packages/server/src/modules/role/infrastructure/roles-repository-live.integration.test.ts
@@ -40,12 +40,12 @@ suite("RolesRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findByUserId", () => {
+  describe("findOneByUserId", () => {
     it.effect("returns an empty aggregate when no rows exist", () =>
       Effect.gen(function* () {
         yield* seedUser;
         const repo = yield* RolesRepository;
-        const roles = yield* repo.findByUserId(userId);
+        const roles = yield* repo.findOneByUserId(userId);
         deepStrictEqual(roles.userId, userId);
         deepStrictEqual([...roles.roles], []);
       }).pipe(Effect.provide(TestLayer)),
@@ -53,14 +53,14 @@ suite("RolesRepositoryLive (integration)", () => {
   });
 
   describe("save", () => {
-    it.effect("persists granted roles and round-trips via findByUserId", () =>
+    it.effect("persists granted roles and round-trips via findOneByUserId", () =>
       Effect.gen(function* () {
         yield* seedUser;
         const repo = yield* RolesRepository;
         const granted = grant(emptyRoles(userId), "super_admin");
         if (Either.isLeft(granted)) throw new Error("expected Right");
-        yield* repo.save(granted.right.roles);
-        const fetched = yield* repo.findByUserId(userId);
+        yield* repo.upsertOne(granted.right.roles);
+        const fetched = yield* repo.findOneByUserId(userId);
         deepStrictEqual([...fetched.roles], ["super_admin"]);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -71,11 +71,11 @@ suite("RolesRepositoryLive (integration)", () => {
         const repo = yield* RolesRepository;
         const granted = grant(emptyRoles(userId), "super_admin");
         if (Either.isLeft(granted)) throw new Error("expected Right");
-        yield* repo.save(granted.right.roles);
+        yield* repo.upsertOne(granted.right.roles);
         const revoked = revoke(granted.right.roles, "super_admin");
         if (Either.isLeft(revoked)) throw new Error("expected Right");
-        yield* repo.save(revoked.right.roles);
-        const fetched = yield* repo.findByUserId(userId);
+        yield* repo.upsertOne(revoked.right.roles);
+        const fetched = yield* repo.findOneByUserId(userId);
         deepStrictEqual([...fetched.roles], []);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/role/infrastructure/roles-repository-live.ts
+++ b/packages/server/src/modules/role/infrastructure/roles-repository-live.ts
@@ -44,7 +44,7 @@ export const RolesRepositoryLive = Layer.effect(
         }
       });
 
-    const save = (roles: Roles) =>
+    const upsertOne = (roles: Roles) =>
       Effect.serviceOption(Database.TransactionContext).pipe(
         Effect.flatMap((existing) =>
           Option.isSome(existing)
@@ -55,10 +55,10 @@ export const RolesRepositoryLive = Layer.effect(
         ),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("RolesRepository.save"),
+        Effect.withSpan("RolesRepository.upsertOne"),
       );
 
-    const findByUserId = db.makeQuery((execute, userId: UserId) =>
+    const findOneByUserId = db.makeQuery((execute, userId: UserId) =>
       execute((client) =>
         client.any(sql.type(RowSchemas.PlatformRoleRowStd)`
           SELECT user_id, role, granted_at FROM platform.roles WHERE user_id = ${userId}
@@ -67,10 +67,10 @@ export const RolesRepositoryLive = Layer.effect(
         Effect.map((rows) => RoleMapper.toDomain(userId, rows)),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("RolesRepository.findByUserId"),
+        Effect.withSpan("RolesRepository.findOneByUserId"),
       ),
     );
 
-    return RolesRepository.of({ save, findByUserId });
+    return RolesRepository.of({ upsertOne, findOneByUserId });
   }),
 );

--- a/packages/server/src/modules/role/queries/find-user-roles.test.ts
+++ b/packages/server/src/modules/role/queries/find-user-roles.test.ts
@@ -26,7 +26,7 @@ describe("findUserRoles", () => {
       const repo = yield* RolesRepository;
       const granted = grant(emptyRoles(userId), "super_admin");
       if (Either.isLeft(granted)) throw new Error("expected Right");
-      yield* repo.save(granted.right.roles);
+      yield* repo.upsertOne(granted.right.roles);
       const result = yield* findUserRoles(FindUserRolesQuery.make({ userId }));
       deepStrictEqual([...result.roles], ["super_admin"]);
     }).pipe(Effect.provide(RolesRepositoryFake)),

--- a/packages/server/src/modules/role/queries/find-user-roles.ts
+++ b/packages/server/src/modules/role/queries/find-user-roles.ts
@@ -13,6 +13,6 @@ import {
 export const findUserRoles = (query: FindUserRolesQuery): FindUserRolesOutput =>
   Effect.gen(function* () {
     const repo = yield* RolesRepository;
-    const aggregate = yield* repo.findByUserId(query.userId);
+    const aggregate = yield* repo.findOneByUserId(query.userId);
     return { userId: aggregate.userId, roles: aggregate.roles };
   });

--- a/packages/server/src/modules/todos/commands/complete-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo.test.ts
@@ -23,7 +23,7 @@ const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 
 const seed = Effect.gen(function* () {
   const repo = yield* TodosRepository;
-  yield* repo.insert(Todo.create({ id: todoId, organizationId: orgId, title: "Buy milk", now }));
+  yield* repo.insertOne(Todo.create({ id: todoId, organizationId: orgId, title: "Buy milk", now }));
 });
 
 describe("completeTodo", () => {
@@ -35,7 +35,7 @@ describe("completeTodo", () => {
       );
       deepStrictEqual(completed.completed, true);
       deepStrictEqual(completed.title, "Buy milk");
-      const stored = yield* (yield* TodosRepository).findById(orgId, todoId);
+      const stored = yield* (yield* TodosRepository).findOneById(orgId, todoId);
       deepStrictEqual(stored.completed, true);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/complete-todo.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo.ts
@@ -11,9 +11,9 @@ import * as Todo from "@/modules/todos/domain/todo.js";
 export const completeTodo = (cmd: CompleteTodoCommand): CompleteTodoOutput =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    const existing = yield* repo.findById(cmd.organizationId, cmd.todoId);
+    const existing = yield* repo.findOneById(cmd.organizationId, cmd.todoId);
     const now = yield* DateTime.now;
     const completed = Todo.complete(existing, now);
-    yield* repo.update(completed);
+    yield* repo.updateOne(completed);
     return completed;
   });

--- a/packages/server/src/modules/todos/commands/create-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.test.ts
@@ -23,7 +23,7 @@ describe("createTodo", () => {
       deepStrictEqual(todo.title, "Buy milk");
       deepStrictEqual(todo.completed, false);
       deepStrictEqual(todo.organizationId, orgId);
-      const stored = yield* repo.findById(orgId, todo.id);
+      const stored = yield* repo.findOneById(orgId, todo.id);
       deepStrictEqual(stored.title, "Buy milk");
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/create-todo.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.ts
@@ -21,6 +21,6 @@ export const createTodo = (cmd: CreateTodoCommand): CreateTodoOutput =>
       title: cmd.title,
       now,
     });
-    yield* repo.insert(todo);
+    yield* repo.insertOne(todo);
     return todo;
   });

--- a/packages/server/src/modules/todos/commands/delete-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.test.ts
@@ -25,13 +25,13 @@ describe("deleteTodo", () => {
   it.effect("removes the todo from the repository", () =>
     Effect.gen(function* () {
       const repo = yield* TodosRepository;
-      yield* repo.insert(
+      yield* repo.insertOne(
         Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now }),
       );
       yield* deleteTodo(
         DeleteTodoCommand.make({ todoId: aliceId, organizationId: orgId, userId: aliceUserId }),
       );
-      const exit = yield* Effect.exit(repo.findById(orgId, aliceId));
+      const exit = yield* Effect.exit(repo.findOneById(orgId, aliceId));
       deepStrictEqual(Exit.isFailure(exit), true);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );
@@ -54,7 +54,7 @@ describe("deleteTodo", () => {
   it.effect("fails TodoNotFound when the todo belongs to a different org (tenant isolation)", () =>
     Effect.gen(function* () {
       const repo = yield* TodosRepository;
-      yield* repo.insert(
+      yield* repo.insertOne(
         Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now }),
       );
       const exit = yield* Effect.exit(
@@ -72,7 +72,7 @@ describe("deleteTodo", () => {
         deepStrictEqual(error instanceof TodoNotFound, true);
       }
       // The original (correct-org) row is untouched.
-      const stillThere = yield* repo.findById(orgId, aliceId);
+      const stillThere = yield* repo.findOneById(orgId, aliceId);
       deepStrictEqual(stillThere.id, aliceId);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/delete-todo.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.ts
@@ -9,5 +9,5 @@ import { TodosRepository } from "@/modules/todos/domain/ports/repositories/todo-
 export const deleteTodo = (cmd: DeleteTodoCommand): DeleteTodoOutput =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    yield* repo.remove(cmd.organizationId, cmd.todoId);
+    yield* repo.deleteOne(cmd.organizationId, cmd.todoId);
   });

--- a/packages/server/src/modules/todos/commands/update-todo.test.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.test.ts
@@ -24,7 +24,7 @@ const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 const seed = Effect.gen(function* () {
   const repo = yield* TodosRepository;
   const todo = Todo.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now });
-  yield* repo.insert(todo);
+  yield* repo.insertOne(todo);
 });
 
 describe("updateTodo", () => {
@@ -44,7 +44,7 @@ describe("updateTodo", () => {
       deepStrictEqual(updated.completed, true);
 
       const repo = yield* TodosRepository;
-      const stored = yield* repo.findById(orgId, aliceId);
+      const stored = yield* repo.findOneById(orgId, aliceId);
       deepStrictEqual(stored.title, "Buy oat milk");
       deepStrictEqual(stored.completed, true);
     }).pipe(Effect.provide(TodosRepositoryFake)),

--- a/packages/server/src/modules/todos/commands/update-todo.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.ts
@@ -11,13 +11,13 @@ import * as Todo from "@/modules/todos/domain/todo.js";
 export const updateTodo = (cmd: UpdateTodoCommand): UpdateTodoOutput =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    const existing = yield* repo.findById(cmd.organizationId, cmd.todoId);
+    const existing = yield* repo.findOneById(cmd.organizationId, cmd.todoId);
     const now = yield* DateTime.now;
     const updated = Todo.update(existing, {
       title: cmd.title,
       completed: cmd.completed,
       now,
     });
-    yield* repo.update(updated);
+    yield* repo.updateOne(updated);
     return updated;
   });

--- a/packages/server/src/modules/todos/domain/ports/repositories/todo-repository.ts
+++ b/packages/server/src/modules/todos/domain/ports/repositories/todo-repository.ts
@@ -7,19 +7,19 @@ import { type TodoId } from "@/modules/todos/domain/todo-id.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
-// Every read/mutate is org-scoped (Phase 5). `findById` and `remove`
+// Every read/mutate is org-scoped (Phase 5). `findOneById` and `remove`
 // take the `organizationId` explicitly so a caller can't reach a todo
 // outside the org in the request path — a row in another org reads as
 // `TodoNotFound`, not a leak. `insert`/`update` carry the org on the
 // `Todo` itself; `update`'s SQL filters on it too.
 export type TodosRepositoryShape = {
-  readonly insert: (todo: Todo) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly update: (todo: Todo) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
-  readonly remove: (
+  readonly insertOne: (todo: Todo) => Effect.Effect<void, PersistenceUnavailable>;
+  readonly updateOne: (todo: Todo) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
+  readonly deleteOne: (
     organizationId: OrganizationId,
     id: TodoId,
   ) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
-  readonly findById: (
+  readonly findOneById: (
     organizationId: OrganizationId,
     id: TodoId,
   ) => Effect.Effect<Todo, TodoNotFound | PersistenceUnavailable>;

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.test.ts
@@ -28,8 +28,8 @@ describe("TodosRepositoryFake", () => {
     it.effect("stores the todo and makes it findable by (org, id)", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        const found = yield* repo.findById(orgId, buyMilk.id);
+        yield* repo.insertOne(buyMilk);
+        const found = yield* repo.findOneById(orgId, buyMilk.id);
         deepStrictEqual(found.id, buyMilk.id);
         deepStrictEqual(found.organizationId, orgId);
         deepStrictEqual(found.title, buyMilk.title);
@@ -38,11 +38,11 @@ describe("TodosRepositoryFake", () => {
     );
   });
 
-  describe("findById", () => {
+  describe("findOneById", () => {
     it.effect("fails TodoNotFound for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.findById(orgId, bobId));
+        const exit = yield* Effect.exit(repo.findOneById(orgId, bobId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -54,8 +54,8 @@ describe("TodosRepositoryFake", () => {
     it.effect("fails TodoNotFound when the id exists but in another org (isolation)", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        const exit = yield* Effect.exit(repo.findById(otherOrgId, buyMilk.id));
+        yield* repo.insertOne(buyMilk);
+        const exit = yield* Effect.exit(repo.findOneById(otherOrgId, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -69,14 +69,14 @@ describe("TodosRepositoryFake", () => {
     it.effect("overwrites the stored todo", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
+        yield* repo.insertOne(buyMilk);
         const completed = Todo.update(buyMilk, {
           title: buyMilk.title,
           completed: true,
           now: later,
         });
-        yield* repo.update(completed);
-        const found = yield* repo.findById(orgId, buyMilk.id);
+        yield* repo.updateOne(completed);
+        const found = yield* repo.findOneById(orgId, buyMilk.id);
         deepStrictEqual(found.completed, true);
         deepStrictEqual(found.updatedAt, later);
       }).pipe(provide),
@@ -85,7 +85,7 @@ describe("TodosRepositoryFake", () => {
     it.effect("fails TodoNotFound when the todo isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.update(buyMilk));
+        const exit = yield* Effect.exit(repo.updateOne(buyMilk));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -99,9 +99,9 @@ describe("TodosRepositoryFake", () => {
     it.effect("removes the todo", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        yield* repo.remove(orgId, buyMilk.id);
-        const exit = yield* Effect.exit(repo.findById(orgId, buyMilk.id));
+        yield* repo.insertOne(buyMilk);
+        yield* repo.deleteOne(orgId, buyMilk.id);
+        const exit = yield* Effect.exit(repo.findOneById(orgId, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
       }).pipe(provide),
     );
@@ -109,7 +109,7 @@ describe("TodosRepositoryFake", () => {
     it.effect("fails TodoNotFound when the todo isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.remove(orgId, bobId));
+        const exit = yield* Effect.exit(repo.deleteOne(orgId, bobId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -121,11 +121,11 @@ describe("TodosRepositoryFake", () => {
     it.effect("fails TodoNotFound when removing from the wrong org (isolation)", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        const exit = yield* Effect.exit(repo.remove(otherOrgId, buyMilk.id));
+        yield* repo.insertOne(buyMilk);
+        const exit = yield* Effect.exit(repo.deleteOne(otherOrgId, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         // Row still present under its real org.
-        const found = yield* repo.findById(orgId, buyMilk.id);
+        const found = yield* repo.findOneById(orgId, buyMilk.id);
         deepStrictEqual(found.id, buyMilk.id);
       }).pipe(provide),
     );

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-fake.ts
@@ -20,10 +20,10 @@ export const TodosRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<TodoId, Todo>());
 
-    const insert = (todo: Todo): Effect.Effect<void> =>
+    const insertOne = (todo: Todo): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(todo.id, todo));
 
-    const update = (todo: Todo): Effect.Effect<void, TodoNotFound> =>
+    const updateOne = (todo: Todo): Effect.Effect<void, TodoNotFound> =>
       Effect.flatMap(Ref.get(store), (m) => {
         const found = HashMap.get(m, todo.id);
         return found._tag === "Some" && found.value.organizationId === todo.organizationId
@@ -31,7 +31,7 @@ export const TodosRepositoryFake = Layer.effect(
           : Effect.fail(new TodoNotFound({ todoId: todo.id }));
       });
 
-    const remove = (
+    const deleteOne = (
       organizationId: OrganizationId,
       id: TodoId,
     ): Effect.Effect<void, TodoNotFound> =>
@@ -42,7 +42,7 @@ export const TodosRepositoryFake = Layer.effect(
           : Effect.fail(new TodoNotFound({ todoId: id }));
       });
 
-    const findById = (
+    const findOneById = (
       organizationId: OrganizationId,
       id: TodoId,
     ): Effect.Effect<Todo, TodoNotFound> =>
@@ -56,6 +56,6 @@ export const TodosRepositoryFake = Layer.effect(
         }),
       );
 
-    return TodosRepository.of({ insert, update, remove, findById });
+    return TodosRepository.of({ insertOne, updateOne, deleteOne, findOneById });
   }),
 );

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.integration.test.ts
@@ -56,12 +56,12 @@ suite("TodosRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists the todo with its org and decodes it back via findById", () =>
+    it.effect("persists the todo with its org and decodes it back via findOneById", () =>
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        const found = yield* repo.findById(orgA, buyMilk.id);
+        yield* repo.insertOne(buyMilk);
+        const found = yield* repo.findOneById(orgA, buyMilk.id);
         deepStrictEqual(found.id, buyMilk.id);
         deepStrictEqual(found.organizationId, orgA);
         deepStrictEqual(found.title, buyMilk.title);
@@ -70,12 +70,12 @@ suite("TodosRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findById", () => {
+  describe("findOneById", () => {
     it.effect("fails TodoNotFound for an unknown id", () =>
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.findById(orgA, bobId));
+        const exit = yield* Effect.exit(repo.findOneById(orgA, bobId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -88,8 +88,8 @@ suite("TodosRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        const exit = yield* Effect.exit(repo.findById(orgB, buyMilk.id));
+        yield* repo.insertOne(buyMilk);
+        const exit = yield* Effect.exit(repo.findOneById(orgB, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -104,14 +104,14 @@ suite("TodosRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
+        yield* repo.insertOne(buyMilk);
         const completed = Todo.update(buyMilk, {
           title: "Buy oat milk",
           completed: true,
           now: later,
         });
-        yield* repo.update(completed);
-        const found = yield* repo.findById(orgA, buyMilk.id);
+        yield* repo.updateOne(completed);
+        const found = yield* repo.findOneById(orgA, buyMilk.id);
         deepStrictEqual(found.title, "Buy oat milk");
         deepStrictEqual(found.completed, true);
         deepStrictEqual(
@@ -125,7 +125,7 @@ suite("TodosRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.update(buyMilk));
+        const exit = yield* Effect.exit(repo.updateOne(buyMilk));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -140,9 +140,9 @@ suite("TodosRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        yield* repo.remove(orgA, buyMilk.id);
-        const exit = yield* Effect.exit(repo.findById(orgA, buyMilk.id));
+        yield* repo.insertOne(buyMilk);
+        yield* repo.deleteOne(orgA, buyMilk.id);
+        const exit = yield* Effect.exit(repo.findOneById(orgA, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -151,14 +151,14 @@ suite("TodosRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        yield* repo.insert(buyMilk);
-        const exit = yield* Effect.exit(repo.remove(orgB, buyMilk.id));
+        yield* repo.insertOne(buyMilk);
+        const exit = yield* Effect.exit(repo.deleteOne(orgB, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
           deepStrictEqual(error instanceof TodoNotFound, true);
         }
-        const found = yield* repo.findById(orgA, buyMilk.id);
+        const found = yield* repo.findOneById(orgA, buyMilk.id);
         deepStrictEqual(found.id, buyMilk.id);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -167,7 +167,7 @@ suite("TodosRepositoryLive (integration)", () => {
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.remove(orgA, bobId));
+        const exit = yield* Effect.exit(repo.deleteOne(orgA, bobId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -186,13 +186,13 @@ suite("TodosRepositoryLive (integration)", () => {
         const exit = yield* Effect.exit(
           db.transaction((tx) =>
             Effect.gen(function* () {
-              yield* repo.insert(buyMilk).pipe(Database.TransactionContext.provide(tx));
+              yield* repo.insertOne(buyMilk).pipe(Database.TransactionContext.provide(tx));
               return yield* Effect.fail(new TodoNotFound({ todoId: bobId }));
             }),
           ),
         );
         deepStrictEqual(Exit.isFailure(exit), true);
-        const after = yield* Effect.exit(repo.findById(orgA, buyMilk.id));
+        const after = yield* Effect.exit(repo.findOneById(orgA, buyMilk.id));
         deepStrictEqual(Exit.isFailure(after), true);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
+++ b/packages/server/src/modules/todos/infrastructure/todos-repository-live.ts
@@ -16,7 +16,7 @@ export const TodosRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, todo: Todo) => {
+    const insertOne = db.makeQuery((execute, todo: Todo) => {
       const row = TodoMapper.toPersistence(todo);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -34,13 +34,13 @@ export const TodosRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("TodosRepository.insert"),
+        Effect.withSpan("TodosRepository.insertOne"),
       );
     });
 
     // Scoped on organization_id as well as id: an update aimed at a todo
     // in another org matches no row and surfaces as TodoNotFound.
-    const update = db.makeQuery((execute, todo: Todo) => {
+    const updateOne = db.makeQuery((execute, todo: Todo) => {
       const row = TodoMapper.toPersistence(todo);
       return execute((client) =>
         client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
@@ -56,7 +56,7 @@ export const TodosRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("TodosRepository.update"),
+        Effect.withSpan("TodosRepository.updateOne"),
       );
     });
 
@@ -72,30 +72,31 @@ export const TodosRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("TodosRepository.remove"),
+        Effect.withSpan("TodosRepository.deleteOne"),
       ),
     );
 
-    const findById = db.makeQuery((execute, args: { organizationId: OrganizationId; id: TodoId }) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
+    const findOneById = db.makeQuery(
+      (execute, args: { organizationId: OrganizationId; id: TodoId }) =>
+        execute((client) =>
+          client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
             SELECT * FROM todos.todos
             WHERE id = ${args.id} AND organization_id = ${args.organizationId}
           `),
-      ).pipe(
-        orFail(() => new TodoNotFound({ todoId: args.id })),
-        Effect.map(TodoMapper.toDomain),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("TodosRepository.findById"),
-      ),
+        ).pipe(
+          orFail(() => new TodoNotFound({ todoId: args.id })),
+          Effect.map(TodoMapper.toDomain),
+          Effect.catchTag("DatabaseError", Effect.die),
+          translatePersistenceUnavailable,
+          Effect.withSpan("TodosRepository.findOneById"),
+        ),
     );
 
     return TodosRepository.of({
-      insert,
-      update,
-      remove: (organizationId, id) => remove({ organizationId, id }),
-      findById: (organizationId, id) => findById({ organizationId, id }),
+      insertOne,
+      updateOne,
+      deleteOne: (organizationId, id) => remove({ organizationId, id }),
+      findOneById: (organizationId, id) => findOneById({ organizationId, id }),
     });
   }),
 );

--- a/packages/server/src/modules/todos/policies/todo-resource-resolvers.ts
+++ b/packages/server/src/modules/todos/policies/todo-resource-resolvers.ts
@@ -66,7 +66,7 @@ export const TodoResolverEntryLive = Layer.effect(
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
     return ({ organizationId, todoId }) =>
-      repo.findById(organizationId, todoId).pipe(
+      repo.findOneById(organizationId, todoId).pipe(
         Effect.map((todo) => ({ organizationId: todo.organizationId })),
         Effect.catchTag("TodoNotFound", () => Effect.fail(new CustomHttpApiError.NotFound())),
         Effect.catchTag("PersistenceUnavailable", Effect.die),

--- a/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.integration.test.ts
@@ -47,7 +47,7 @@ const seedOrgs = Effect.gen(function* () {
 const seed = (id: TodoId, organizationId: OrganizationId, title: string, now: DateTime.Utc) =>
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
-    yield* repo.insert(Todo.create({ id, organizationId, title, now }));
+    yield* repo.insertOne(Todo.create({ id, organizationId, title, now }));
   });
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;

--- a/packages/server/src/modules/user/commands/create-user.test.ts
+++ b/packages/server/src/modules/user/commands/create-user.test.ts
@@ -28,7 +28,7 @@ describe("createUser", () => {
     Effect.gen(function* () {
       const repo = yield* UserRepository;
       const id = yield* createUser(CreateUserCommand.make(baseCmd));
-      const stored = yield* repo.findById(id);
+      const stored = yield* repo.findOneById(id);
       deepStrictEqual(stored.email, "alice@example.com");
     }).pipe(Effect.provide(TestLayer)),
   );
@@ -50,7 +50,7 @@ describe("createUser", () => {
     Effect.gen(function* () {
       const repo = yield* UserRepository;
       const id = yield* createUser(CreateUserCommand.make({ email: "jit@example.com" }));
-      const stored = yield* repo.findById(id);
+      const stored = yield* repo.findOneById(id);
       deepStrictEqual(stored.email, "jit@example.com");
       deepStrictEqual(stored.address, null);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/user/commands/create-user.ts
+++ b/packages/server/src/modules/user/commands/create-user.ts
@@ -30,7 +30,7 @@ export const createUser = (cmd: CreateUserCommand): CreateUserOutput =>
           })
         : null;
     const { events, user } = User.create({ id, email: cmd.email, address, now });
-    yield* repo.insert(user);
+    yield* repo.insertOne(user);
     yield* bus.dispatch(events);
     return user.id;
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/user/commands/delete-user.test.ts
+++ b/packages/server/src/modules/user/commands/delete-user.test.ts
@@ -42,7 +42,7 @@ describe("deleteUser", () => {
 
       yield* deleteUser(DeleteUserCommand.make({ userId: id }));
 
-      const exit = yield* Effect.exit(repo.findById(id));
+      const exit = yield* Effect.exit(repo.findOneById(id));
       deepStrictEqual(Exit.isFailure(exit), true);
 
       const events = yield* rec.byTag<UserDeleted>("UserDeleted");

--- a/packages/server/src/modules/user/commands/delete-user.ts
+++ b/packages/server/src/modules/user/commands/delete-user.ts
@@ -13,8 +13,8 @@ export const deleteUser = (cmd: DeleteUserCommand): DeleteUserOutput =>
   Effect.gen(function* () {
     const repo = yield* UserRepository;
     const bus = yield* DomainEventBus;
-    const user = yield* repo.findById(cmd.userId);
+    const user = yield* repo.findOneById(cmd.userId);
     const { events } = User.markDeleted(user);
-    yield* repo.remove(user.id);
+    yield* repo.deleteOne(user.id);
     yield* bus.dispatch(events);
   }).pipe(withUnitOfWork);

--- a/packages/server/src/modules/user/domain/ports/repositories/user-repository.ts
+++ b/packages/server/src/modules/user/domain/ports/repositories/user-repository.ts
@@ -15,11 +15,13 @@ import { type UserId } from "@/platform/ids/user-id.js";
 // this abstract port-level error at the boundary. Fakes never produce
 // this at runtime but match the channel for type compatibility.
 export type UserRepositoryShape = {
-  readonly insert: (user: User) => Effect.Effect<void, UserAlreadyExists | PersistenceUnavailable>;
-  readonly update: (user: User) => Effect.Effect<void, UserNotFound | PersistenceUnavailable>;
-  readonly remove: (id: UserId) => Effect.Effect<void, UserNotFound | PersistenceUnavailable>;
-  readonly findById: (id: UserId) => Effect.Effect<User, UserNotFound | PersistenceUnavailable>;
-  readonly findByEmail: (
+  readonly insertOne: (
+    user: User,
+  ) => Effect.Effect<void, UserAlreadyExists | PersistenceUnavailable>;
+  readonly updateOne: (user: User) => Effect.Effect<void, UserNotFound | PersistenceUnavailable>;
+  readonly deleteOne: (id: UserId) => Effect.Effect<void, UserNotFound | PersistenceUnavailable>;
+  readonly findOneById: (id: UserId) => Effect.Effect<User, UserNotFound | PersistenceUnavailable>;
+  readonly findOneByEmail: (
     email: string,
   ) => Effect.Effect<Option.Option<User>, PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.test.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.test.ts
@@ -33,8 +33,8 @@ describe("UserRepositoryFake", () => {
     it.effect("stores the user and makes it findable by id", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
-        const found = yield* repo.findById(alice.id);
+        yield* repo.insertOne(alice);
+        const found = yield* repo.findOneById(alice.id);
         deepStrictEqual(found.id, alice.id);
         deepStrictEqual(found.email, alice.email);
       }).pipe(provide),
@@ -43,14 +43,14 @@ describe("UserRepositoryFake", () => {
     it.effect("fails UserAlreadyExists when email is already taken", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
+        yield* repo.insertOne(alice);
         const clashing = User.create({
           id: bobId,
           email: alice.email,
           address,
           now,
         }).user;
-        const exit = yield* Effect.exit(repo.insert(clashing));
+        const exit = yield* Effect.exit(repo.insertOne(clashing));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -61,11 +61,11 @@ describe("UserRepositoryFake", () => {
     );
   });
 
-  describe("findById", () => {
+  describe("findOneById", () => {
     it.effect("fails UserNotFound for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.findById(aliceId));
+        const exit = yield* Effect.exit(repo.findOneById(aliceId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -75,12 +75,12 @@ describe("UserRepositoryFake", () => {
     );
   });
 
-  describe("findByEmail", () => {
+  describe("findOneByEmail", () => {
     it.effect("returns Some(user) when the email matches", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
-        const result = yield* repo.findByEmail("alice@example.com");
+        yield* repo.insertOne(alice);
+        const result = yield* repo.findOneByEmail("alice@example.com");
         deepStrictEqual(Option.isSome(result), true);
         if (Option.isSome(result)) {
           deepStrictEqual(result.value.id, alice.id);
@@ -91,7 +91,7 @@ describe("UserRepositoryFake", () => {
     it.effect("returns None when no user has the email", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const result = yield* repo.findByEmail("nobody@example.com");
+        const result = yield* repo.findOneByEmail("nobody@example.com");
         deepStrictEqual(Option.isNone(result), true);
       }).pipe(provide),
     );
@@ -101,10 +101,10 @@ describe("UserRepositoryFake", () => {
     it.effect("overwrites the stored user", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
+        yield* repo.insertOne(alice);
         const { user: updated } = User.updateAddress(alice, { country: "Canada", now: later });
-        yield* repo.update(updated);
-        const found = yield* repo.findById(alice.id);
+        yield* repo.updateOne(updated);
+        const found = yield* repo.findOneById(alice.id);
         deepStrictEqual(found.address?.country, "Canada");
         deepStrictEqual(found.updatedAt, later);
       }).pipe(provide),
@@ -113,7 +113,7 @@ describe("UserRepositoryFake", () => {
     it.effect("fails UserNotFound when the user isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.update(alice));
+        const exit = yield* Effect.exit(repo.updateOne(alice));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -127,9 +127,9 @@ describe("UserRepositoryFake", () => {
     it.effect("removes the user", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
-        yield* repo.remove(alice.id);
-        const exit = yield* Effect.exit(repo.findById(alice.id));
+        yield* repo.insertOne(alice);
+        yield* repo.deleteOne(alice.id);
+        const exit = yield* Effect.exit(repo.findOneById(alice.id));
         deepStrictEqual(Exit.isFailure(exit), true);
       }).pipe(provide),
     );
@@ -137,7 +137,7 @@ describe("UserRepositoryFake", () => {
     it.effect("fails UserNotFound when the user isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.remove(aliceId));
+        const exit = yield* Effect.exit(repo.deleteOne(aliceId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -151,15 +151,15 @@ describe("UserRepositoryFake", () => {
     it.effect("each Layer acquisition gets its own store", () =>
       Effect.gen(function* () {
         const repo1 = yield* UserRepository;
-        yield* repo1.insert(alice);
-        const exists = yield* repo1.findByEmail(alice.email);
+        yield* repo1.insertOne(alice);
+        const exists = yield* repo1.findOneByEmail(alice.email);
         deepStrictEqual(Option.isSome(exists), true);
       }).pipe(provide, (first) =>
         Effect.zipRight(
           first,
           Effect.gen(function* () {
             const repo2 = yield* UserRepository;
-            const empty = yield* repo2.findByEmail(alice.email);
+            const empty = yield* repo2.findOneByEmail(alice.email);
             deepStrictEqual(Option.isNone(empty), true);
           }).pipe(provide),
         ),

--- a/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-fake.ts
@@ -25,28 +25,28 @@ export const UserRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<UserId, User>());
 
-    const insert = (user: User): Effect.Effect<void, UserAlreadyExists> =>
+    const insertOne = (user: User): Effect.Effect<void, UserAlreadyExists> =>
       Effect.flatMap(Ref.get(store), (m) =>
         Option.isSome(findUserByEmail(m, user.email))
           ? Effect.fail(new UserAlreadyExists({ email: user.email }))
           : Ref.update(store, HashMap.set(user.id, user)),
       );
 
-    const update = (user: User): Effect.Effect<void, UserNotFound> =>
+    const updateOne = (user: User): Effect.Effect<void, UserNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         HashMap.has(m, user.id)
           ? Ref.update(store, HashMap.set(user.id, user))
           : Effect.fail(new UserNotFound({ userId: user.id })),
       );
 
-    const remove = (id: UserId): Effect.Effect<void, UserNotFound> =>
+    const deleteOne = (id: UserId): Effect.Effect<void, UserNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         HashMap.has(m, id)
           ? Ref.update(store, HashMap.remove(id))
           : Effect.fail(new UserNotFound({ userId: id })),
       );
 
-    const findById = (id: UserId): Effect.Effect<User, UserNotFound> =>
+    const findOneById = (id: UserId): Effect.Effect<User, UserNotFound> =>
       Effect.flatMap(Ref.get(store), (m) =>
         Option.match(HashMap.get(m, id), {
           onNone: () => Effect.fail(new UserNotFound({ userId: id })),
@@ -54,9 +54,9 @@ export const UserRepositoryFake = Layer.effect(
         }),
       );
 
-    const findByEmail = (email: string): Effect.Effect<Option.Option<User>> =>
+    const findOneByEmail = (email: string): Effect.Effect<Option.Option<User>> =>
       Effect.map(Ref.get(store), (m) => findUserByEmail(m, email));
 
-    return UserRepository.of({ insert, update, remove, findById, findByEmail });
+    return UserRepository.of({ insertOne, updateOne, deleteOne, findOneById, findOneByEmail });
   }),
 );

--- a/packages/server/src/modules/user/infrastructure/user-repository-live.integration.test.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-live.integration.test.ts
@@ -41,11 +41,11 @@ suite("UserRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists the user and decodes it back via findById", () =>
+    it.effect("persists the user and decodes it back via findOneById", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
-        const found = yield* repo.findById(alice.id);
+        yield* repo.insertOne(alice);
+        const found = yield* repo.findOneById(alice.id);
         deepStrictEqual(found.id, alice.id);
         deepStrictEqual(found.email, alice.email);
         if (found.address === null) throw new Error("expected a stored address");
@@ -58,14 +58,14 @@ suite("UserRepositoryLive (integration)", () => {
     it.effect("fails UserAlreadyExists on duplicate email (unique violation → domain error)", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
+        yield* repo.insertOne(alice);
         const clashing = User.create({
           id: bobId,
           email: alice.email,
           address,
           now,
         }).user;
-        const exit = yield* Effect.exit(repo.insert(clashing));
+        const exit = yield* Effect.exit(repo.insertOne(clashing));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -76,11 +76,11 @@ suite("UserRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findById", () => {
+  describe("findOneById", () => {
     it.effect("fails UserNotFound for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.findById(aliceId));
+        const exit = yield* Effect.exit(repo.findOneById(aliceId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -90,12 +90,12 @@ suite("UserRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findByEmail", () => {
+  describe("findOneByEmail", () => {
     it.effect("returns Some(user) when the email matches", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
-        const result = yield* repo.findByEmail("alice@example.com");
+        yield* repo.insertOne(alice);
+        const result = yield* repo.findOneByEmail("alice@example.com");
         deepStrictEqual(Option.isSome(result), true);
         if (Option.isSome(result)) {
           deepStrictEqual(result.value.id, alice.id);
@@ -106,7 +106,7 @@ suite("UserRepositoryLive (integration)", () => {
     it.effect("returns None when no user has the email", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const result = yield* repo.findByEmail("nobody@example.com");
+        const result = yield* repo.findOneByEmail("nobody@example.com");
         deepStrictEqual(Option.isNone(result), true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -116,10 +116,10 @@ suite("UserRepositoryLive (integration)", () => {
     it.effect("overwrites address and updatedAt", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
+        yield* repo.insertOne(alice);
         const { user: updated } = User.updateAddress(alice, { country: "Canada", now: later });
-        yield* repo.update(updated);
-        const found = yield* repo.findById(alice.id);
+        yield* repo.updateOne(updated);
+        const found = yield* repo.findOneById(alice.id);
         deepStrictEqual(found.address?.country, "Canada");
         deepStrictEqual(
           DateTime.toDate(found.updatedAt).toISOString(),
@@ -131,7 +131,7 @@ suite("UserRepositoryLive (integration)", () => {
     it.effect("fails UserNotFound when the user isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.update(alice));
+        const exit = yield* Effect.exit(repo.updateOne(alice));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -145,9 +145,9 @@ suite("UserRepositoryLive (integration)", () => {
     it.effect("deletes the row", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        yield* repo.insert(alice);
-        yield* repo.remove(alice.id);
-        const exit = yield* Effect.exit(repo.findById(alice.id));
+        yield* repo.insertOne(alice);
+        yield* repo.deleteOne(alice.id);
+        const exit = yield* Effect.exit(repo.findOneById(alice.id));
         deepStrictEqual(Exit.isFailure(exit), true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -155,7 +155,7 @@ suite("UserRepositoryLive (integration)", () => {
     it.effect("fails UserNotFound when the user isn't stored", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.remove(aliceId));
+        const exit = yield* Effect.exit(repo.deleteOne(aliceId));
         deepStrictEqual(Exit.isFailure(exit), true);
         if (Exit.isFailure(exit)) {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -171,9 +171,9 @@ suite("UserRepositoryLive (integration)", () => {
         const repo = yield* UserRepository;
         const db = yield* Database.Database;
         yield* db.transaction((tx) =>
-          repo.insert(alice).pipe(Database.TransactionContext.provide(tx)),
+          repo.insertOne(alice).pipe(Database.TransactionContext.provide(tx)),
         );
-        const found = yield* repo.findByEmail(alice.email);
+        const found = yield* repo.findOneByEmail(alice.email);
         deepStrictEqual(Option.isSome(found), true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -185,7 +185,7 @@ suite("UserRepositoryLive (integration)", () => {
         const exit = yield* Effect.exit(
           db.transaction((tx) =>
             Effect.gen(function* () {
-              yield* repo.insert(alice).pipe(Database.TransactionContext.provide(tx));
+              yield* repo.insertOne(alice).pipe(Database.TransactionContext.provide(tx));
               return yield* Effect.fail(new UserNotFound({ userId: bobId }));
             }),
           ),
@@ -195,7 +195,7 @@ suite("UserRepositoryLive (integration)", () => {
           const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
           deepStrictEqual(error instanceof UserNotFound, true);
         }
-        const after = yield* repo.findByEmail(alice.email);
+        const after = yield* repo.findOneByEmail(alice.email);
         deepStrictEqual(Option.isNone(after), true);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/user/infrastructure/user-repository-live.ts
+++ b/packages/server/src/modules/user/infrastructure/user-repository-live.ts
@@ -16,7 +16,7 @@ export const UserRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, user: User) => {
+    const insertOne = db.makeQuery((execute, user: User) => {
       const row = UserMapper.toPersistence(user);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -39,11 +39,11 @@ export const UserRepositoryLive = Layer.effect(
             : Effect.die(e),
         ),
         translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.insert"),
+        Effect.withSpan("UserRepository.insertOne"),
       );
     });
 
-    const update = db.makeQuery((execute, user: User) => {
+    const updateOne = db.makeQuery((execute, user: User) => {
       const row = UserMapper.toPersistence(user);
       return execute((client) =>
         client.maybeOne(sql.type(RowSchemas.UserRowStd)`
@@ -61,11 +61,11 @@ export const UserRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.update"),
+        Effect.withSpan("UserRepository.updateOne"),
       );
     });
 
-    const remove = db.makeQuery((execute, id: UserId) =>
+    const deleteOne = db.makeQuery((execute, id: UserId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.UserRowStd)`
           DELETE FROM "user".users WHERE id = ${id} RETURNING *
@@ -75,11 +75,11 @@ export const UserRepositoryLive = Layer.effect(
         Effect.asVoid,
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.remove"),
+        Effect.withSpan("UserRepository.deleteOne"),
       ),
     );
 
-    const findById = db.makeQuery((execute, id: UserId) =>
+    const findOneById = db.makeQuery((execute, id: UserId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.UserRowStd)`
           SELECT * FROM "user".users WHERE id = ${id}
@@ -89,11 +89,11 @@ export const UserRepositoryLive = Layer.effect(
         Effect.map(UserMapper.toDomain),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.findById"),
+        Effect.withSpan("UserRepository.findOneById"),
       ),
     );
 
-    const findByEmail = db.makeQuery((execute, email: string) =>
+    const findOneByEmail = db.makeQuery((execute, email: string) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.UserRowStd)`
           SELECT * FROM "user".users WHERE email = ${email}
@@ -102,10 +102,10 @@ export const UserRepositoryLive = Layer.effect(
         Effect.map((row) => (row === null ? Option.none() : Option.some(UserMapper.toDomain(row)))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.findByEmail"),
+        Effect.withSpan("UserRepository.findOneByEmail"),
       ),
     );
 
-    return UserRepository.of({ insert, update, remove, findById, findByEmail });
+    return UserRepository.of({ insertOne, updateOne, deleteOne, findOneById, findOneByEmail });
   }),
 );

--- a/packages/server/src/modules/user/policies/user-resource-resolver.ts
+++ b/packages/server/src/modules/user/policies/user-resource-resolver.ts
@@ -21,7 +21,7 @@ export const UserResolverEntryLive = Layer.effect(
   Effect.gen(function* () {
     const repo = yield* UserRepository;
     return (id) =>
-      repo.findById(id).pipe(
+      repo.findOneById(id).pipe(
         Effect.catchTag("UserNotFound", () => Effect.fail(new CustomHttpApiError.NotFound())),
         Effect.catchTag("PersistenceUnavailable", Effect.die),
       );

--- a/packages/server/src/modules/user/queries/find-users-by-ids.integration.test.ts
+++ b/packages/server/src/modules/user/queries/find-users-by-ids.integration.test.ts
@@ -35,9 +35,9 @@ suite("findUsersByIds (integration)", () => {
       const alice = User.create({ id: aliceId, email: "alice@example.com", address, now }).user;
       const bob = User.create({ id: bobId, email: "bob@example.com", address, now }).user;
       const carol = User.create({ id: carolId, email: "carol@example.com", address, now }).user;
-      yield* repo.insert(alice);
-      yield* repo.insert(bob);
-      yield* repo.insert(carol);
+      yield* repo.insertOne(alice);
+      yield* repo.insertOne(bob);
+      yield* repo.insertOne(carol);
 
       const result = yield* findUsersByIds(FindUsersByIdsQuery.make({ ids: [aliceId, carolId] }));
       deepStrictEqual(result.length, 2);

--- a/packages/server/src/modules/user/queries/find-users.integration.test.ts
+++ b/packages/server/src/modules/user/queries/find-users.integration.test.ts
@@ -34,7 +34,7 @@ const seed = (id: UserId, email: string, now: DateTime.Utc) =>
   Effect.gen(function* () {
     const repo = yield* UserRepository;
     const { user } = User.create({ id, email, address, now });
-    yield* repo.insert(user);
+    yield* repo.insertOne(user);
   });
 
 const suite = hasTestDatabase ? describe.sequential : describe.skip;

--- a/packages/server/src/modules/wallet/domain/ports/repositories/wallet-repository.ts
+++ b/packages/server/src/modules/wallet/domain/ports/repositories/wallet-repository.ts
@@ -8,10 +8,10 @@ import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistenc
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 export type WalletRepositoryShape = {
-  readonly insert: (
+  readonly insertOne: (
     wallet: Wallet,
   ) => Effect.Effect<void, WalletAlreadyExistsForOrganization | PersistenceUnavailable>;
-  readonly findByOrganizationId: (
+  readonly findOneByOrganizationId: (
     organizationId: OrganizationId,
   ) => Effect.Effect<Option.Option<Wallet>, PersistenceUnavailable>;
 };

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.integration.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.integration.test.ts
@@ -90,8 +90,8 @@ const probeName = "Rollback Probe Org";
 const FailingWalletRepository = Layer.succeed(
   WalletRepository,
   WalletRepository.of({
-    insert: () => Effect.die("simulated wallet subscriber failure"),
-    findByOrganizationId: () => Effect.succeed(Option.none()),
+    insertOne: () => Effect.die("simulated wallet subscriber failure"),
+    findOneByOrganizationId: () => Effect.succeed(Option.none()),
   }),
 );
 

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.test.ts
@@ -26,7 +26,7 @@ const seedWallet = (organizationId: OrganizationId) =>
     const id = WalletId.make("99999999-9999-9999-9999-999999999999");
     const now = yield* DateTime.now;
     const { wallet } = Wallet.create({ id, organizationId, now });
-    yield* repo.insert(wallet);
+    yield* repo.insertOne(wallet);
   });
 
 describe("createWalletWhenOrganizationIsCreated (handleOrganizationCreated)", () => {
@@ -34,7 +34,7 @@ describe("createWalletWhenOrganizationIsCreated (handleOrganizationCreated)", ()
     Effect.gen(function* () {
       yield* handleOrganizationCreated(trigger(acmeId));
       const repo = yield* WalletRepository;
-      const stored = yield* repo.findByOrganizationId(acmeId);
+      const stored = yield* repo.findOneByOrganizationId(acmeId);
       ok(Option.isSome(stored));
       deepStrictEqual(stored.value.balance, 0);
       deepStrictEqual(stored.value.organizationId, acmeId);
@@ -56,8 +56,8 @@ describe("createWalletWhenOrganizationIsCreated (handleOrganizationCreated)", ()
     () =>
       Effect.gen(function* () {
         const FailingRepo = Effect.provideService(WalletRepository, {
-          insert: () => Effect.die("simulated infrastructure failure"),
-          findByOrganizationId: () => Effect.succeed(Option.none()),
+          insertOne: () => Effect.die("simulated infrastructure failure"),
+          findOneByOrganizationId: () => Effect.succeed(Option.none()),
         });
         const exit = yield* Effect.exit(
           handleOrganizationCreated(trigger(acmeId)).pipe(FailingRepo),

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.ts
@@ -26,6 +26,6 @@ export const handleOrganizationCreated = (trigger: OrganizationCreatedTrigger) =
     const now = yield* DateTime.now;
     const { wallet } = Wallet.create({ id, organizationId: trigger.organizationId, now });
     yield* repo
-      .insert(wallet)
+      .insertOne(wallet)
       .pipe(Effect.catchTag("WalletAlreadyExistsForOrganization", () => Effect.void));
   });

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.test.ts
@@ -27,8 +27,8 @@ describe("WalletRepositoryFake", () => {
       Effect.gen(function* () {
         const repo = yield* WalletRepository;
         const { wallet } = Wallet.create({ id: walletA, organizationId: acmeId, now });
-        yield* repo.insert(wallet);
-        const found = yield* repo.findByOrganizationId(acmeId);
+        yield* repo.insertOne(wallet);
+        const found = yield* repo.findOneByOrganizationId(acmeId);
         ok(Option.isSome(found));
         if (Option.isSome(found)) {
           deepStrictEqual(found.value.id, walletA);
@@ -45,8 +45,8 @@ describe("WalletRepositoryFake", () => {
           const repo = yield* WalletRepository;
           const { wallet: first } = Wallet.create({ id: walletA, organizationId: acmeId, now });
           const { wallet: clashing } = Wallet.create({ id: walletB, organizationId: acmeId, now });
-          yield* repo.insert(first);
-          const exit = yield* Effect.exit(repo.insert(clashing));
+          yield* repo.insertOne(first);
+          const exit = yield* Effect.exit(repo.insertOne(clashing));
           ok(Exit.isFailure(exit));
           if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
             const err = exit.cause.error;
@@ -71,10 +71,10 @@ describe("WalletRepositoryFake", () => {
           organizationId: betaId,
           now,
         });
-        yield* repo.insert(acmeWallet);
-        yield* repo.insert(betaWallet);
-        const acmeFound = yield* repo.findByOrganizationId(acmeId);
-        const betaFound = yield* repo.findByOrganizationId(betaId);
+        yield* repo.insertOne(acmeWallet);
+        yield* repo.insertOne(betaWallet);
+        const acmeFound = yield* repo.findOneByOrganizationId(acmeId);
+        const betaFound = yield* repo.findOneByOrganizationId(betaId);
         ok(Option.isSome(acmeFound));
         ok(Option.isSome(betaFound));
         if (Option.isSome(acmeFound)) deepStrictEqual(acmeFound.value.id, walletA);
@@ -83,11 +83,11 @@ describe("WalletRepositoryFake", () => {
     );
   });
 
-  describe("findByOrganizationId", () => {
+  describe("findOneByOrganizationId", () => {
     it.effect("returns None when no wallet exists for the org", () =>
       Effect.gen(function* () {
         const repo = yield* WalletRepository;
-        const result = yield* repo.findByOrganizationId(acmeId);
+        const result = yield* repo.findOneByOrganizationId(acmeId);
         ok(Option.isNone(result));
       }).pipe(provide),
     );
@@ -98,15 +98,15 @@ describe("WalletRepositoryFake", () => {
       Effect.gen(function* () {
         const repo1 = yield* WalletRepository;
         const { wallet } = Wallet.create({ id: walletA, organizationId: acmeId, now });
-        yield* repo1.insert(wallet);
-        const exists = yield* repo1.findByOrganizationId(acmeId);
+        yield* repo1.insertOne(wallet);
+        const exists = yield* repo1.findOneByOrganizationId(acmeId);
         ok(Option.isSome(exists));
       }).pipe(provide, (first) =>
         Effect.zipRight(
           first,
           Effect.gen(function* () {
             const repo2 = yield* WalletRepository;
-            const empty = yield* repo2.findByOrganizationId(acmeId);
+            const empty = yield* repo2.findOneByOrganizationId(acmeId);
             ok(Option.isNone(empty));
           }).pipe(provide),
         ),

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-fake.ts
@@ -26,7 +26,7 @@ export const WalletRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<WalletId, Wallet>());
 
-    const insert = (wallet: Wallet): Effect.Effect<void, WalletAlreadyExistsForOrganization> =>
+    const insertOne = (wallet: Wallet): Effect.Effect<void, WalletAlreadyExistsForOrganization> =>
       Effect.flatMap(Ref.get(store), (m) =>
         Option.isSome(findByOrganizationIdIn(m, wallet.organizationId))
           ? Effect.fail(
@@ -35,11 +35,11 @@ export const WalletRepositoryFake = Layer.effect(
           : Ref.update(store, HashMap.set(wallet.id, wallet)),
       );
 
-    const findByOrganizationId = (
+    const findOneByOrganizationId = (
       organizationId: OrganizationId,
     ): Effect.Effect<Option.Option<Wallet>> =>
       Effect.map(Ref.get(store), (m) => findByOrganizationIdIn(m, organizationId));
 
-    return WalletRepository.of({ insert, findByOrganizationId });
+    return WalletRepository.of({ insertOne, findOneByOrganizationId });
   }),
 );

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.integration.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.integration.test.ts
@@ -58,12 +58,12 @@ suite("WalletRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists the wallet and decodes it back via findByOrganizationId", () =>
+    it.effect("persists the wallet and decodes it back via findOneByOrganizationId", () =>
       Effect.gen(function* () {
         yield* seedOrgRow(organizationId);
         const repo = yield* WalletRepository;
-        yield* repo.insert(acmeWallet);
-        const found = yield* repo.findByOrganizationId(organizationId);
+        yield* repo.insertOne(acmeWallet);
+        const found = yield* repo.findOneByOrganizationId(organizationId);
         deepStrictEqual(Option.isSome(found), true);
         if (Option.isSome(found)) {
           deepStrictEqual(found.value.id, acmeWallet.id);
@@ -79,9 +79,9 @@ suite("WalletRepositoryLive (integration)", () => {
         Effect.gen(function* () {
           yield* seedOrgRow(organizationId);
           const repo = yield* WalletRepository;
-          yield* repo.insert(acmeWallet);
+          yield* repo.insertOne(acmeWallet);
           const clashing = Wallet.create({ id: otherWalletId, organizationId, now }).wallet;
-          const exit = yield* Effect.exit(repo.insert(clashing));
+          const exit = yield* Effect.exit(repo.insertOne(clashing));
           deepStrictEqual(Exit.isFailure(exit), true);
           if (Exit.isFailure(exit)) {
             const error = exit.cause._tag === "Fail" ? exit.cause.error : null;
@@ -95,11 +95,11 @@ suite("WalletRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findByOrganizationId", () => {
+  describe("findOneByOrganizationId", () => {
     it.effect("returns None when no wallet exists for the org", () =>
       Effect.gen(function* () {
         const repo = yield* WalletRepository;
-        const result = yield* repo.findByOrganizationId(otherOrgId);
+        const result = yield* repo.findOneByOrganizationId(otherOrgId);
         deepStrictEqual(Option.isNone(result), true);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.ts
+++ b/packages/server/src/modules/wallet/infrastructure/wallet-repository-live.ts
@@ -16,7 +16,7 @@ export const WalletRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const insert = db.makeQuery((execute, wallet: Wallet) => {
+    const insertOne = db.makeQuery((execute, wallet: Wallet) => {
       const row = WalletMapper.toPersistence(wallet);
       return execute((client) =>
         client.query(sql.unsafe`
@@ -41,11 +41,11 @@ export const WalletRepositoryLive = Layer.effect(
             : Effect.die(e),
         ),
         translatePersistenceUnavailable,
-        Effect.withSpan("WalletRepository.insert"),
+        Effect.withSpan("WalletRepository.insertOne"),
       );
     });
 
-    const findByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
+    const findOneByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.WalletRowStd)`
           SELECT * FROM wallet.wallets WHERE organization_id = ${organizationId}
@@ -56,10 +56,10 @@ export const WalletRepositoryLive = Layer.effect(
         ),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("WalletRepository.findByOrganizationId"),
+        Effect.withSpan("WalletRepository.findOneByOrganizationId"),
       ),
     );
 
-    return WalletRepository.of({ insert, findByOrganizationId });
+    return WalletRepository.of({ insertOne, findOneByOrganizationId });
   }),
 );

--- a/packages/server/src/modules/wallet/interface/events/organization-event-adapter.test.ts
+++ b/packages/server/src/modules/wallet/interface/events/organization-event-adapter.test.ts
@@ -45,7 +45,7 @@ describe("OrganizationEventAdapterLive", () => {
         } as unknown as OrganizationCreated;
         yield* bus.dispatch([event]);
 
-        const wallet = yield* repo.findByOrganizationId(organizationId);
+        const wallet = yield* repo.findOneByOrganizationId(organizationId);
         ok(Option.isSome(wallet));
         deepStrictEqual(Option.getOrThrow(wallet).organizationId, organizationId);
         // In production this dispatch runs inside `uow.run`; supply a no-op

--- a/scripts/eslint-rules/dumb-repository-ports.mjs
+++ b/scripts/eslint-rules/dumb-repository-ports.mjs
@@ -1,0 +1,95 @@
+/* eslint-disable */
+/**
+ * @fileoverview Repository ports are dumb persistence with a cardinality-explicit
+ * vocabulary (ADR-0024). The `*RepositoryShape` type may only declare methods of
+ * the form <verb><One|Many>, where verb is insert/update/delete/upsert, plus
+ * findOne / findMany (each optionally suffixed with a `By<Key>` lookup). Every
+ * operation names its size — one row or many — so callers read intent off the
+ * method name. Domain verbs (grant, revoke, promote, activate, cancel, …) are
+ * aggregate behaviour, not persistence. Because the Live and Fake implementations
+ * must structurally satisfy the port, constraining the port's method names
+ * transitively keeps the implementations dumb too.
+ *
+ * Scoped (via eslint.config.mjs) to:
+ *   packages/server/src/modules/<m>/domain/ports/repositories/*-repository.ts
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// A method name is allowed when it is one of:
+//   <verb><One|Many>                    — insertOne, updateMany, deleteOne, upsertOne, …
+//   find<One|Many>[<Qualifier>]By<Key>  — findOneById, findManyByOrganizationId,
+//                                          findOneOpenByOrganizationIdAndEmail, …
+//   find<One|Many>                      — findOne, findMany (bare)
+//   findAll[<Qualifier>]                — findAll, findAllActive (whole collection,
+//                                          no key argument; qualifier is a built-in filter)
+// On a keyed find the optional qualifier (e.g. "Open") is only permitted in front
+// of the `By<Key>` clause, so it always rides along with a lookup — a bare
+// find-and-mutate name like `findOneAndDelete` (no `By`) is still rejected. A
+// keyless filtered collection is `findAll<Qualifier>`, not `findMany<Qualifier>`.
+const ALLOWED_METHOD =
+  /^(?:(?:insert|update|delete|upsert)(?:One|Many)|findAll(?:[A-Z][A-Za-z0-9]*)?|find(?:One|Many)(?:(?:[A-Z][A-Za-z0-9]*)?By[A-Z][A-Za-z0-9]*)?)$/;
+
+function describeAllowed() {
+  return "insertOne/insertMany, updateOne/updateMany, deleteOne/deleteMany, upsertOne/upsertMany, findOne/findMany (optionally find{One,Many}[<Qualifier>]By<Key>, e.g. findOneById / findManyByOrganizationId / findOneOpenByOrganizationIdAndEmail), findAll / findAll<Qualifier> (e.g. findAllActive)";
+}
+
+function keyName(member) {
+  // Covers both `readonly save: (...) => ...` (TSPropertySignature) and
+  // `save(...): ...` (TSMethodSignature). Computed keys (`[k]: ...`) are
+  // skipped — a repository port never declares those.
+  if (!member.key || member.computed) return null;
+  if (member.key.type === "Identifier") return member.key.name;
+  if (member.key.type === "Literal" && typeof member.key.value === "string") {
+    return member.key.value;
+  }
+  return null;
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Repository ports may only declare CRUD-shaped methods; domain verbs belong on the aggregate (ADR-0024)",
+      category: "Best Practices",
+      recommended: true,
+    },
+    schema: [],
+  },
+
+  create: function (context) {
+    function checkTypeLiteral(typeLiteral) {
+      for (const member of typeLiteral.members) {
+        if (member.type !== "TSPropertySignature" && member.type !== "TSMethodSignature") {
+          continue;
+        }
+        const name = keyName(member);
+        if (name === null) continue;
+        if (ALLOWED_METHOD.test(name)) continue;
+
+        context.report({
+          node: member.key,
+          message:
+            `Repository port method "${name}" is not in the cardinality-explicit vocabulary — repositories are dumb persistence (ADR-0024). ` +
+            `Either it reads like a domain verb (put that behaviour on the aggregate and have the use case persist the result), ` +
+            `or it omits the One/Many size (rename to e.g. ${name.startsWith("find") ? "findOne…/findMany…" : "…One/…Many"}). ` +
+            `Allowed: ${describeAllowed()}.`,
+        });
+      }
+    }
+
+    return {
+      // Target the named `*Repository` / `*RepositoryShape` alias the Tag
+      // is built from. Helper types in the same file are left alone.
+      TSTypeAliasDeclaration(node) {
+        if (!/Repository(Shape)?$/.test(node.id.name)) return;
+        if (node.typeAnnotation && node.typeAnnotation.type === "TSTypeLiteral") {
+          checkTypeLiteral(node.typeAnnotation);
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## What & why

Repository ports drifted in two ways: contributors (often automated) slipped domain verbs onto them, and even the legitimately-dumb methods named cardinality inconsistently — `findByOrganizationId` returned a single `Subscription` in one module but a collection of `Membership` rows in another. This PR standardizes every repository on a **cardinality-explicit vocabulary** and makes it stick with lint.

## The vocabulary

Every repository method is now one of:

- `insertOne` / `insertMany`, `updateOne` / `updateMany`, `deleteOne` / `deleteMany`, `upsertOne` / `upsertMany`
- `findOne` / `findMany`, optionally `find{One,Many}[<Qualifier>]By<Key>` — e.g. `findOneById`, `findManyByOrganizationId`, `findOneOpenByOrganizationIdAndEmail`
- `findAll` / `findAll<Qualifier>` — keyless whole-collection reads (e.g. `findAllActive`)

You read the operation's size off the name. `findOneByOrganizationId` (the org's subscription) vs `findManyByOrganizationId` (its memberships) — where the old name hid it.

Notable mappings: `save` → `upsertOne`; `findByX` → `findOneByX` / `findManyByX` by return cardinality; `findOpenByOrganizationIdAndEmail` → `findOneOpenByOrganizationIdAndEmail` (the `Open` filter is preserved as a qualifier).

## How the rename was done

A type-aware **ts-morph codemod** renamed every `*RepositoryShape` property and all its references — call sites, object-shorthand keys, the `delete: deleteById` reserved-word idiom, and `withSpan` strings — while leaving genuine non-repository collisions untouched (`Ref.update`, `client.todos.delete`, `createHmac().update`). The codemod was a throwaway tool, not added to the repo.

## Enforcement (two lint rules)

- **eslint `dumb-repository-ports`** (`scripts/eslint-rules/dumb-repository-ports.mjs`) — port method names must match the vocabulary regex. Rejects domain verbs *and* names that omit the One/Many/All size.
- **depcruise `dumb-repository-live-no-app-collaborators`** — repository `Live`s may not import use cases (`commands`/`queries`/`event-handlers`) or the application-tier buses / unit-of-work.

Both are documented in **ADR-0024**.

## Verification

`typecheck` · `lint` · `lint:deps` · `lint:tests` · 498 unit tests · **541 integration tests against a live Postgres** — all green.

## Notes for reviewers

- Guardrails, not proofs: a determinedly misleading name (`findOneAndCredit`) or pure computation inside an `updateOne` body can still pass — they raise the floor, not replace review.
- Keyless filtered reads are intentionally `findAll<Qualifier>` (e.g. `findAllActive`), not `findMany<Qualifier>` — `Many` always pairs with a `By<Key>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
