### PR TITLE
test: split unit/integration suites; integration fails instead of skipping

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  server-integration:
-    name: Server integration
+  integration:
+    name: Integration (server + jobs)
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -54,5 +54,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - name: Run server integration tests
-        run: pnpm -F @org/server test --run integration.test
+      - name: Run integration suite (server + jobs)
+        run: pnpm test:integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,20 +81,21 @@ escapes — low risk.
 ## Test seams
 
 - **Use-case unit tests** (`commands/`, `event-handlers/`) compose three test-only services: `UserRepositoryFake`, `RecordingEventBus`, `IdentityUnitOfWork`. No DB, no docker.
-- **Integration tests** (`*.repository-live.integration.test.ts`, `<endpoint>.endpoint.integration.test.ts`, `<query>.handler.integration.test.ts`) hit a real DB. They self-skip when `DATABASE_URL_TEST` is unset; `pnpm test` succeeds with no auxiliary services.
+- **Two disjoint suites, selected by file suffix + the `TEST_INTEGRATION` env toggle** (in `vitest.shared.ts`). `pnpm test` runs the **unit** suite — every `*.test.ts` _except_ `*.integration.test.ts` — and needs no auxiliary services. `pnpm test:integration` (sets `TEST_INTEGRATION=true`, scoped to `@org/server` + `@org/jobs`) runs **only** `*.integration.test.ts`. The suites never overlap.
+- **Integration tests** (`*.repository-live.integration.test.ts`, `<endpoint>.endpoint.integration.test.ts`, `<query>.handler.integration.test.ts`) hit a real DB and are **dumb** — they do not self-skip. The integration global-setup hard-fails (asserts `DATABASE_URL_TEST` is set, then connects) so a missing or unreachable DB aborts the whole run rather than silently skipping. Provide `DATABASE_URL_TEST` (name must contain `test`) before running `pnpm test:integration`.
 - **HTTP integration tests** use `useServerTestRuntime(["table1", "table2"])` from `test-utils/`, which wires `ManagedRuntime.make(TestServerLive)` + `beforeAll`/`afterAll` + per-test `truncate`. Tests then exercise the contract via `HttpApiClient.make(Api)` and seed prior state by calling _other endpoints_, not by reaching into module internals.
 - **Query/repository integration tests** seed via the live repository (or other production-path code), not via raw SQL. Using the repository as the seeding seam keeps the test honest about what production paths look like.
 - **Endpoint test naming.** A test file ending in `*.endpoint.integration.test.ts` exercises the real HTTP layer against a live database via `useServerTestRuntime(...)`. A file ending in `*.endpoint.test.ts` is a true unit test — no DB, no HTTP round-trip — typically a parity-rule token for endpoints whose meaningful coverage lives elsewhere (the OIDC `login` / `logout` flows, covered by Playwright + `SessionRepositoryLive` integration tests; `callback`'s reachable no-IdP guard has a real `callback.endpoint.integration.test.ts`). The `login`/`logout` endpoints are the two named exemptions in the folder-structure rule; every other endpoint must have `*.endpoint.integration.test.ts`. Any `.endpoint.test.ts` file must carry a header comment naming where the meaningful coverage lives; if a test starts hitting real HTTP + DB, rename it to `.endpoint.integration.test.ts`.
 
 ## Commands
 
-| Command                                    | What it runs                                                                                    |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| `pnpm check:all`                           | lint + lint:deps + typecheck + tests (the full gate)                                            |
-| `pnpm lint`                                | ESLint — includes the `project-structure/folder-structure` file-taxonomy rule (layout + parity) |
-| `pnpm test`                                | vitest, no DB                                                                                   |
-| `DATABASE_URL_TEST=postgres://… pnpm test` | also runs integration tests                                                                     |
-| `pnpm lint:deps`                           | dependency-cruiser architecture rules                                                           |
+| Command                                                | What it runs                                                                                    |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `pnpm check:all`                                       | lint + lint:deps + typecheck + tests (the full gate)                                            |
+| `pnpm lint`                                            | ESLint — includes the `project-structure/folder-structure` file-taxonomy rule (layout + parity) |
+| `pnpm test`                                            | vitest **unit** suite (excludes `*.integration.test.ts`), no DB                                 |
+| `DATABASE_URL_TEST=postgres://… pnpm test:integration` | **integration** suite only (`*.integration.test.ts`); hard-fails if no DB                       |
+| `pnpm lint:deps`                                       | dependency-cruiser architecture rules                                                           |
 
 ## Conventions worth knowing
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:deps": "depcruise --config .dependency-cruiser.cjs packages/server/src packages/contracts/src packages/jobs/src && depcruise --config .dependency-cruiser.cjs --ts-config tsconfig.depcruise-web.json packages/web packages/components",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "TEST_INTEGRATION=true pnpm --workspace-concurrency=1 --filter @org/server --filter @org/jobs run test --run",
     "test:acceptance": "pnpm -F @org/acceptance test",
     "bootstrap": "node scripts/dev-bootstrap.mjs",
     "auth:up": "docker compose up -d zitadel",

--- a/packages/jobs/src/jobs/purge-expired-sessions.integration.test.ts
+++ b/packages/jobs/src/jobs/purge-expired-sessions.integration.test.ts
@@ -5,7 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { beforeEach } from "vitest";
 
-import { hasTestDatabase, TestDatabaseLive, truncate } from "../test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "../test-utils/test-database.js";
 import { purgeExpiredSessions } from "./purge-expired-sessions.js";
 
 const userId = "11111111-1111-1111-1111-111111111111";
@@ -58,7 +58,7 @@ const findSessionIds = Effect.flatMap(Database.Database, (db) =>
 
 const TestLayer = Layer.provideMerge(Layer.empty, TestDatabaseLive);
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("purgeExpiredSessions (integration)", () => {
   beforeEach(async () => {

--- a/packages/jobs/src/test-utils/global-setup.ts
+++ b/packages/jobs/src/test-utils/global-setup.ts
@@ -1,7 +1,13 @@
-import { runMigrations } from "./test-database.js";
+import { assertTestDatabaseConfigured, runMigrations } from "./test-database.js";
 
 // Vitest expects globalSetup to default-export a function.
 // eslint-disable-next-line no-restricted-syntax
 export default async function globalSetup(): Promise<void> {
+  // Integration mode must fail — never skip — when there's no database.
+  // Assert the URL is set, then let `runMigrations` connect (it throws if the
+  // database is unreachable), so a missing or dead DB aborts the whole run.
+  if (process.env.TEST_INTEGRATION === "true") {
+    assertTestDatabaseConfigured();
+  }
   await runMigrations();
 }

--- a/packages/jobs/src/test-utils/test-database.ts
+++ b/packages/jobs/src/test-utils/test-database.ts
@@ -17,7 +17,17 @@ const rawUrl = process.env.DATABASE_URL_TEST;
 export const TEST_DATABASE_URL: string | undefined =
   rawUrl !== undefined && rawUrl.length > 0 ? rawUrl : undefined;
 
-export const hasTestDatabase = TEST_DATABASE_URL !== undefined;
+// The integration suite must fail — never skip — when it has no database to
+// talk to. Called from the integration global-setup; throws a clear error if
+// `DATABASE_URL_TEST` is unset so the whole run aborts before any test loads.
+export const assertTestDatabaseConfigured = (): void => {
+  if (TEST_DATABASE_URL === undefined) {
+    throw new Error(
+      "[test-database] integration tests require DATABASE_URL_TEST to be set. " +
+        "Start the test database and export DATABASE_URL_TEST (its name must contain 'test').",
+    );
+  }
+};
 
 const assertTestDbName = (url: string): string => {
   const name = new URL(url).pathname.replace(/^\//, "");

--- a/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-live.integration.test.ts
@@ -13,7 +13,7 @@ import { ApiTokenRootOps } from "@/modules/auth/domain/api-token.root.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/ports/repositories/api-token.repository.js";
 import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/repositories/api-token.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const idA = ApiTokenId.make("22222222-2222-2222-2222-222222222222");
@@ -42,7 +42,7 @@ const make = (id: ApiTokenId, hash: string, now: DateTime.Utc, createdAt?: DateT
     expiresAt: DateTime.add(createdAt ?? now, { days: 90 }),
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("ApiTokenRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-live.integration.test.ts
@@ -10,7 +10,7 @@ import { AuthIdentityRepository } from "@/modules/auth/domain/ports/repositories
 import { AuthIdentityNotFound } from "@/modules/auth/domain/session.errors.js";
 import { AuthIdentityRepositoryLive } from "@/modules/auth/infrastructure/repositories/auth-identity.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const subject = "zitadel-sub-integration";
@@ -33,7 +33,7 @@ const seedUserAndIdentity = Effect.gen(function* () {
   );
 }).pipe(Effect.orDie);
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("AuthIdentityRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-live.integration.test.ts
@@ -13,7 +13,7 @@ import { DeviceGrantRootOps } from "@/modules/auth/domain/device-grant.root.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/ports/repositories/device-grant.repository.js";
 import { DeviceGrantRepositoryLive } from "@/modules/auth/infrastructure/repositories/device-grant.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const id = DeviceGrantId.make("22222222-2222-2222-2222-222222222222");
@@ -39,7 +39,7 @@ const start = (now: DateTime.Utc) =>
     ttlSeconds: 600,
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DeviceGrantRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/auth/infrastructure/repositories/session.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/session.repository-live.integration.test.ts
@@ -13,7 +13,7 @@ import { SessionId } from "@/modules/auth/domain/session.id.js";
 import { SessionRootOps } from "@/modules/auth/domain/session.root.js";
 import { SessionRepositoryLive } from "@/modules/auth/infrastructure/repositories/session.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const sessionId = SessionId.make("22222222-2222-2222-2222-222222222222");
@@ -41,7 +41,7 @@ const makeSession = (now: DateTime.Utc) =>
     absoluteTtlSeconds: 43200,
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("SessionRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/auth/interface/cli/device-start.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/cli/device-start.endpoint.integration.test.ts
@@ -5,10 +5,8 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
-
 // Public endpoint — no caller identity needed.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /cli/device/start (integration)", () => {
   const { run } = useServerTestRuntime(["auth.device_grants"]);

--- a/packages/server/src/modules/auth/interface/cli/device-token.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/cli/device-token.endpoint.integration.test.ts
@@ -5,11 +5,9 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
-
 // Drives the full device flow through the real HTTP surface: the fake auth
 // middleware supplies the super-admin caller for the browser `approve` step.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /cli/device/token (integration)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/auth/interface/http/callback.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/callback.endpoint.integration.test.ts
@@ -7,8 +7,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
-
 // The callback happy path (PKCE cookie present → Zitadel code exchange →
 // session issued) needs a live Zitadel and is covered end-to-end by Playwright
 // (`packages/acceptance/specs/login.spec.ts`) and at the persistence boundary
@@ -17,7 +15,7 @@ import { hasTestDatabase } from "@/test-utils/test-database.js";
 // arriving without our signed OIDC state cookie must be rejected with 401
 // before any code exchange is attempted. This is the CSRF/replay defense, and
 // it's reachable without an IdP because it fails before `OidcClient` is called.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /auth/callback (integration)", () => {
   const { run } = useServerTestRuntime(["auth.sessions", "user.users"]);

--- a/packages/server/src/modules/auth/interface/http/create-token.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/create-token.endpoint.integration.test.ts
@@ -5,11 +5,9 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
-
 // `TestServerLive` provides the super-admin fake CurrentUser; `seedSuperAdminCaller`
 // inserts that user row so the token's user_id FK resolves.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /auth/tokens (integration)", () => {
   const { run } = useServerTestRuntime(["auth.api_tokens", "user.users", "platform.roles"], {

--- a/packages/server/src/modules/auth/interface/http/device-approve.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/device-approve.endpoint.integration.test.ts
@@ -5,10 +5,8 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
-
 // The fake auth middleware supplies the approving super-admin caller.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /auth/device/approve (integration)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/auth/interface/http/list-tokens.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/list-tokens.endpoint.integration.test.ts
@@ -5,9 +5,8 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /auth/tokens (integration)", () => {
   const { run } = useServerTestRuntime(["auth.api_tokens", "user.users", "platform.roles"], {

--- a/packages/server/src/modules/auth/interface/http/me.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/me.endpoint.integration.test.ts
@@ -5,14 +5,12 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
-
 // `TestServerLive` provides `UserAuthMiddlewareFake`, which always succeeds
 // with a deterministic admin CurrentUser. So `/auth/me` should always return
 // that fake identity here — no cookie required, no Zitadel involved. The
 // real cookie path is exercised by `auth-identity-repository-live` and by
 // the Playwright auth-setup project / login.spec.ts.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /auth/me (integration)", () => {
   const { run } = useServerTestRuntime(["user.users", "platform.roles"], {

--- a/packages/server/src/modules/auth/interface/http/revoke-token.endpoint.integration.test.ts
+++ b/packages/server/src/modules/auth/interface/http/revoke-token.endpoint.integration.test.ts
@@ -6,9 +6,8 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DELETE /auth/tokens/:id (integration)", () => {
   const { run } = useServerTestRuntime(["auth.api_tokens", "user.users", "platform.roles"], {

--- a/packages/server/src/modules/auth/queries/find-api-token-by-hash.handler.integration.test.ts
+++ b/packages/server/src/modules/auth/queries/find-api-token-by-hash.handler.integration.test.ts
@@ -16,7 +16,7 @@ import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/repositori
 import { findApiTokenByHash } from "@/modules/auth/queries/find-api-token-by-hash.handler.js";
 import { FindApiTokenByHashQuery } from "@/modules/auth/queries/find-api-token-by-hash.query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const apiTokenId = ApiTokenId.make("11111111-1111-1111-1111-111111111111");
 const userId = UserId.make("22222222-2222-2222-2222-222222222222");
@@ -73,7 +73,7 @@ const insert = (opts: { expiresAt: DateTime.Utc | null; revokedAt?: DateTime.Utc
 const errorOf = (exit: Exit.Exit<unknown, unknown>) =>
   Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findApiTokenByHash (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/auth/queries/find-session.handler.integration.test.ts
+++ b/packages/server/src/modules/auth/queries/find-session.handler.integration.test.ts
@@ -20,7 +20,7 @@ import { SessionRepositoryLive } from "@/modules/auth/infrastructure/repositorie
 import { findSession } from "@/modules/auth/queries/find-session.handler.js";
 import { FindSessionQuery } from "@/modules/auth/queries/find-session.query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const sessionId = SessionId.make("22222222-2222-2222-2222-222222222222");
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
@@ -64,7 +64,7 @@ const insertSession = (session: SessionRoot) =>
 const errorOf = (exit: Exit.Exit<unknown, unknown>) =>
   Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findSession (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/auth/queries/list-my-api-tokens.handler.integration.test.ts
+++ b/packages/server/src/modules/auth/queries/list-my-api-tokens.handler.integration.test.ts
@@ -13,7 +13,7 @@ import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/repositori
 import { listMyApiTokens } from "@/modules/auth/queries/list-my-api-tokens.handler.js";
 import { ListMyApiTokensQuery } from "@/modules/auth/queries/list-my-api-tokens.query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");
@@ -36,7 +36,7 @@ const seedUsers = Effect.gen(function* () {
     .pipe(Effect.orDie);
 });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("listMyApiTokens (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-live.integration.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-live.integration.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@/modules/billing/domain/subscription.root.js";
 import { SubscriptionRepositoryLive } from "@/modules/billing/infrastructure/repositories/subscription.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const acme = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const beta = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -59,7 +59,7 @@ const seedOrgRow = (id: OrganizationId, name: string) =>
   });
 
 const TestLayer = SubscriptionRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("SubscriptionRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-live.integration.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-live.integration.test.ts
@@ -9,10 +9,10 @@ import { beforeEach } from "vitest";
 import { WebhookEventRepository } from "@/modules/billing/domain/ports/repositories/webhook-event.repository.js";
 import { WebhookEventAlreadyRecorded } from "@/modules/billing/domain/webhook-event.errors.js";
 import { WebhookEventRepositoryLive } from "@/modules/billing/infrastructure/repositories/webhook-event.repository-live.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const TestLayer = WebhookEventRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("WebhookEventRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/billing/interface/http/cancel-subscription.endpoint.integration.test.ts
+++ b/packages/server/src/modules/billing/interface/http/cancel-subscription.endpoint.integration.test.ts
@@ -7,7 +7,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const BILLING_TABLES = [
@@ -20,7 +19,7 @@ const BILLING_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DELETE /orgs/:orgId/billing/subscriptions/current (integration)", () => {
   const { run } = useServerTestRuntime(BILLING_TABLES, {

--- a/packages/server/src/modules/billing/interface/http/get-current-subscription.endpoint.integration.test.ts
+++ b/packages/server/src/modules/billing/interface/http/get-current-subscription.endpoint.integration.test.ts
@@ -9,7 +9,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const BILLING_TABLES = [
@@ -22,7 +21,7 @@ const BILLING_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /orgs/:orgId/billing/subscriptions/current (integration)", () => {
   const { run } = useServerTestRuntime(BILLING_TABLES, {
@@ -61,7 +60,7 @@ suite("GET /orgs/:orgId/billing/subscriptions/current (integration)", () => {
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("GET /orgs/:orgId/billing/subscriptions/current (non-member caller)", () => {
   const { run } = useServerTestRuntime(BILLING_TABLES, {

--- a/packages/server/src/modules/billing/interface/http/start-subscription.endpoint.integration.test.ts
+++ b/packages/server/src/modules/billing/interface/http/start-subscription.endpoint.integration.test.ts
@@ -9,7 +9,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const BILLING_TABLES = [
@@ -22,7 +21,7 @@ const BILLING_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /orgs/:orgId/billing/subscriptions (integration)", () => {
   // The super-admin caller bypasses `IsBillingOrgAdmin` via the
@@ -78,7 +77,7 @@ suite("POST /orgs/:orgId/billing/subscriptions (integration)", () => {
 // as the CurrentUser. That user has no `super_admin` platform role and
 // no `admin` org-role on a foreign org — composed check returns false,
 // endpoint surfaces `Forbidden`.
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("POST /orgs/:orgId/billing/subscriptions (non-admin caller)", () => {
   const { run } = useServerTestRuntime(BILLING_TABLES, {

--- a/packages/server/src/modules/billing/interface/http/stripe-webhook.endpoint.integration.test.ts
+++ b/packages/server/src/modules/billing/interface/http/stripe-webhook.endpoint.integration.test.ts
@@ -11,7 +11,6 @@ import { Api } from "@/api.js";
 import { FAKE_WEBHOOK_SIGNATURE } from "@/modules/billing/infrastructure/clients/billing-gateway.client-fake.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 // The fake billing gateway's `sub_test_N` counter persists across
@@ -47,7 +46,7 @@ const BILLING_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 // The webhook endpoint reads raw bytes via `HttpServerRequest.text`
 // (Stripe's `constructEvent` requires the EXACT bytes the signature

--- a/packages/server/src/modules/billing/queries/find-subscription-by-organization.handler.integration.test.ts
+++ b/packages/server/src/modules/billing/queries/find-subscription-by-organization.handler.integration.test.ts
@@ -14,7 +14,7 @@ import { SubscriptionRepositoryLive } from "@/modules/billing/infrastructure/rep
 import { findSubscriptionByOrganization } from "@/modules/billing/queries/find-subscription-by-organization.handler.js";
 import { FindSubscriptionByOrganizationQuery } from "@/modules/billing/queries/find-subscription-by-organization.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const acme = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const beta = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -41,7 +41,7 @@ const seedOrg = (id: OrganizationId, name: string) =>
       .pipe(Effect.orDie);
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findSubscriptionByOrganization (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-live.integration.test.ts
@@ -21,7 +21,7 @@ import { InvitationRepositoryLive } from "@/modules/organization/infrastructure/
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const invitationId = InvitationId.make("44444444-4444-4444-4444-444444444444");
 const orgId = OrganizationId.make("55555555-5555-5555-5555-555555555555");
@@ -55,7 +55,7 @@ const seed = (): InvitationRoot =>
 
 const TestLayer = InvitationRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("InvitationRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-live.integration.test.ts
@@ -13,7 +13,7 @@ import { MembershipRepository } from "@/modules/organization/domain/ports/reposi
 import { MembershipRepositoryLive } from "@/modules/organization/infrastructure/repositories/membership.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");
@@ -46,7 +46,7 @@ const seedFks = Effect.gen(function* () {
 
 const TestLayer = MembershipRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("MembershipRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-live.integration.test.ts
@@ -11,7 +11,7 @@ import { OrganizationRolesRepository } from "@/modules/organization/domain/ports
 import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -51,7 +51,7 @@ const seedFixtures = Effect.gen(function* () {
 
 const TestLayer = OrganizationRolesRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("OrganizationRolesRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-live.integration.test.ts
@@ -12,7 +12,7 @@ import { OrganizationRootOps } from "@/modules/organization/domain/organization.
 import { OrganizationRepository } from "@/modules/organization/domain/ports/repositories/organization.repository.js";
 import { OrganizationRepositoryLive } from "@/modules/organization/infrastructure/repositories/organization.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const id = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const now = DateTime.unsafeMake(new Date("2026-01-01T00:00:00Z"));
@@ -20,7 +20,7 @@ const later = DateTime.unsafeMake(new Date("2026-02-01T00:00:00Z"));
 
 const TestLayer = OrganizationRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("OrganizationRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/interface/cli/find-mine.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/cli/find-mine.endpoint.integration.test.ts
@@ -5,7 +5,6 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const ORG_TABLES = [
@@ -16,7 +15,7 @@ const ORG_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /cli/orgs (integration)", () => {
   const { run } = useServerTestRuntime(ORG_TABLES, {

--- a/packages/server/src/modules/organization/interface/http/accept-invitation.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/accept-invitation.endpoint.integration.test.ts
@@ -8,10 +8,9 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { MEMBER_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 

--- a/packages/server/src/modules/organization/interface/http/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/create.endpoint.integration.test.ts
@@ -8,13 +8,12 @@ import * as Schema from "effect/Schema";
 import { Api } from "@/api.js";
 import { MEMBER_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const NameRowStd = Schema.standardSchemaV1(Schema.Struct({ name: Schema.String }));
 const MembershipCountRowStd = Schema.standardSchemaV1(Schema.Struct({ user_id: Schema.UUID }));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /orgs (integration)", () => {
   // Super-admins can't own orgs (they're a disjoint user type), so org

--- a/packages/server/src/modules/organization/interface/http/demote-member.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/demote-member.endpoint.integration.test.ts
@@ -10,10 +10,9 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { SUPER_ADMIN_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 const TARGET_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as never;
@@ -108,7 +107,7 @@ suite("DELETE /orgs/:orgId/members/:userId/admin (integration, super-admin calle
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("DELETE /orgs/:orgId/members/:userId/admin (integration, plain-member caller)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/organization/interface/http/find-all.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/find-all.endpoint.integration.test.ts
@@ -8,10 +8,9 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /admin/orgs (integration)", () => {
   // Listing all orgs is super-admin-only (organizationPolicies.read =
@@ -64,7 +63,7 @@ suite("GET /admin/orgs (integration)", () => {
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("GET /admin/orgs (integration, non-super-admin caller)", () => {
   const { run } = useServerTestRuntime(["organization.organizations", "platform.roles"], {

--- a/packages/server/src/modules/organization/interface/http/find-invitations.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/find-invitations.endpoint.integration.test.ts
@@ -6,9 +6,8 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 

--- a/packages/server/src/modules/organization/interface/http/find-members.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/find-members.endpoint.integration.test.ts
@@ -9,10 +9,9 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { MEMBER_CALLER_ID, SUPER_ADMIN_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 // A second, plain (non-admin) member, distinct from the seeded callers.
@@ -93,7 +92,7 @@ suite("GET /orgs/:orgId/members (integration, super-admin caller)", () => {
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("GET /orgs/:orgId/members (integration, plain-member caller)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/organization/interface/http/find-mine.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/find-mine.endpoint.integration.test.ts
@@ -6,10 +6,9 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /orgs (integration — findMine)", () => {
   // findMine returns the caller's own orgs, so the caller must be able to own

--- a/packages/server/src/modules/organization/interface/http/invite.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/invite.endpoint.integration.test.ts
@@ -8,10 +8,9 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 const UNKNOWN_ORG_ID = "99999999-9999-9999-9999-999999999999" as never;

--- a/packages/server/src/modules/organization/interface/http/leave.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/leave.endpoint.integration.test.ts
@@ -8,9 +8,8 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { SUPER_ADMIN_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 

--- a/packages/server/src/modules/organization/interface/http/promote-member.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/promote-member.endpoint.integration.test.ts
@@ -10,10 +10,9 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { SUPER_ADMIN_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 const TARGET_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as never;
@@ -124,7 +123,7 @@ suite("POST /orgs/:orgId/members/:userId/admin (integration, super-admin caller)
   });
 });
 
-const orgAdminSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const orgAdminSuite = describe.sequential;
 
 orgAdminSuite("POST /orgs/:orgId/members/:userId/admin (integration, org-admin caller)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/organization/interface/http/remove-member.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/remove-member.endpoint.integration.test.ts
@@ -9,10 +9,9 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { MEMBER_CALLER_ID } from "@/test-utils/fake-auth-middleware.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 const UNKNOWN_ORG_ID = "99999999-9999-9999-9999-999999999999" as never;

--- a/packages/server/src/modules/organization/interface/http/resend-invitation.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/resend-invitation.endpoint.integration.test.ts
@@ -7,9 +7,8 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 const UNKNOWN_INVITATION_ID = "22222222-2222-2222-2222-222222222222" as never;

--- a/packages/server/src/modules/organization/interface/http/restore.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/restore.endpoint.integration.test.ts
@@ -10,14 +10,13 @@ import * as Schema from "effect/Schema";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const DeletedAtRowStd = Schema.standardSchemaV1(
   Schema.Struct({ deleted_at: Schema.NullOr(Schema.DateTimeUtcFromDate) }),
 );
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /orgs/:id/restore (integration)", () => {
   // Restore is super-admin-or-org-admin; this suite runs as the super-admin
@@ -99,7 +98,7 @@ suite("POST /orgs/:id/restore (integration)", () => {
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("POST /orgs/:id/restore (integration, non-super-admin caller)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/organization/interface/http/revoke-invitation.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/revoke-invitation.endpoint.integration.test.ts
@@ -8,10 +8,9 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111" as never;
 const UNKNOWN_INVITATION_ID = "22222222-2222-2222-2222-222222222222" as never;

--- a/packages/server/src/modules/organization/interface/http/soft-delete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/organization/interface/http/soft-delete.endpoint.integration.test.ts
@@ -10,14 +10,13 @@ import * as Schema from "effect/Schema";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const DeletedAtRowStd = Schema.standardSchemaV1(
   Schema.Struct({ deleted_at: Schema.NullOr(Schema.DateTimeUtcFromDate) }),
 );
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DELETE /orgs/:id (integration)", () => {
   // Tombstoning an org is super-admin-only (organizationPolicies.delete =
@@ -80,7 +79,7 @@ suite("DELETE /orgs/:id (integration)", () => {
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("DELETE /orgs/:id (integration, non-super-admin caller)", () => {
   const { run } = useServerTestRuntime(

--- a/packages/server/src/modules/organization/queries/find-all-organizations.handler.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-all-organizations.handler.integration.test.ts
@@ -12,7 +12,7 @@ import { OrganizationRepositoryLive } from "@/modules/organization/infrastructur
 import { findAllOrganizations } from "@/modules/organization/queries/find-all-organizations.handler.js";
 import { FindAllOrganizationsQuery } from "@/modules/organization/queries/find-all-organizations.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const acmeId = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const beta = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -21,7 +21,7 @@ const later = DateTime.unsafeMake(new Date("2026-02-01T00:00:00Z"));
 
 const TestLayer = OrganizationRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findAllOrganizations (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/queries/find-membership.handler.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-membership.handler.integration.test.ts
@@ -16,7 +16,7 @@ import { findMembership } from "@/modules/organization/queries/find-membership.h
 import { FindMembershipQuery } from "@/modules/organization/queries/find-membership.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -43,7 +43,7 @@ const seedOrg = Effect.gen(function* () {
   yield* orgs.insertOne(OrganizationRootOps.create({ id: orgId, name: "Acme", now }).organization);
 });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findMembership (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/queries/find-my-organizations.handler.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-my-organizations.handler.integration.test.ts
@@ -16,7 +16,7 @@ import { findMyOrganizations } from "@/modules/organization/queries/find-my-orga
 import { FindMyOrganizationsQuery } from "@/modules/organization/queries/find-my-organizations.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
 const bobId = UserId.make("22222222-2222-2222-2222-222222222222");
@@ -41,7 +41,7 @@ const seedUsers = Effect.gen(function* () {
     .pipe(Effect.orDie);
 });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findMyOrganizations (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/queries/find-organization-memberships.handler.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-organization-memberships.handler.integration.test.ts
@@ -22,7 +22,7 @@ import { findOrganizationMemberships } from "@/modules/organization/queries/find
 import { FindOrganizationMembershipsQuery } from "@/modules/organization/queries/find-organization-memberships.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const orgA = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const orgB = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -91,7 +91,7 @@ const seedAdmin = (userId: UserId, organizationId: OrganizationId) =>
     yield* rolesRepo.upsertOne(granted.right.organizationRoles);
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findOrganizationMemberships (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/queries/find-pending-invitations.handler.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-pending-invitations.handler.integration.test.ts
@@ -18,7 +18,7 @@ import { FindPendingInvitationsQuery } from "@/modules/organization/queries/find
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const orgId = OrganizationId.make("55555555-5555-5555-5555-555555555555");
 const otherOrgId = OrganizationId.make("99999999-9999-9999-9999-999999999999");
@@ -54,7 +54,7 @@ const seedOrgs = Effect.gen(function* () {
   );
 });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findPendingInvitations (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/organization/queries/find-user-organization-roles.handler.integration.test.ts
+++ b/packages/server/src/modules/organization/queries/find-user-organization-roles.handler.integration.test.ts
@@ -17,7 +17,7 @@ import { findUserOrganizationRoles } from "@/modules/organization/queries/find-u
 import { FindUserOrganizationRolesQuery } from "@/modules/organization/queries/find-user-organization-roles.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -46,7 +46,7 @@ const seedOrg = Effect.gen(function* () {
   yield* orgs.insertOne(OrganizationRootOps.create({ id: orgId, name: "Acme", now }).organization);
 });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findUserOrganizationRoles (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/role/infrastructure/repositories/roles.repository-live.integration.test.ts
+++ b/packages/server/src/modules/role/infrastructure/repositories/roles.repository-live.integration.test.ts
@@ -10,7 +10,7 @@ import { RolesRepository } from "@/modules/role/domain/ports/repositories/roles.
 import { RolesRootOps } from "@/modules/role/domain/roles.root.js";
 import { RolesRepositoryLive } from "@/modules/role/infrastructure/repositories/roles.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 
@@ -31,7 +31,7 @@ const seedUser = Effect.gen(function* () {
 
 const TestLayer = RolesRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("RolesRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/role/queries/find-user-roles.handler.integration.test.ts
+++ b/packages/server/src/modules/role/queries/find-user-roles.handler.integration.test.ts
@@ -12,7 +12,7 @@ import { RolesRepositoryLive } from "@/modules/role/infrastructure/repositories/
 import { findUserRoles } from "@/modules/role/queries/find-user-roles.handler.js";
 import { FindUserRolesQuery } from "@/modules/role/queries/find-user-roles.query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 
@@ -30,7 +30,7 @@ const seedUser = Effect.gen(function* () {
     .pipe(Effect.orDie);
 });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findUserRoles (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-live.integration.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-live.integration.test.ts
@@ -13,7 +13,7 @@ import { TodoId } from "@/modules/todos/domain/todo.id.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo.root.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/repositories/todos.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");
@@ -46,7 +46,7 @@ const seedOrgs = Effect.gen(function* () {
 
 const TestLayer = TodosRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("TodosRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/todos/interface/cli/complete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/complete.endpoint.integration.test.ts
@@ -6,7 +6,6 @@ import * as Effect from "effect/Effect";
 import { Api } from "@/api.js";
 import { TodoId } from "@/modules/todos/domain/todo.id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -18,7 +17,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /cli/orgs/:orgId/todos/:id/complete (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/cli/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/create.endpoint.integration.test.ts
@@ -5,7 +5,6 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -17,7 +16,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /cli/orgs/:orgId/todos (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/cli/list.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/list.endpoint.integration.test.ts
@@ -5,7 +5,6 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -17,7 +16,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /cli/orgs/:orgId/todos (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/cli/remove.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/cli/remove.endpoint.integration.test.ts
@@ -6,7 +6,6 @@ import * as Effect from "effect/Effect";
 import { Api } from "@/api.js";
 import { TodoId } from "@/modules/todos/domain/todo.id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -18,7 +17,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DELETE /cli/orgs/:orgId/todos/:id (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/http/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/create.endpoint.integration.test.ts
@@ -8,7 +8,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -20,7 +19,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /orgs/:orgId/todos (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {
@@ -42,7 +41,7 @@ suite("POST /orgs/:orgId/todos (integration)", () => {
   });
 });
 
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("POST /orgs/:orgId/todos (integration, non-member caller)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/http/delete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/delete.endpoint.integration.test.ts
@@ -8,7 +8,6 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { TodoId } from "@/modules/todos/domain/todo.id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -20,7 +19,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DELETE /orgs/:orgId/todos/:id (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/http/get.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/get.endpoint.integration.test.ts
@@ -8,7 +8,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -20,7 +19,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /orgs/:orgId/todos (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {
@@ -52,7 +51,7 @@ suite("GET /orgs/:orgId/todos (integration)", () => {
 });
 
 // Non-member caller (not super-admin) is rejected before any query.
-const memberSuite = hasTestDatabase ? describe.sequential : describe.skip;
+const memberSuite = describe.sequential;
 
 memberSuite("GET /orgs/:orgId/todos (integration, non-member caller)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/interface/http/update.endpoint.integration.test.ts
+++ b/packages/server/src/modules/todos/interface/http/update.endpoint.integration.test.ts
@@ -8,7 +8,6 @@ import * as Exit from "effect/Exit";
 import { Api } from "@/api.js";
 import { TodoId } from "@/modules/todos/domain/todo.id.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const TODO_TABLES = [
@@ -20,7 +19,7 @@ const TODO_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("PUT /orgs/:orgId/todos/:id (integration)", () => {
   const { run } = useServerTestRuntime(TODO_TABLES, {

--- a/packages/server/src/modules/todos/queries/list-todos.handler.integration.test.ts
+++ b/packages/server/src/modules/todos/queries/list-todos.handler.integration.test.ts
@@ -13,7 +13,7 @@ import { TodosRepositoryLive } from "@/modules/todos/infrastructure/repositories
 import { listTodos } from "@/modules/todos/queries/list-todos.handler.js";
 import { ListTodosQuery } from "@/modules/todos/queries/list-todos.query.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
 const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");
@@ -50,7 +50,7 @@ const seed = (id: TodoId, organizationId: OrganizationId, title: string, now: Da
     yield* repo.insertOne(TodoRootOps.create({ id, organizationId, title, now }));
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("listTodos (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/user/infrastructure/repositories/user.repository-live.integration.test.ts
+++ b/packages/server/src/modules/user/infrastructure/repositories/user.repository-live.integration.test.ts
@@ -14,7 +14,7 @@ import { UserRootOps } from "@/modules/user/domain/user.root.js";
 import { AddressValueObject } from "@/modules/user/domain/value-objects/address.value-object.js";
 import { UserRepositoryLive } from "@/modules/user/infrastructure/repositories/user.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
 const bobId = UserId.make("22222222-2222-2222-2222-222222222222");
@@ -33,7 +33,7 @@ const TestLayer = UserRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
 // Integration tests share one DB and truncate between cases, so they must run
 // sequentially — vitest.shared.ts sets sequence.concurrent: true globally.
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("UserRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/user/interface/http/create.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/create.endpoint.integration.test.ts
@@ -9,7 +9,6 @@ import { Api } from "@/api.js";
 import { FindUsersQuery } from "@/modules/user/index.js";
 import { QueryBus } from "@/platform/ddd/ports/query-bus.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",
@@ -18,7 +17,7 @@ const basePayload = {
   postalCode: "12345",
 };
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("POST /users (integration)", () => {
   const { run } = useServerTestRuntime(["user.users"]);

--- a/packages/server/src/modules/user/interface/http/delete.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/delete.endpoint.integration.test.ts
@@ -7,7 +7,6 @@ import * as Exit from "effect/Exit";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",
@@ -16,7 +15,7 @@ const basePayload = {
   postalCode: "12345",
 };
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("DELETE /users/:id (integration)", () => {
   const { run } = useServerTestRuntime(["user.users"]);

--- a/packages/server/src/modules/user/interface/http/find.endpoint.integration.test.ts
+++ b/packages/server/src/modules/user/interface/http/find.endpoint.integration.test.ts
@@ -5,7 +5,6 @@ import * as Effect from "effect/Effect";
 
 import { Api } from "@/api.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase } from "@/test-utils/test-database.js";
 
 const basePayload = {
   email: "alice@example.com",
@@ -14,7 +13,7 @@ const basePayload = {
   postalCode: "12345",
 };
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("GET /users (integration)", () => {
   const { run } = useServerTestRuntime(["user.users"]);

--- a/packages/server/src/modules/user/queries/find-users-by-ids.handler.integration.test.ts
+++ b/packages/server/src/modules/user/queries/find-users-by-ids.handler.integration.test.ts
@@ -12,7 +12,7 @@ import { UserRepositoryLive } from "@/modules/user/infrastructure/repositories/u
 import { findUsersByIds } from "@/modules/user/queries/find-users-by-ids.handler.js";
 import { FindUsersByIdsQuery } from "@/modules/user/queries/find-users-by-ids.query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const address = AddressValueObject.make({
   country: "USA",
@@ -26,7 +26,7 @@ const now = DateTime.unsafeMake(new Date("2025-01-01T00:00:00Z"));
 
 const TestLayer = UserRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findUsersByIds (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/user/queries/find-users.handler.integration.test.ts
+++ b/packages/server/src/modules/user/queries/find-users.handler.integration.test.ts
@@ -12,7 +12,7 @@ import { UserRepositoryLive } from "@/modules/user/infrastructure/repositories/u
 import { findUsers } from "@/modules/user/queries/find-users.handler.js";
 import { FindUsersQuery } from "@/modules/user/queries/find-users.query.js";
 import { UserId } from "@/platform/ids/user-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const address = AddressValueObject.make({
   country: "USA",
@@ -37,7 +37,7 @@ const seed = (id: UserId, email: string, now: DateTime.Utc) =>
     yield* repo.insertOne(user);
   });
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("findUsers (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.handler.integration.test.ts
+++ b/packages/server/src/modules/wallet/event-handlers/create-wallet-when-organization-is-created.handler.integration.test.ts
@@ -19,7 +19,7 @@ import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { makeIntegrationEventBusLive } from "@/platform/integration-event-bus-live.js";
 import { UnitOfWorkLive } from "@/platform/unit-of-work-live.js";
 import { useServerTestRuntime } from "@/test-utils/server-test-runtime.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 import { TestServerLiveAsMember } from "@/test-utils/test-server.js";
 
 const WALLET_TABLES = [
@@ -31,7 +31,7 @@ const WALLET_TABLES = [
   "user.users",
 ] as const;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("CreateWalletWhenOrganizationIsCreated (integration)", () => {
   // `seedSuperAdminCaller` is required: creating an org inserts a

--- a/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-live.integration.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-live.integration.test.ts
@@ -14,7 +14,7 @@ import { WalletId } from "@/modules/wallet/domain/wallet.id.js";
 import { WalletRootOps } from "@/modules/wallet/domain/wallet.root.js";
 import { WalletRepositoryLive } from "@/modules/wallet/infrastructure/repositories/wallet.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const organizationId = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const otherOrgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
@@ -46,7 +46,7 @@ const seedOrgRow = (id: OrganizationId) =>
 
 const TestLayer = WalletRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("WalletRepositoryLive (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/platform/unit-of-work-live.integration.test.ts
+++ b/packages/server/src/platform/unit-of-work-live.integration.test.ts
@@ -12,8 +12,7 @@ import { IntegrationEventBus } from "@/platform/ddd/ports/integration-event-bus.
 import { UnitOfWork } from "@/platform/ddd/ports/unit-of-work.js";
 import { makeIntegrationEventBusLive } from "@/platform/integration-event-bus-live.js";
 import { UnitOfWorkLive } from "@/platform/unit-of-work-live.js";
-import { hasTestDatabase, TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
-
+import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 // `UnitOfWorkLive` now depends on `IntegrationEventBus` (for the post-commit
 // flush). Bundling them in one layer guarantees the test body's
 // `yield* IntegrationEventBus` and the unit of work's flush share the SAME bus
@@ -44,7 +43,7 @@ const countFlush = sql.type(RowSchemas.UserRowStd)`
   SELECT * FROM "user".users WHERE id IN (${outerId}, ${markerId})
 `;
 
-const suite = hasTestDatabase ? describe.sequential : describe.skip;
+const suite = describe.sequential;
 
 suite("UnitOfWorkLive re-entrancy (integration)", () => {
   beforeEach(async () => {

--- a/packages/server/src/test-utils/global-setup.ts
+++ b/packages/server/src/test-utils/global-setup.ts
@@ -1,8 +1,14 @@
-import { runMigrations } from "./test-database.js";
+import { assertTestDatabaseConfigured, runMigrations } from "./test-database.js";
 
 // Vitest expects globalSetup to default-export a function. The eslint rule
 // prefers named exports, but the framework contract overrides that here.
 // eslint-disable-next-line no-restricted-syntax
 export default async function globalSetup(): Promise<void> {
+  // Integration mode must fail — never skip — when there's no database.
+  // Assert the URL is set, then let `runMigrations` connect (it throws if the
+  // database is unreachable), so a missing or dead DB aborts the whole run.
+  if (process.env.TEST_INTEGRATION === "true") {
+    assertTestDatabaseConfigured();
+  }
   await runMigrations();
 }

--- a/packages/server/src/test-utils/test-database.ts
+++ b/packages/server/src/test-utils/test-database.ts
@@ -12,7 +12,17 @@ const rawUrl = process.env.DATABASE_URL_TEST;
 export const TEST_DATABASE_URL: string | undefined =
   rawUrl !== undefined && rawUrl.length > 0 ? rawUrl : undefined;
 
-export const hasTestDatabase = TEST_DATABASE_URL !== undefined;
+// The integration suite must fail — never skip — when it has no database to
+// talk to. Called from the integration global-setup; throws a clear error if
+// `DATABASE_URL_TEST` is unset so the whole run aborts before any test loads.
+export const assertTestDatabaseConfigured = (): void => {
+  if (TEST_DATABASE_URL === undefined) {
+    throw new Error(
+      "[test-database] integration tests require DATABASE_URL_TEST to be set. " +
+        "Start the test database and export DATABASE_URL_TEST (its name must contain 'test').",
+    );
+  }
+};
 
 // Never point a truncate/migrate at a DB that isn't explicitly a test DB.
 const assertTestDbName = (url: string): string => {

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,5 +1,13 @@
 import * as path from "node:path";
-import type { ViteUserConfig } from "vitest/config";
+import { configDefaults, type ViteUserConfig } from "vitest/config";
+
+// Two mutually exclusive test modes, selected by the `TEST_INTEGRATION` env
+// var (set by the `test:integration` scripts). The unit suite runs every
+// `*.test.ts` EXCEPT `*.integration.test.ts` and needs no auxiliary services.
+// The integration suite runs ONLY `*.integration.test.ts` and requires a real
+// database — its global-setup hard-fails (never skips) when the DB is
+// unconfigured or unreachable.
+const runIntegration = process.env.TEST_INTEGRATION === "true";
 
 const alias = (name: string) => {
   const target = process.env.TEST_DIST !== undefined ? "dist/dist/esm" : "src";
@@ -29,7 +37,18 @@ const config: ViteUserConfig = {
     sequence: {
       concurrent: true,
     },
-    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+    include: runIntegration
+      ? ["test/**/*.integration.test.ts", "src/**/*.integration.test.ts"]
+      : ["test/**/*.test.ts", "src/**/*.test.ts"],
+    exclude: runIntegration
+      ? [...configDefaults.exclude]
+      : ["**/*.integration.test.ts", ...configDefaults.exclude],
+    // A package may legitimately have tests for only one suite (e.g. @org/jobs
+    // has integration tests but no unit tests), so an isolated per-package run
+    // of the other suite finds zero files. Don't treat that as a failure — the
+    // integration global-setup, not an empty file set, is what enforces "fail,
+    // don't skip" when the DB is missing.
+    passWithNoTests: true,
     alias: {
       ...alias("cli"),
       ...alias("contracts"),


### PR DESCRIPTION
## What & why

The integration suite used to be too clever: each `*.integration.test.ts` file self-skipped when `DATABASE_URL_TEST` was unset (`hasTestDatabase ? describe.sequential : describe.skip`), and `pnpm test` ran unit + integration files together. A misconfigured or unreachable DB silently produced a green run.

This makes the integration suite **dumb**: it *fails* — never skips — when it can't reach a database, and the unit/integration suites are cleanly separated by file suffix.

## Behavior

- **`pnpm test`** — unit suite: every `*.test.ts` **except** `*.integration.test.ts`. No DB, no docker.
- **`pnpm test:integration`** — integration suite: **only** `*.integration.test.ts`. Requires a real DB; **hard-fails** if `DATABASE_URL_TEST` is unset or the DB is unreachable.

The two suites never overlap.

## How

- **`vitest.shared.ts`** — a `TEST_INTEGRATION` env toggle flips `include`/`exclude`. Unit mode adds `**/*.integration.test.ts` to `exclude`; integration mode includes only those files. Added `passWithNoTests` so a package with integration tests but no unit tests (`@org/jobs`) doesn't error on an isolated unit run.
- **global-setup (server + jobs)** — in integration mode, assert `DATABASE_URL_TEST` is set (new `assertTestDatabaseConfigured`), then let `runMigrations` connect. A missing/unreachable DB aborts the whole run in setup, before any test loads.
- Dropped the per-file `describe.skip` ternary and the now-unused `hasTestDatabase` import/export across all 70 integration test files.
- Added **`pnpm test:integration`** (`TEST_INTEGRATION=true`, scoped to `@org/server` + `@org/jobs`, `--workspace-concurrency=1` so the two package runs don't race on the shared test DB). The integration CI workflow now routes through this script — which also brings the `@org/jobs` integration test into CI for the first time.
- **CLAUDE.md** — documents the two-suite split and the fail-don't-skip behavior.

## Verification

- Unit suite (no DB): 78 files / 353 tests pass; no integration files loaded.
- Integration mode, no DB: aborts in global-setup with a clear error (exit 1) — fails, doesn't skip.
- `pnpm test:integration` against a local DB: server 69 files / 218 tests + jobs 1 file / 3 tests, all pass, no migration race.
- `pnpm lint` and `tsc -b` (server + jobs) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)