### PR TITLE
perf(auth): fork last-used touch off the request critical path

### DIFF
--- a/docs/adr/0016-authentication-with-self-hosted-zitadel.md
+++ b/docs/adr/0016-authentication-with-self-hosted-zitadel.md
@@ -38,7 +38,7 @@ Logout flow: the browser navigates to `GET /auth/logout` (idempotent, public —
 `Session` is an aggregate, not a leaf record. Sliding TTL with an absolute cap (`SESSION_TTL_SECONDS` / `SESSION_ABSOLUTE_TTL_SECONDS`). The aggregate, repository (live + fake), the `SignIn` and `TouchSession` commands, the `findSession` query, and the four endpoints (`login`, `callback`, `me`, `logout`) live under `modules/auth/` per the module conventions (ADR-0002, ADR-0013). A few things sit at platform level:
 
 - `platform/auth/cookie-codec.ts` — generic HMAC sign/verify, used by both the auth module and the auth middleware.
-- `platform/middlewares/auth-middleware-live.ts` — the implementation behind the auth middleware. It reads the cookie, dispatches `FindSessionQuery`, dispatches `TouchSessionCommand` (sliding refresh), performs a one-line `users.role` lookup to populate the super-admin flag, and hydrates `CurrentUser`. Authorization checks themselves live in the per-route policy layer (ADR-0021).
+- `platform/middlewares/auth-middleware-live.ts` — the implementation behind the auth middleware. It reads the cookie, dispatches `FindSessionQuery`, dispatches `TouchSessionCommand` (sliding refresh, fire-and-forget — see below), performs a one-line `users.role` lookup to populate the super-admin flag, and hydrates `CurrentUser`. Authorization checks themselves live in the per-route policy layer (ADR-0021).
 
 ### Sliding-TTL refresh via `TouchSessionCommand`
 
@@ -47,6 +47,8 @@ Every authenticated request, after `findSession` succeeds, the middleware dispat
 - Skips the write when the prior `lastUsedAt` is younger than `SESSION_TOUCH_THRESHOLD_SECONDS` (default 60). Without this throttle, a busy client would hammer Postgres with one UPDATE per request for no real-world benefit.
 - Computes the new `expiresAt` via the `Session.touch` aggregate function, which clamps to `absoluteExpiresAt` so the hard cap holds.
 - Persists via `SessionRepository.updateOne`, whose SQL `WHERE revoked_at IS NULL` guards against touching a session revoked between the query and the command. `SessionNotFound` failures (revoked or deleted mid-flight) are swallowed — the user already has a valid `CurrentUser` for this request, and the next request fails cleanly.
+
+The dispatch is **fire-and-forget**: the middleware forks the command onto a detached fiber (`forkDetach`) rather than awaiting it, so the touch's read-and-maybe-write never sits on the auth critical path. Authentication is already established by `findSession`; the touch is a best-effort refresh, and blocking every authenticated request on an extra round-trip would add latency for no correctness gain. Because the fiber is detached it is also not awaited at shutdown — an in-flight touch can be dropped on restart, which is harmless for a stamp the next request re-applies. The bearer path (CLI / MCP) dispatches its analogous `TouchApiTokenCommand` the same way, for the same reason.
 
 This keeps lifecycle reads (`findSession`) and writes (`TouchSessionCommand`) on opposite sides of CQRS without putting business logic in the middleware.
 

--- a/packages/server/src/platform/middlewares/auth-middleware-live.ts
+++ b/packages/server/src/platform/middlewares/auth-middleware-live.ts
@@ -67,8 +67,10 @@ export const UserAuthMiddlewareLive = Layer.effect(
         const apiToken = yield* queryBus
           .execute(FindApiTokenByHashQuery.make({ tokenHash: CredentialHash.of(bearer) }))
           .pipe(Effect.provideService(Database.Database, db), Effect.mapError(toAuthError));
-        // Fire-and-forget last-used stamp; throttled + error-swallowing in the
-        // handler, same rationale as the session touch below.
+        // Last-used stamp, forked off the request fiber (`forkDetach`) so its
+        // lookup + throttle never sit on the auth critical path. Detached from
+        // the request scope so it outlives the response; throttled +
+        // error-swallowing in the handler. Same rationale as the session touch.
         yield* commandBus
           .execute(
             TouchApiTokenCommand.make({
@@ -76,7 +78,7 @@ export const UserAuthMiddlewareLive = Layer.effect(
               thresholdSeconds: env.API_TOKEN_TOUCH_THRESHOLD_SECONDS,
             }),
           )
-          .pipe(Effect.provideService(Database.Database, db));
+          .pipe(Effect.provideService(Database.Database, db), Effect.forkDetach);
         // No browser session for a bearer caller; the token id stands in as
         // the opaque principal id on `CurrentUser` (Policy.ts unchanged).
         return { sessionId: apiToken.id, userId: apiToken.userId };
@@ -91,7 +93,8 @@ export const UserAuthMiddlewareLive = Layer.effect(
       const session = yield* queryBus
         .execute(FindSessionQuery.make({ sessionId }))
         .pipe(Effect.provideService(Database.Database, db), Effect.mapError(toAuthError));
-      // Sliding-TTL refresh, fire-and-forget on the request fiber. The
+      // Sliding-TTL refresh, forked off the request fiber (`forkDetach`) so it
+      // stays off the auth critical path and outlives the response. The
       // command's own throttle decides whether to write; failures are
       // benign races (revoked / removed mid-flight) and are swallowed by
       // the handler so they never bubble up as a 401.
@@ -103,7 +106,7 @@ export const UserAuthMiddlewareLive = Layer.effect(
             thresholdSeconds: env.SESSION_TOUCH_THRESHOLD_SECONDS,
           }),
         )
-        .pipe(Effect.provideService(Database.Database, db));
+        .pipe(Effect.provideService(Database.Database, db), Effect.forkDetach);
       return {
         sessionId: session.id,
         userId: session.userId,


### PR DESCRIPTION
## Summary

The auth middleware dispatched `TouchSessionCommand` (cookie path) and `TouchApiTokenCommand` (bearer path) with `yield*`, so the request fiber **blocked** on the touch's read-and-maybe-write before the endpoint ran — adding a DB round-trip to every authenticated request for a best-effort last-used/TTL stamp that carries no correctness weight (auth is already established by `findSession` / `findApiTokenByHash`).

This forks both dispatches onto a detached fiber (`Effect.forkDetach`) so the stamp runs **off the critical path**.

## Why `forkDetach` is safe here

- **No orphan/leak.** `forkDetach` attaches to the global scope so the touch survives the response returning, but the effect is short and self-terminating (one read + throttled write, errors already swallowed in the handler). Verified against `effect@4.0.0-beta.94`: `forkUnsafe(..., daemon=true)` skips the `parent.children().add(child)` registration entirely, so the fiber isn't retained in any child set — it completes and is GC'd.
- **`db` handle is long-lived.** It's captured at layer-build time (a pool handle), safe to reference from the detached fiber.
- **Gating is unaffected.** The fork is downstream of the resolved principal; the endpoint still runs only inside the `flatMap` that provides `CurrentUser`.

## Trade-off (accepted)

A detached fiber isn't awaited at shutdown, so an in-flight touch can be dropped on restart. Harmless for a stamp the next request re-applies.

## Alternatives considered

- **Pass the already-fetched token in the command** to skip the handler's re-query — rejected: leaks the write-side aggregate (and `tokenHash`) into the public command contract, and the re-read guards against a stale full-row `updateOne` clobbering a concurrent change.
- **Targeted conditional `UPDATE` in the repository** — rejected: violates the dumb-repository rule (ADR-0005) by pushing throttle/revocation logic into infrastructure.

## Docs

Updates **ADR-0016** to document the fire-and-forget dispatch and its rationale for both the session and api-token touch paths.

## Test plan

- [x] `pnpm --filter @org/server typecheck`
- [x] `pnpm check:effect` (no diagnostics)
- [x] ESLint on the changed file
- No test asserted synchronous touch-through-middleware behavior (touch logic is covered by the handler unit tests, which are unchanged), so nothing goes racy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)