### PR TITLE
fix(server): eslint stopgap for declaration-merged registries + real typecheck script

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -484,4 +484,47 @@ export default [
       "no-restricted-syntax": "off",
     },
   },
+  {
+    // ADR-0006 / ADR-0022: the type-safe Command/Query buses and the policy
+    // infrastructure are extended by modules via TypeScript **declaration
+    // merging**, which only works on `interface` (a merged `type` is a compile
+    // error). `consistent-type-definitions` is a `--fix`-able warn that would
+    // rewrite those `interface`s to `type` and silently break the merge, so it
+    // is turned off for the registry seam files and every file that augments
+    // them by convention. This is the Option-0 stopgap from
+    // docs/scratch/typesafe-registry-declaration-merging-spike.md — it replaces
+    // ~27 inline eslint-disable directives. The rule stays on everywhere else.
+    files: [
+      "packages/server/src/platform/ddd/ports/command-bus.ts",
+      "packages/server/src/platform/ddd/ports/query-bus.ts",
+      "packages/server/src/platform/auth/policy-registry.ts",
+      "packages/server/src/platform/auth/resource-resolver-registry.ts",
+      "packages/server/src/modules/**/*.command-handlers.ts",
+      "packages/server/src/modules/**/*.query-handlers.ts",
+      "packages/server/src/modules/**/queries/*.query.ts",
+      "packages/server/src/modules/**/policies/*.policies.ts",
+      "packages/server/src/modules/**/policies/*.resource-resolver*.ts",
+      // Test seam that declaration-merges a synthetic `test` resource into the
+      // policy registries (PolicyMap / ResourceResolverMap).
+      "packages/server/src/platform/auth/authz.test.ts",
+    ],
+    rules: {
+      "@typescript-eslint/consistent-type-definitions": "off",
+    },
+  },
+  {
+    // The four registry seams above are declared as intentionally-empty
+    // `interface`s (the merge target). Turn off the empty-interface rules for
+    // just those files so the empty declaration needs no inline disable.
+    files: [
+      "packages/server/src/platform/ddd/ports/command-bus.ts",
+      "packages/server/src/platform/ddd/ports/query-bus.ts",
+      "packages/server/src/platform/auth/policy-registry.ts",
+      "packages/server/src/platform/auth/resource-resolver-registry.ts",
+    ],
+    rules: {
+      "@typescript-eslint/no-empty-interface": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
+    },
+  },
 ];

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,7 @@
     "circular": "madge --circular src/server.ts",
     "lint": "eslint . --quiet",
     "format": "prettier --write .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -b"
   },
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.1073.0",

--- a/packages/server/src/platform/auth/policy-registry.ts
+++ b/packages/server/src/platform/auth/policy-registry.ts
@@ -32,7 +32,9 @@ export type PolicyErrors = PersistenceUnavailable;
 // root Layer-merges the per-module contributions into a single
 // registry.
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+// Must stay an `interface` (declaration merging does not work on `type`); the
+// lint rules that would fight the empty interface and rewrite it to `type` are
+// disabled for the registry seam files in eslint.config.mjs.
 export interface PolicyMap {}
 
 export type PolicyResource = keyof PolicyMap;

--- a/packages/server/src/platform/auth/resource-resolver-registry.ts
+++ b/packages/server/src/platform/auth/resource-resolver-registry.ts
@@ -11,9 +11,11 @@ import * as Layer from "effect/Layer";
 // composition root (`server.ts` / `test-server.ts`) Layer-merges the
 // resolvers into a single registry. See `docs/scratch/authz-dsl-plan.md`.
 
-// Modules contribute entries via declaration merging; this empty
-// declaration is the seam they extend.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+// Modules contribute entries via declaration merging; this empty declaration is
+// the seam they extend. It must stay an `interface` (declaration merging does not
+// work on `type`); the lint rules that would fight the empty interface and
+// rewrite it to `type` are disabled for the registry seam files in
+// eslint.config.mjs.
 export interface ResourceResolverMap {}
 
 export type ResourceName = keyof ResourceResolverMap;

