### PR TITLE
fix(effect-v4): auth-middleware errors as array so status codes map (fixes E2E)

### DIFF
--- a/packages/contracts/src/Policy.ts
+++ b/packages/contracts/src/Policy.ts
@@ -1,5 +1,4 @@
 import * as Context from "effect/Context";
-import * as Schema from "effect/Schema";
 import * as HttpApiMiddleware from "effect/unstable/httpapi/HttpApiMiddleware";
 
 import * as CustomHttpApiError from "./CustomHttpApiError.js";
@@ -29,5 +28,13 @@ export class UserAuthMiddleware extends HttpApiMiddleware.Service<
   UserAuthMiddleware,
   { provides: CurrentUser }
 >()("UserAuthMiddleware", {
-  error: Schema.Union([CustomHttpApiError.Unauthorized, CustomHttpApiError.ServiceUnavailable]),
+  // Declare the errors as an ARRAY, not `Schema.Union([...])`. The
+  // middleware stores `error` as a `Set` of individual schemas
+  // (`getError` wraps a non-array in a one-element set), and
+  // `HttpApiBuilder` reads each member's `httpApiStatus` annotation to
+  // pick the response status. A single union schema has no status
+  // annotation on its own node, so every auth failure collapses to 500
+  // (the `getStatusError` fallback) — e.g. `/auth/me` returns 500 instead
+  // of 401. Passing the array keeps each error's status (401 / 503).
+  error: [CustomHttpApiError.Unauthorized, CustomHttpApiError.ServiceUnavailable],
 }) {}


### PR DESCRIPTION
## Problem

All Playwright E2E tests started failing after the effect v4 migration (#97). CI hangs for 60s then fails with:

```
Error: Timed out waiting 60000ms from config.webServer.
[bff] ... 'http.url': '/auth/me', 'http.status': 500   (repeated until timeout)
```

Playwright's `webServer` readiness probe hits `GET /auth/me` and treats the pre-migration **401** as "ready". Post-migration the endpoint returned **500** on every request, so the probe never went green and the whole suite failed **before any spec ran**.

## Root cause

`UserAuthMiddleware` (in `packages/contracts/src/Policy.ts`) declared its error channel as a single `Schema.Union([Unauthorized, ServiceUnavailable])`.

In effect v4's httpapi:
- `HttpApiMiddleware.Service` stores `error` as a **`Set` of schemas** — `getError` wraps a non-array value in a one-element set, so the union became a single Set member.
- `HttpApiBuilder` derives each error's HTTP status by reading the `httpApiStatus` annotation **off that schema's own AST node** (`getStatusError`).
- A `Schema.Union` node carries no `httpApiStatus` of its own (only its members do), so `getStatusError` fell back to its `?? 500` default.

Result: every auth failure — including the unauthenticated `/auth/me` — was emitted as **HTTP 500** with the body still correctly serialized as `{"_tag":"Unauthorized"}`. Unit/integration tests didn't catch it because they use a fake middleware and `HttpApiClient` decodes by `_tag`, not status.

## Fix

Declare the errors as an **array** so each is stored as a distinct Set member and keeps its own status annotation:

```diff
-  error: Schema.Union([CustomHttpApiError.Unauthorized, CustomHttpApiError.ServiceUnavailable]),
+  error: [CustomHttpApiError.Unauthorized, CustomHttpApiError.ServiceUnavailable],
```

The middleware's error type is unchanged (`Unauthorized | ServiceUnavailable`).

## Verification

- Booted the BFF against the test DB: `GET /auth/me` (no cookie) now returns **401** (was 500).
- `pnpm check:effect` and `tsc -b` (contracts + server) green.
- **All 7 acceptance specs pass locally**, including the live Zitadel login flow.