--- a/packages/server/src/platform/ddd/ports/command-bus.ts
+++ b/packages/server/src/platform/ddd/ports/command-bus.ts
@@ -26,9 +26,10 @@ import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attr
 // correct typed Effect at call sites, without the bus itself knowing about
 // individual commands.
 // Intentionally empty — modules extend this via TypeScript declaration merging.
-/* eslint-disable @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type */
+// It must stay an `interface` (declaration merging does not work on `type`); the
+// lint rules that would fight the empty interface and rewrite it to `type` are
+// disabled for the registry seam files in eslint.config.mjs.
 export interface CommandRegistry {}
-/* eslint-enable @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type */
 
 type RegisteredCommand = CommandRegistry[keyof CommandRegistry] extends {
   readonly command: infer C;

--- a/packages/server/src/platform/ddd/ports/query-bus.ts
+++ b/packages/server/src/platform/ddd/ports/query-bus.ts
@@ -9,9 +9,10 @@ import { type SpanAttributesExtractor } from "@/platform/ddd/contracts/span-attr
 // (`makeQueryBus` in `platform/query-bus-live.ts`) is wired only at the
 // composition root.
 // Intentionally empty — modules extend this via TypeScript declaration merging.
-/* eslint-disable @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type */
+// It must stay an `interface` (declaration merging does not work on `type`); the
+// lint rules that would fight the empty interface and rewrite it to `type` are
+// disabled for the registry seam files in eslint.config.mjs.
 export interface QueryRegistry {}
-/* eslint-enable @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type */
 
 type RegisteredQuery = QueryRegistry[keyof QueryRegistry] extends {
   readonly query: infer Q;


### PR DESCRIPTION
## Summary

Two dev-tooling fixes surfaced while reviewing the command/query bus and policy infrastructure.

### 1. Stop `eslint --fix` from silently breaking the declaration-merged registries

The typed Command/Query buses (ADR-0006) and the policy infrastructure (ADR-0022) are extended by modules via TypeScript **declaration merging**, which only works on `interface` — a merged `type` is a compile error. But the repo's `@typescript-eslint/consistent-type-definitions` rule is set to `["warn", "type"]` and is `--fix`-able, so a non-`--quiet` `eslint --fix` (editor fix-on-save, a manual run) rewrites those `interface`s to `type` and **silently breaks the merge**. (The pre-commit hook uses `--quiet`, which skips warn-level fixes on ESLint 9, so the hook itself is safe today — the hazard is any other fix invocation.)

This replaces the ~27 inline `eslint-disable` directives (4 base seams + 23 module augmentation sites) with **two scoped overrides in `eslint.config.mjs`**:
- disable `consistent-type-definitions` for the registry seam files and every file that augments them by convention;
- disable the empty-interface rules for the four intentionally-empty seam declarations.

The rule stays on everywhere else. Net effect on the module augmentation files vs `main` is zero — they never carried disables on `main`; this PR moves the protection into config instead.

### 2. Make `pnpm --filter @org/server typecheck` a real check

`packages/server/tsconfig.json` uses the solution-style shape (`include: []` + project `references`), so the old `tsc --noEmit` script typechecked **nothing** — a false green locally. CI was unaffected (it runs `pnpm check` = `tsc -b` at the root). Switched to `tsc -b` so the script follows the references. (`tsc -b --noEmit` is rejected with TS6310 — composite referenced projects may not disable emit.)

## Verification

- A non-`--quiet` `eslint --fix` across **every** merge site is now a no-op — no `interface` is rewritten to `type` (proved via before/after working-tree diff).
- `pnpm check` (tsc -b): green.
- `pnpm lint:layout`, `pnpm lint:tests`: green.
- The fixed `typecheck` script catches an injected type error (confirmed via TS2322) and is green on a clean tree.

## Follow-up (not in this PR)

This is a **stopgap**. The inline-disable churn was a symptom of the declaration-merging design itself; a redesign spike (self-describing message/resource types that carry their own output contract, removing the registries entirely) is written up separately in the local scratch notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)