### PR TITLE
refactor(server): specification query-object repositories

### DIFF
--- a/docs/adr/0005-repository-pattern.md
+++ b/docs/adr/0005-repository-pattern.md
@@ -1,7 +1,7 @@
-# ADR-0005: Repository pattern — dumb, cardinality-explicit ports (Live + Fake in infrastructure)
+# ADR-0005: Repository pattern — dumb, specification-queried ports (Live + Fake in infrastructure)
 
 - Status: Accepted
-- Date: 2026-04-24
+- Date: 2026-07-13
 
 ## Context and Problem Statement
 
@@ -12,25 +12,26 @@ The architecture demands several things of the persistence layer simultaneously:
 3. **Production wiring supports transactions** that span multiple repository calls and event handlers, so multi-aggregate writes triggered by domain events commit atomically.
 4. **The repository stays dumb.** Its job is narrow — persist the current state of an aggregate and fetch it back. The aggregate carries the invariants and the domain verbs (grant, revoke, promote); the use case orchestrates them and declares the transaction boundary; the repository only writes the resulting state and reads it again.
 
-The fourth demand is easy to state and easy to erode. The recurring failure mode — especially from automated contributors — is business logic creeping into persistence: a domain-verb method (`creditFunds`, `grantAccess`, `markAsPaid`) appears on the port and forces the `Live` to express domain decisions as SQL; or the `Live` imports a use case or an application-tier bus and starts publishing events / owning the transaction. A softer failure is naming drift: `findByOrganizationId` returning a single row in one module and a collection in another, so a reader can't tell a method's cardinality from its name.
+The fourth demand is easy to state and easy to erode. The recurring failure mode — especially from automated contributors — is business logic creeping into persistence: a domain-verb method (`creditFunds`, `grantAccess`, `markAsPaid`) appears on the port and forces the `Live` to express domain decisions as SQL; or the `Live` imports a use case or an application-tier bus and starts publishing events / owning the transaction. A softer failure is read-method bloat: a new `findOneOpenByOrganizationIdAndEmail` / `findManyActiveByUser` for every variant a use case needs, each re-encoding a domain predicate as bespoke SQL that then drifts from the same rule expressed in memory.
 
 ## Decision
 
-For each aggregate: a port in its subdomain folder (`domain/<subdomain>/`), a `Live` and `Fake` in `infrastructure/repositories/`, and a mapper. The port speaks a fixed, **cardinality-explicit vocabulary**, and two lint rules keep it dumb.
+For each aggregate: a port in its subdomain folder (`domain/<subdomain>/`), a `Live` and `Fake` in `infrastructure/repositories/`, and a mapper. Reads are expressed with **specifications** — a domain predicate that also carries a translatable criteria AST — and the port speaks a fixed, minimal vocabulary that two lint rules keep dumb.
 
 ### Port
 
-The port lives in its aggregate's subdomain folder, `domain/<subdomain>/<feature>.repository.ts`, as a `Context.Service`. Its method signatures are typed in terms of domain aggregates, not rows. The transient-store failure is the domain-language `PersistenceUnavailable` (from `platform/ddd/contracts/`); absence is modeled as `Option` or an empty aggregate rather than a thrown `NotFound` where that reads better.
+The port lives in its aggregate's subdomain folder, `domain/<subdomain>/<feature>.repository.ts`, as a `Context.Service`. Its method signatures are typed in terms of domain aggregates, not rows. The transient-store failure is the domain-language `PersistenceUnavailable` (from `platform/ddd/contracts/`). Absence is a plain `null` (for `findOne`) or an empty array (for `findMany`); mapping a `null` to a domain `NotFound` is the use case's job, since which not-found error applies depends on the caller.
 
 ```ts
 export type UserRepositoryShape = {
   readonly insertOne: (user: UserRoot) => Effect.Effect<void, PersistenceUnavailable>;
   readonly updateOne: (user: UserRoot) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly deleteOne: (id: UserId) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneById: (id: UserId) => Effect.Effect<Option<UserRoot>, PersistenceUnavailable>;
-  readonly findOneByEmail: (
-    email: string,
-  ) => Effect.Effect<Option<UserRoot>, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<UserRoot>,
+  ) => Effect.Effect<UserRoot | null, PersistenceUnavailable>;
+  readonly findMany: (
+    spec: Specification<UserRoot>,
+  ) => Effect.Effect<ReadonlyArray<UserRoot>, PersistenceUnavailable>;
 };
 
 export class UserRepository extends Context.Service<UserRepository, UserRepositoryShape>()(
@@ -38,39 +39,50 @@ export class UserRepository extends Context.Service<UserRepository, UserReposito
 ) {}
 ```
 
-### The cardinality-explicit vocabulary
+### The vocabulary
 
 Every repository method is one of:
 
-- `insertOne` / `insertMany`
-- `updateOne` / `updateMany`
-- `deleteOne` / `deleteMany`
-- `upsertOne` / `upsertMany` — for aggregates whose persistence reconciles "create or replace" in one step
-- `findOne` / `findMany`, each optionally followed by an `[<Qualifier>]By<Key>` lookup — `findOneById`, `findOneByEmail`, `findManyByOrganizationId`, `findOneByUserIdAndOrgId`, and with a qualifier `findOneOpenByOrganizationIdAndEmail`
-- `findAll` / `findAll<Qualifier>` — a whole-collection read that takes no lookup key (`findAll`, `findAllActive`)
+- `insertOne` / `insertMany`, `updateOne` / `updateMany`, `deleteOne` / `deleteMany`, `upsertOne` / `upsertMany` — writes, typed in terms of the aggregate (or its identity for a delete).
+- `findOne` / `findMany` — the **only** reads. Each takes a `Specification` and returns `T | null` / `ReadonlyArray<T>`.
 
-The `One`/`Many`/`All` size is the point: a caller reads the operation's cardinality off the method name. The same `By<Key>` lookup disambiguates by cardinality — `findOneByOrganizationId` (the org's subscription) versus `findManyByOrganizationId` (the org's memberships) — where a bare `findByOrganizationId` would hide it. A keyless collection read is `findAll[<Qualifier>]`; a keyed read is `find{One,Many}[<Qualifier>]By<Key>`. Because a qualifier on a keyed find is only allowed ahead of the `By<Key>`, a find-and-mutate name like `findOneAndDelete` is rejected.
+There are no `findOneById` / `findManyByX` / `findOneOpenBy…` methods. Identity lookups, natural-key lookups, and variant selection are all expressed as a specification at the call site — `repo.findOne(UserSpecifications.withEmail(email))`, `repo.findOne(Spec.and(forOrganization(orgId), withInviteeEmail(email), isOpen))`. This kills read-method bloat (one `findOne` instead of a keyed method per lookup) and, because the same specification object filters the fake and compiles the live query, kills the fake/live drift that per-variant SQL invited.
+
+### Specification: one predicate, two interpreters
+
+A `Specification<T>` (in `platform/ddd/contracts/`) is a **callable predicate that also carries a translatable `Criteria` AST**. Builders — `Spec.eq`, `Spec.isNull`, `Spec.isNotNull`, `Spec.and`, `Spec.or`, `Spec.not` — produce both halves at once, so a spec is defined once and used three ways:
+
+- **Domain guards** (`RootOps`) call it as a predicate: `if (InvitationSpecifications.isAccepted(invitation)) …`.
+- **The fake repository** filters in memory with the same object: `rows.find(spec)`.
+- **The live repository** compiles its `.criteria` to a SQL `WHERE` fragment with `criteriaToWhere(spec.criteria, columns)`.
+
+A spec named after a lookup lives in the aggregate's `*.specification.ts` (`withId`, `withEmail`, `forOrganization`, `isOpen`); ad-hoc composition happens at the call site with `Spec.and` / `Spec.or` / `Spec.not`.
+
+### The boundary: what a specification may express
+
+The `Criteria` AST has only **root-level scalar** nodes (`Eq`, `IsNull`, `IsNotNull` over the root's own columns, combined with `And`/`Or`/`Not`). It has no "some child row matches" node. This is deliberate:
+
+- The **specification carries only the predicate**; the **repository owns FROM, JOINs, projection, ordering, and — for a multi-row aggregate — reconstitution**. The compiler emits nothing but the `WHERE`. The field→column map (which may name qualified columns of a fixed multi-table query) lives in the mapper.
+- A predicate that reaches into a child collection (e.g. `OrganizationRolesSpecifications.hasRole`) cannot be built as a `Criteria`, so it is a plain `Predicate<T>` — usable as a guard, in the fake, or as a post-load filter, but **not assignable to `findOne`/`findMany`**. The type system refuses to hand a join-shaped filter to the repository. A filter that genuinely needs dynamic joins or child-collection matching is a bespoke repo query (a two-phase "`SELECT` ids `WHERE …`, then load by id" the repo writes by hand) or a read-side projection (ADR-0002) — never the generic compiler.
 
 ### Live implementation
 
-The live implementation lives in `infrastructure/repositories/<feature>.repository-live.ts` as a `Layer` that depends on the shared `Database` service. Every method is built via the database's `makeQuery` helper, which automatically joins any active transaction context (see ADR-0007). Database-level errors are translated at this boundary; a transient outage surfaces as `PersistenceUnavailable`, and non-domain failures drop to defects (`Effect.die`).
+The live implementation lives in `infrastructure/repositories/<feature>.repository-live.ts` as a `Layer` that depends on the shared `Database` service. Every method is built via the database's `makeQuery` helper, which automatically joins any active transaction context (see ADR-0007). A read runs `SELECT <projection> FROM <tables/joins> WHERE ${criteriaToWhere(spec.criteria, columns)}` — the repo owns everything but the `WHERE`. Database-level errors are translated at this boundary; a transient outage surfaces as `PersistenceUnavailable`, and non-domain failures drop to defects (`Effect.die`).
 
 ### Fake implementation
 
-A fake implementation lives in `infrastructure/repositories/<feature>.repository-fake.ts` as a `Layer` backed by a `Ref<Map<EntityId, Entity>>`. Use-case unit tests provide it instead of the live implementation. The fake satisfies the same port, so the use case sees no difference between fake and live.
+A fake implementation lives in `infrastructure/repositories/<feature>.repository-fake.ts` as a `Layer` backed by a `Ref` of stored aggregates. `findOne` / `findMany` filter with the specification directly (`Array.from(values).find(spec)` / `.filter(spec)`). The fake must mirror the live repository's **row model**, not just its predicate: an aggregate the live repo persists as zero rows (e.g. a multi-row aggregate whose collection is now empty) must be un-findable in the fake too, so an empty-aggregate upsert deletes the stored entry rather than retaining it.
 
 ### Mapper
 
-Persistence-format conversion lives in `infrastructure/repositories/<feature>.mapper.ts` as a pair of plain functions: `toPersistence(entity) -> Row` and `toDomain(row) -> entity`. For variant aggregates the mapper switches on the persisted discriminant column to reconstitute the right variant (ADR-0003), keeping the `Live` dumb.
+Persistence-format conversion lives in `infrastructure/repositories/<feature>.mapper.ts`: `toPersistence(entity) -> Row`, `toDomain(rows) -> entity | null`, and the `columns` field→column map the compiler consumes. A **single-row** aggregate maps one row to one aggregate (`findOne` runs `maybeOne(… LIMIT 1)`). A **multi-row** aggregate reconstitutes one aggregate from the row set the spec's `WHERE` returns (`findOne` runs `any(…)`, groups, and returns `null` for zero rows); identity is read from the rows. For variant aggregates the mapper switches on the persisted discriminant column (ADR-0003), keeping the `Live` dumb. Because "no rows" and "empty aggregate" are the same state, the empty aggregate is synthesized by the caller (`… ?? XRootOps.empty(id)`), not by the repository.
 
 ### Two lint rules keep the port dumb
 
-The two highest-frequency forms of logic creep fail `check:all` deterministically:
-
-1. **eslint `dumb-repository-ports`** (`scripts/eslint-rules/dumb-repository-ports.mjs`), scoped to the subdomain repository ports (`domain/<subdomain>/*.repository.ts`), inspects the `*RepositoryShape` type literal and requires every method name to match the vocabulary above. A name that reads as a domain verb, or omits the `One`/`Many` size, fails — the message tells the contributor to move the behaviour onto the aggregate or add the cardinality. The port is the right enforcement point because the `Live` and `Fake` must structurally satisfy it.
+1. **eslint `dumb-repository-ports`**, scoped to the subdomain repository ports (`domain/<subdomain>/*.repository.ts`), inspects the `*RepositoryShape` type literal and requires every method name to be one of the write verbs or bare `findOne` / `findMany`. A name that reads as a domain verb, omits the `One`/`Many` size, or is a keyed/variant finder (`findOneById`, `findOneOpenBy…`) fails — the message tells the contributor to move behaviour onto the aggregate or express the lookup as a specification. The port is the right enforcement point because the `Live` and `Fake` must structurally satisfy it.
 2. **dependency-cruiser `dumb-repository-live-no-app-collaborators`** forbids `infrastructure/repositories/*.repository-live.ts` from importing the module's own `commands/` / `queries/` use cases, or the application-tier ports (`command-bus`, `query-bus`, `domain-event-bus`, `integration-event-bus`, `unit-of-work`, `with-unit-of-work`). A repository that reaches for these is smuggling orchestration into persistence.
 
-Both are allowlists (by name and by import path): a determinedly misleading name or pure computation inside an `updateOne` body can still pass. They are guardrails against the common case, not a substitute for review.
+Both are allowlists: a determinedly misleading name or pure computation inside an `updateOne` body can still pass. They are guardrails against the common case, not a substitute for review.
 
 ### Test exemption
 
@@ -80,20 +92,23 @@ Static analysis allows test files in `commands/` and `queries/` to import from `
 
 - The domain layer has zero infrastructure dependencies. It compiles after deleting the entire `infrastructure/` folder for a module.
 - Use-case unit tests need only the fake repository, the recording event bus, and the identity unit of work. No database, no docker, no migrations.
-- Two implementations of the same port must stay in sync. The shared port type makes signature drift a compile error; a fake-repository test exercises the fake against the same scenarios as the live integration test, catching behavioral drift.
+- A variant/lookup is defined once, as a specification, and reused by guards, the fake, and the live query — so "open", "not deleted", "by email" cannot drift between an in-memory rule and a hand-written `WHERE`.
+- Two implementations of the same port must stay in sync. The shared port type makes signature drift a compile error; a fake-repository test and the live integration test exercise the same specifications, catching behavioral drift (including row-model mismatches like the empty-aggregate case).
 - Repositories are _transaction-passive_: they don't open or close transactions; they participate in whatever transaction context is active. This keeps the pattern composable with the unit-of-work mechanism (ADR-0007) and matches real database semantics.
-- Method cardinality is legible from the name. Reads that legitimately bypass the aggregate (read-side projections) live in `queries/` and address the database directly; they are unaffected, because they are not repositories.
+- Reads that legitimately bypass the aggregate (read-side projections) live in `queries/` and address the database directly; they are unaffected, because they are not repositories. Filtered loads that would need dynamic joins stay on the read side rather than distorting the specification DSL.
 
 ## Alternatives considered
 
+- **Cardinality-explicit keyed finders** (`findOneById`, `findManyByOrganizationId`, `findOneOpenBy…`) — the previous decision. Rejected — every new variant added a port method plus a bespoke `WHERE`, and the same predicate expressed in the fake (in memory) and the live (as SQL) drifted. The specification collapses both into one object.
+- **Query-object specifications that own the whole query** (FROM/JOIN/projection). Rejected — a spec that knows table and column layout leaks persistence into the domain and re-introduces an ORM. The spec owns only the predicate; the repository owns the physical query.
 - **No repository abstraction; use cases call `db.execute(sql...)` directly.** Rejected — couples the domain to SQL, prevents fake-based unit tests, and concentrates persistence knowledge at every call site.
-- **Generic `Repository<T>` base class** with CRUD operations. Rejected — generic CRUD rarely fits; per-aggregate ports stay smaller and more honest about what's actually queryable.
+- **Generic `Repository<T>` base class** with CRUD operations. Rejected — writes stay per-aggregate and honest; only the read surface (`findOne`/`findMany` over a spec) is uniform.
 - **ORM-managed entities** (proxies / change-tracking). Rejected — leaks persistence concerns into the domain via lazy-loading and identity-map semantics.
-- **Single in-memory implementation used in both production and tests.** Rejected — the discipline of two implementations from day one is cheap insurance against the pattern getting bypassed under deadline pressure.
 - **Domain-verb methods on the port** (`repo.creditFunds(...)`). Rejected — that is business logic; it belongs on the aggregate's `RootOps`. The `dumb-repository-ports` rule rejects it by name.
 
 ## Related
 
 - ADR-0001 (functional core) — domain has no infrastructure dependencies.
+- ADR-0003 (aggregates) — the `RootOps` that own the invariants specifications guard.
 - ADR-0007 (unit of work) — explains how the live repository's per-call transaction-context check makes it transaction-aware.
 - ADR-0009 (testing) — explains how the fake fits into the use-case unit tests.

--- a/packages/server/src/modules/auth/commands/approve-device-grant.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant.handler.test.ts
@@ -15,6 +15,7 @@ import {
   DeviceGrantNotFound,
 } from "@/modules/auth/domain/device-grant/device-grant.errors.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
+import { DeviceGrantSpecifications } from "@/modules/auth/domain/device-grant/device-grant.specification.js";
 import { DeviceGrantRepositoryFake } from "@/modules/auth/infrastructure/repositories/device-grant.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -34,7 +35,8 @@ describe("approveDeviceGrant", () => {
       );
       yield* approveDeviceGrant(ApproveDeviceGrantCommand.make({ userCode, userId }));
       const repo = yield* DeviceGrantRepository;
-      const grant = yield* repo.findOneByUserCode(userCode);
+      const grant = yield* repo.findOne(DeviceGrantSpecifications.withUserCode(userCode));
+      if (grant === null) throw new Error("expected a grant");
       deepStrictEqual(grant.status, "approved");
       deepStrictEqual(grant.userId, userId);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/auth/commands/approve-device-grant.handler.ts
+++ b/packages/server/src/modules/auth/commands/approve-device-grant.handler.ts
@@ -2,7 +2,10 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type ApproveDeviceGrantCommand } from "@/modules/auth/commands/approve-device-grant.command.js";
-import { DeviceGrantExpired } from "@/modules/auth/domain/device-grant/device-grant.errors.js";
+import {
+  DeviceGrantExpired,
+  DeviceGrantNotFound,
+} from "@/modules/auth/domain/device-grant/device-grant.errors.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
 import { DeviceGrantRootOps } from "@/modules/auth/domain/device-grant/device-grant.root-ops.js";
 import { DeviceGrantSpecifications } from "@/modules/auth/domain/device-grant/device-grant.specification.js";
@@ -17,7 +20,10 @@ export const approveDeviceGrant = Effect.fn("approveDeviceGrant")(function* (
   cmd: ApproveDeviceGrantCommand,
 ) {
   const repo = yield* DeviceGrantRepository;
-  const grant = yield* repo.findOneByUserCode(cmd.userCode);
+  const grant = yield* repo.findOne(DeviceGrantSpecifications.withUserCode(cmd.userCode));
+  if (grant === null) {
+    return yield* new DeviceGrantNotFound();
+  }
   const now = yield* DateTime.now;
   if (DeviceGrantSpecifications.isExpired(grant, now)) {
     return yield* new DeviceGrantExpired();

--- a/packages/server/src/modules/auth/commands/mint-api-token.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/mint-api-token.handler.test.ts
@@ -7,6 +7,7 @@ import { MintApiTokenCommand } from "@/modules/auth/commands/mint-api-token.comm
 import { mintApiToken } from "@/modules/auth/commands/mint-api-token.handler.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { API_TOKEN_PREFIX } from "@/modules/auth/domain/api-token/api-token.root-ops.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import { CredentialHash } from "@/modules/auth/domain/domain-services/credential-hash.domain-service.js";
 import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/repositories/api-token.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -34,7 +35,8 @@ describe("mintApiToken", () => {
 
       // Round-trips: the minted token resolves by its hash.
       const repo = yield* ApiTokenRepository;
-      const found = yield* repo.findOneByHash(CredentialHash.of(token));
+      const found = yield* repo.findOne(ApiTokenSpecifications.withHash(CredentialHash.of(token)));
+      if (found === null) throw new Error("expected an api token");
       deepStrictEqual(found.id, apiToken.id);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/auth/commands/poll-device-grant.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant.handler.test.ts
@@ -13,12 +13,14 @@ import { pollDeviceGrant } from "@/modules/auth/commands/poll-device-grant.handl
 import { StartDeviceGrantCommand } from "@/modules/auth/commands/start-device-grant.command.js";
 import { startDeviceGrant } from "@/modules/auth/commands/start-device-grant.handler.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import {
   DeviceGrantExpired,
   DeviceGrantNotFound,
   DeviceGrantPending,
 } from "@/modules/auth/domain/device-grant/device-grant.errors.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
+import { DeviceGrantSpecifications } from "@/modules/auth/domain/device-grant/device-grant.specification.js";
 import { CredentialHash } from "@/modules/auth/domain/domain-services/credential-hash.domain-service.js";
 import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/repositories/api-token.repository-fake.js";
 import { DeviceGrantRepositoryFake } from "@/modules/auth/infrastructure/repositories/device-grant.repository-fake.js";
@@ -63,13 +65,17 @@ describe("pollDeviceGrant", () => {
       deepStrictEqual(apiToken.userId, userId);
       // Minted token is resolvable by its hash…
       const apiTokens = yield* ApiTokenRepository;
-      deepStrictEqual((yield* apiTokens.findOneByHash(CredentialHash.of(token))).id, apiToken.id);
+      const foundToken = yield* apiTokens.findOne(
+        ApiTokenSpecifications.withHash(CredentialHash.of(token)),
+      );
+      if (foundToken === null) throw new Error("expected an api token");
+      deepStrictEqual(foundToken.id, apiToken.id);
       // …and the grant is consumed: a second poll finds nothing.
       const grants = yield* DeviceGrantRepository;
-      deepStrictEqual(
-        Exit.isFailure(yield* Effect.exit(grants.findOneByCodeHash(CredentialHash.of(deviceCode)))),
-        true,
+      const consumed = yield* grants.findOne(
+        DeviceGrantSpecifications.withCodeHash(CredentialHash.of(deviceCode)),
       );
+      deepStrictEqual(consumed, null);
       deepStrictEqual(
         errorOf(yield* Effect.exit(poll(deviceCode))) instanceof DeviceGrantNotFound,
         true,

--- a/packages/server/src/modules/auth/commands/poll-device-grant.handler.ts
+++ b/packages/server/src/modules/auth/commands/poll-device-grant.handler.ts
@@ -5,6 +5,7 @@ import { mintApiTokenCore } from "@/modules/auth/commands/mint-api-token.handler
 import { type PollDeviceGrantCommand } from "@/modules/auth/commands/poll-device-grant.command.js";
 import {
   DeviceGrantExpired,
+  DeviceGrantNotFound,
   DeviceGrantPending,
 } from "@/modules/auth/domain/device-grant/device-grant.errors.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
@@ -25,7 +26,12 @@ export const pollDeviceGrant = Effect.fn("pollDeviceGrant")(function* (
   cmd: PollDeviceGrantCommand,
 ) {
   const grants = yield* DeviceGrantRepository;
-  const grant = yield* grants.findOneByCodeHash(CredentialHash.of(cmd.deviceCode));
+  const grant = yield* grants.findOne(
+    DeviceGrantSpecifications.withCodeHash(CredentialHash.of(cmd.deviceCode)),
+  );
+  if (grant === null) {
+    return yield* new DeviceGrantNotFound();
+  }
   const now = yield* DateTime.now;
 
   if (DeviceGrantSpecifications.isExpired(grant, now)) {

--- a/packages/server/src/modules/auth/commands/revoke-api-token.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token.handler.test.ts
@@ -13,6 +13,7 @@ import { revokeApiToken } from "@/modules/auth/commands/revoke-api-token.handler
 import { ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token.errors.js";
 import { ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/repositories/api-token.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -30,7 +31,9 @@ describe("revokeApiToken", () => {
       const { apiToken } = yield* mint(userId);
       yield* revokeApiToken(RevokeApiTokenCommand.make({ apiTokenId: apiToken.id, userId }));
       const repo = yield* ApiTokenRepository;
-      deepStrictEqual((yield* repo.findOneById(apiToken.id)).revokedAt !== null, true);
+      const found = yield* repo.findOne(ApiTokenSpecifications.withId(apiToken.id));
+      if (found === null) throw new Error("expected an api token");
+      deepStrictEqual(found.revokedAt !== null, true);
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -48,7 +51,9 @@ describe("revokeApiToken", () => {
         deepStrictEqual(error instanceof ApiTokenNotFound, true);
       }
       const repo = yield* ApiTokenRepository;
-      deepStrictEqual((yield* repo.findOneById(apiToken.id)).revokedAt, null);
+      const found = yield* repo.findOne(ApiTokenSpecifications.withId(apiToken.id));
+      if (found === null) throw new Error("expected an api token");
+      deepStrictEqual(found.revokedAt, null);
     }).pipe(Effect.provide(TestLayer)),
   );
 

--- a/packages/server/src/modules/auth/commands/revoke-api-token.handler.ts
+++ b/packages/server/src/modules/auth/commands/revoke-api-token.handler.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import { type RevokeApiTokenCommand } from "@/modules/auth/commands/revoke-api-token.command.js";
 import { ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token.errors.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
 // Ownership-scoped revoke: load the token, refuse (as NotFound) if it isn't
@@ -12,8 +13,8 @@ import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 // Bus-boundary span (ADR-0012) wraps this at dispatch time.
 export const revokeApiToken = Effect.fn("revokeApiToken")(function* (cmd: RevokeApiTokenCommand) {
   const repo = yield* ApiTokenRepository;
-  const token = yield* repo.findOneById(cmd.apiTokenId);
-  if (token.userId !== cmd.userId) {
+  const token = yield* repo.findOne(ApiTokenSpecifications.withId(cmd.apiTokenId));
+  if (token?.userId !== cmd.userId) {
     return yield* new ApiTokenNotFound();
   }
   yield* repo.deleteOne(cmd.apiTokenId);

--- a/packages/server/src/modules/auth/commands/revoke-session.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/revoke-session.handler.test.ts
@@ -9,6 +9,7 @@ import { revokeSession } from "@/modules/auth/commands/revoke-session.handler.js
 import { SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.js";
+import { SessionSpecifications } from "@/modules/auth/domain/session/session.specification.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/repositories/session.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -38,9 +39,7 @@ describe("revokeSession", () => {
       yield* seedSession();
       yield* revokeSession(RevokeSessionCommand.make({ sessionId }));
       const repo = yield* SessionRepository;
-      const found = yield* repo
-        .findOneById(sessionId)
-        .pipe(Effect.catchTag("SessionNotFound", () => Effect.succeed(null)));
+      const found = yield* repo.findOne(SessionSpecifications.withId(sessionId));
       ok(found !== null);
       ok(Option.isSome(Option.fromNullishOr(found.revokedAt)));
     }).pipe(provide),

--- a/packages/server/src/modules/auth/commands/sign-in.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.handler.test.ts
@@ -13,7 +13,9 @@ import {
   type AuthIdentity,
   AuthIdentityRepository,
 } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
+import { AuthIdentitySpecifications } from "@/modules/auth/domain/auth-identity/auth-identity.specification.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
+import { SessionSpecifications } from "@/modules/auth/domain/session/session.specification.js";
 import { makeAuthIdentityRepositoryFake } from "@/modules/auth/infrastructure/repositories/auth-identity.repository-fake.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/repositories/session.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -48,7 +50,8 @@ describe("signIn", () => {
       const result = yield* signIn(command);
       deepStrictEqual(result.userId, userId);
       const sessions = yield* SessionRepository;
-      const stored = yield* sessions.findOneById(result.sessionId);
+      const stored = yield* sessions.findOne(SessionSpecifications.withId(result.sessionId));
+      if (stored === null) throw new Error("expected a session");
       deepStrictEqual(stored.userId, userId);
       deepStrictEqual(stored.subject, subject);
       deepStrictEqual(stored.revokedAt, null);
@@ -64,11 +67,13 @@ describe("signIn", () => {
       deepStrictEqual(result.userId, provisionedUserId);
       // …and the identity is now linked, so a subsequent lookup finds it.
       const identities = yield* AuthIdentityRepository;
-      const linked = yield* identities.findOneBySubject("new-subject");
+      const linked = yield* identities.findOne(AuthIdentitySpecifications.bySubject("new-subject"));
+      if (linked === null) throw new Error("expected an identity");
       deepStrictEqual(linked.userId, provisionedUserId);
       deepStrictEqual(linked.provider, "zitadel");
       const sessions = yield* SessionRepository;
-      const stored = yield* sessions.findOneById(result.sessionId);
+      const stored = yield* sessions.findOne(SessionSpecifications.withId(result.sessionId));
+      if (stored === null) throw new Error("expected a session");
       deepStrictEqual(stored.userId, provisionedUserId);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/auth/commands/sign-in.handler.ts
+++ b/packages/server/src/modules/auth/commands/sign-in.handler.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 
 import { type SignInCommand } from "@/modules/auth/commands/sign-in.command.js";
 import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
+import { AuthIdentitySpecifications } from "@/modules/auth/domain/auth-identity/auth-identity.specification.js";
 import { SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.js";
@@ -29,37 +30,36 @@ export const signIn = Effect.fn("signIn")(function* (cmd: SignInCommand) {
   const sessions = yield* SessionRepository;
   const provisioning = yield* UserProvisioning;
 
-  const userId = yield* identities.findOneBySubject(cmd.subject).pipe(
-    Effect.map((identity) => identity.userId),
-    // First sign-in for this subject: JIT provision an ordinary user.
-    // Requires an email (the `users` row needs one); a verified
-    // identity with no email can't be provisioned. The provisioning
-    // command runs in this same transaction.
-    Effect.catchTag("AuthIdentityNotFound", () =>
-      Effect.gen(function* () {
-        if (cmd.email === null) {
-          return yield* new CustomHttpApiError.Unauthorized({
-            message: "Cannot provision a user: the identity has no email.",
-          });
-        }
-        const newUserId = yield* provisioning.provision(cmd.email).pipe(
-          Effect.catchTag("UserProvisioningConflict", (e) =>
-            Effect.fail(
-              new CustomHttpApiError.Unauthorized({
-                message: `Cannot provision a user: email ${e.email} is already registered.`,
-              }),
+  const identity = yield* identities.findOne(AuthIdentitySpecifications.bySubject(cmd.subject));
+  const userId =
+    identity !== null
+      ? identity.userId
+      : // First sign-in for this subject: JIT provision an ordinary user.
+        // Requires an email (the `users` row needs one); a verified
+        // identity with no email can't be provisioned. The provisioning
+        // command runs in this same transaction.
+        yield* Effect.gen(function* () {
+          if (cmd.email === null) {
+            return yield* new CustomHttpApiError.Unauthorized({
+              message: "Cannot provision a user: the identity has no email.",
+            });
+          }
+          const newUserId = yield* provisioning.provision(cmd.email).pipe(
+            Effect.catchTag("UserProvisioningConflict", (e) =>
+              Effect.fail(
+                new CustomHttpApiError.Unauthorized({
+                  message: `Cannot provision a user: email ${e.email} is already registered.`,
+                }),
+              ),
             ),
-          ),
-        );
-        yield* identities.insertOne({
-          subject: cmd.subject,
-          userId: newUserId,
-          provider: "zitadel",
+          );
+          yield* identities.insertOne({
+            subject: cmd.subject,
+            userId: newUserId,
+            provider: "zitadel",
+          });
+          return newUserId;
         });
-        return newUserId;
-      }),
-    ),
-  );
 
   const id = SessionId.make(yield* Effect.sync(() => crypto.randomUUID()));
   const now = yield* DateTime.now;

--- a/packages/server/src/modules/auth/commands/start-device-grant.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/start-device-grant.handler.test.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import { StartDeviceGrantCommand } from "@/modules/auth/commands/start-device-grant.command.js";
 import { startDeviceGrant } from "@/modules/auth/commands/start-device-grant.handler.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
+import { DeviceGrantSpecifications } from "@/modules/auth/domain/device-grant/device-grant.specification.js";
 import { CredentialHash } from "@/modules/auth/domain/domain-services/credential-hash.domain-service.js";
 import { DeviceGrantRepositoryFake } from "@/modules/auth/infrastructure/repositories/device-grant.repository-fake.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -22,7 +23,10 @@ describe("startDeviceGrant", () => {
       ok(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(userCode));
 
       const repo = yield* DeviceGrantRepository;
-      const stored = yield* repo.findOneByCodeHash(CredentialHash.of(deviceCode));
+      const stored = yield* repo.findOne(
+        DeviceGrantSpecifications.withCodeHash(CredentialHash.of(deviceCode)),
+      );
+      if (stored === null) throw new Error("expected a grant");
       deepStrictEqual(stored.status, "pending");
       deepStrictEqual(stored.userId, null);
       deepStrictEqual(stored.userCode, userCode);

--- a/packages/server/src/modules/auth/commands/touch-api-token.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token.handler.test.ts
@@ -8,6 +8,7 @@ import { touchApiToken } from "@/modules/auth/commands/touch-api-token.handler.j
 import { ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { ApiTokenRootOps } from "@/modules/auth/domain/api-token/api-token.root-ops.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import { ApiTokenRepositoryFake } from "@/modules/auth/infrastructure/repositories/api-token.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -42,7 +43,8 @@ describe("touchApiToken", () => {
       const before = yield* seed(farPast);
       yield* touchApiToken(cmd);
       const repo = yield* ApiTokenRepository;
-      const after = yield* repo.findOneById(apiTokenId);
+      const after = yield* repo.findOne(ApiTokenSpecifications.withId(apiTokenId));
+      if (after === null) throw new Error("expected an api token");
       deepStrictEqual(DateTime.isGreaterThan(after.lastUsedAt, before.lastUsedAt), true);
       // Fixed expiry: touch must NOT extend it.
       deepStrictEqual(after.expiresAt, before.expiresAt);
@@ -55,7 +57,8 @@ describe("touchApiToken", () => {
       const before = yield* seed(justNow);
       yield* touchApiToken(TouchApiTokenCommand.make({ apiTokenId, thresholdSeconds: 3600 }));
       const repo = yield* ApiTokenRepository;
-      const after = yield* repo.findOneById(apiTokenId);
+      const after = yield* repo.findOne(ApiTokenSpecifications.withId(apiTokenId));
+      if (after === null) throw new Error("expected an api token");
       deepStrictEqual(after.lastUsedAt, before.lastUsedAt);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/auth/commands/touch-api-token.handler.ts
+++ b/packages/server/src/modules/auth/commands/touch-api-token.handler.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import { type TouchApiTokenCommand } from "@/modules/auth/commands/touch-api-token.command.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { ApiTokenRootOps } from "@/modules/auth/domain/api-token/api-token.root-ops.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 
 // Last-used stamp, throttled + race-tolerant.
 //
@@ -18,10 +19,9 @@ import { ApiTokenRootOps } from "@/modules/auth/domain/api-token/api-token.root-
 // Bus-boundary span (ADR-0012) wraps this at dispatch time.
 export const touchApiToken = Effect.fn("touchApiToken")(function* (cmd: TouchApiTokenCommand) {
   const repo = yield* ApiTokenRepository;
-  const token = yield* repo.findOneById(cmd.apiTokenId).pipe(
-    Effect.catchTag("ApiTokenNotFound", () => Effect.succeed(null)),
-    Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)),
-  );
+  const token = yield* repo
+    .findOne(ApiTokenSpecifications.withId(cmd.apiTokenId))
+    .pipe(Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)));
   if (token?.revokedAt !== null) return;
 
   const now = yield* DateTime.now;

--- a/packages/server/src/modules/auth/commands/touch-session.handler.test.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.handler.test.ts
@@ -8,6 +8,7 @@ import { touchSession } from "@/modules/auth/commands/touch-session.handler.js";
 import { SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.js";
+import { SessionSpecifications } from "@/modules/auth/domain/session/session.specification.js";
 import { SessionRepositoryFake } from "@/modules/auth/infrastructure/repositories/session.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -44,7 +45,8 @@ describe("touchSession", () => {
       const seed = yield* seedSession(farPast);
       yield* touchSession(cmd);
       const repo = yield* SessionRepository;
-      const after = yield* repo.findOneById(sessionId);
+      const after = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      if (after === null) throw new Error("expected a session");
       deepStrictEqual(DateTime.isGreaterThan(after.lastUsedAt, seed.lastUsedAt), true);
       deepStrictEqual(DateTime.isGreaterThan(after.expiresAt, seed.expiresAt), true);
     }).pipe(Effect.provide(SessionRepositoryFake)),
@@ -56,7 +58,8 @@ describe("touchSession", () => {
       const seed = yield* seedSession(justNow);
       yield* touchSession(cmd);
       const repo = yield* SessionRepository;
-      const after = yield* repo.findOneById(sessionId);
+      const after = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      if (after === null) throw new Error("expected a session");
       deepStrictEqual(after.lastUsedAt, seed.lastUsedAt);
       deepStrictEqual(after.expiresAt, seed.expiresAt);
     }).pipe(Effect.provide(SessionRepositoryFake)),
@@ -73,7 +76,8 @@ describe("touchSession", () => {
       const repo = yield* SessionRepository;
       yield* repo.deleteOne(sessionId);
       yield* touchSession(cmd);
-      const after = yield* repo.findOneById(sessionId);
+      const after = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      if (after === null) throw new Error("expected a session");
       deepStrictEqual(after.expiresAt, seed.expiresAt);
       deepStrictEqual(after.lastUsedAt, seed.lastUsedAt);
     }).pipe(Effect.provide(SessionRepositoryFake)),

--- a/packages/server/src/modules/auth/commands/touch-session.handler.ts
+++ b/packages/server/src/modules/auth/commands/touch-session.handler.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import { type TouchSessionCommand } from "@/modules/auth/commands/touch-session.command.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.js";
+import { SessionSpecifications } from "@/modules/auth/domain/session/session.specification.js";
 
 // Sliding-TTL refresh.
 //
@@ -23,10 +24,9 @@ import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.j
 // Bus-boundary span (ADR-0012) wraps this at dispatch time.
 export const touchSession = Effect.fn("touchSession")(function* (cmd: TouchSessionCommand) {
   const repo = yield* SessionRepository;
-  const session = yield* repo.findOneById(cmd.sessionId).pipe(
-    Effect.catchTag("SessionNotFound", () => Effect.succeed(null)),
-    Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)),
-  );
+  const session = yield* repo
+    .findOne(SessionSpecifications.withId(cmd.sessionId))
+    .pipe(Effect.catchTag("PersistenceUnavailable", () => Effect.succeed(null)));
   if (session?.revokedAt !== null) return;
 
   const now = yield* DateTime.now;

--- a/packages/server/src/modules/auth/domain/api-token/api-token.errors.ts
+++ b/packages/server/src/modules/auth/domain/api-token/api-token.errors.ts
@@ -1,9 +1,9 @@
 import * as Schema from "effect/Schema";
 
-// Fieldless: raised both by `findOneById` (revoke path — the caller already
-// holds the id from the request) and by `findOneByHash` (per-request lookup,
-// where a miss has no id to report). Keeping it fieldless lets one error
-// serve both without an awkward optional id.
+// Fieldless: raised by the revoke path (the caller already holds the id from
+// the request) and by the per-request bearer lookup (where a miss has no id to
+// report). Keeping it fieldless lets one error serve both without an awkward
+// optional id.
 export class ApiTokenNotFound extends Schema.TaggedErrorClass<ApiTokenNotFound>("ApiTokenNotFound")(
   "ApiTokenNotFound",
   {},

--- a/packages/server/src/modules/auth/domain/api-token/api-token.repository.ts
+++ b/packages/server/src/modules/auth/domain/api-token/api-token.repository.ts
@@ -5,25 +5,22 @@ import { type ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token
 import { type ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { type ApiTokenRoot } from "@/modules/auth/domain/api-token/api-token.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
-// Dumb collection port (per `feedback_dumb_repositories`): save / findByX
-// only. Domain verbs (mint, revoke, touch) live in the use cases and the
-// aggregate; the soft-delete storage mechanism behind `delete` is an
-// implementation detail.
+// Dumb collection port (per `feedback_dumb_repositories`): insert/update the
+// aggregate, delete by id, and read it back by a Specification. Domain verbs
+// (mint, revoke, touch) live in the use cases and the aggregate; the
+// soft-delete storage mechanism behind `delete` is an implementation detail.
+// Every lookup — by id, by hash, the owner's active tokens — is expressed as a
+// spec at the call site (ApiTokenSpecifications). Absence is a plain `null` /
+// empty array; mapping it to ApiTokenNotFound is the caller's job.
 export type ApiTokenRepositoryShape = {
   readonly insertOne: (token: ApiTokenRoot) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneById: (
-    id: ApiTokenId,
-  ) => Effect.Effect<ApiTokenRoot, ApiTokenNotFound | PersistenceUnavailable>;
-  // Per-request lookup of the presented bearer (already hashed by the
-  // caller — the raw secret never reaches the repository).
-  readonly findOneByHash: (
-    tokenHash: string,
-  ) => Effect.Effect<ApiTokenRoot, ApiTokenNotFound | PersistenceUnavailable>;
-  // Active (non-revoked) tokens for the owner's management listing.
-  readonly findManyByUser: (
-    userId: UserId,
+  readonly findOne: (
+    spec: Specification<ApiTokenRoot>,
+  ) => Effect.Effect<ApiTokenRoot | null, PersistenceUnavailable>;
+  readonly findMany: (
+    spec: Specification<ApiTokenRoot>,
   ) => Effect.Effect<ReadonlyArray<ApiTokenRoot>, PersistenceUnavailable>;
   // Soft-delete via `revoked_at` (SQL `WHERE revoked_at IS NULL`). A
   // re-revoke matches zero rows and surfaces as `ApiTokenNotFound`, same as

--- a/packages/server/src/modules/auth/domain/api-token/api-token.specification.test.ts
+++ b/packages/server/src/modules/auth/domain/api-token/api-token.specification.test.ts
@@ -5,11 +5,14 @@ import * as DateTime from "effect/DateTime";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { ApiTokenId } from "./api-token.id.js";
+import { ApiTokenRoot } from "./api-token.root.js";
 import { ApiTokenRootOps } from "./api-token.root-ops.js";
 import { ApiTokenSpecifications } from "./api-token.specification.js";
 
 const apiTokenId = ApiTokenId.make("11111111-1111-1111-1111-111111111111");
+const otherId = ApiTokenId.make("99999999-9999-9999-9999-999999999999");
 const userId = UserId.make("22222222-2222-2222-2222-222222222222");
+const otherUserId = UserId.make("33333333-3333-3333-3333-333333333333");
 const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
 
 const mint = (expiresAt: DateTime.Utc | null) =>
@@ -22,6 +25,58 @@ const mint = (expiresAt: DateTime.Utc | null) =>
     now,
     expiresAt,
   });
+
+describe("ApiTokenSpecifications.withId", () => {
+  it("matches the token with the given id and no other", () => {
+    const token = mint(DateTime.add(now, { days: 90 }));
+    deepStrictEqual(ApiTokenSpecifications.withId(apiTokenId)(token), true);
+    deepStrictEqual(ApiTokenSpecifications.withId(otherId)(token), false);
+  });
+
+  it("carries an Eq criteria over the id column", () => {
+    deepStrictEqual(ApiTokenSpecifications.withId(apiTokenId).criteria, {
+      _tag: "Eq",
+      field: "id",
+      value: apiTokenId,
+    });
+  });
+});
+
+describe("ApiTokenSpecifications.withHash", () => {
+  it("matches the token with the given hash and no other", () => {
+    const token = mint(DateTime.add(now, { days: 90 }));
+    deepStrictEqual(ApiTokenSpecifications.withHash("hash")(token), true);
+    deepStrictEqual(ApiTokenSpecifications.withHash("other")(token), false);
+  });
+
+  it("carries an Eq criteria over the token_hash column", () => {
+    deepStrictEqual(ApiTokenSpecifications.withHash("hash").criteria, {
+      _tag: "Eq",
+      field: "tokenHash",
+      value: "hash",
+    });
+  });
+});
+
+describe("ApiTokenSpecifications.forUser", () => {
+  it("matches the owner's active tokens and excludes revoked or foreign ones", () => {
+    const active = mint(DateTime.add(now, { days: 90 }));
+    deepStrictEqual(ApiTokenSpecifications.forUser(userId)(active), true);
+    const revoked = ApiTokenRoot.make({ ...active, revokedAt: now });
+    deepStrictEqual(ApiTokenSpecifications.forUser(userId)(revoked), false);
+    deepStrictEqual(ApiTokenSpecifications.forUser(otherUserId)(active), false);
+  });
+
+  it("carries an And of the user_id Eq and the revoked_at IsNull", () => {
+    deepStrictEqual(ApiTokenSpecifications.forUser(userId).criteria, {
+      _tag: "And",
+      nodes: [
+        { _tag: "Eq", field: "userId", value: userId },
+        { _tag: "IsNull", field: "revokedAt" },
+      ],
+    });
+  });
+});
 
 describe("ApiTokenSpecifications.isExpired", () => {
   it("is false before the expiry instant and true at/after it", () => {

--- a/packages/server/src/modules/auth/domain/api-token/api-token.specification.ts
+++ b/packages/server/src/modules/auth/domain/api-token/api-token.specification.ts
@@ -1,10 +1,31 @@
 import * as DateTime from "effect/DateTime";
 
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+import { type ApiTokenId } from "./api-token.id.js";
 import { type ApiTokenRoot } from "./api-token.root.js";
 
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The field-name strings live here and in the mapper's
+// column map; `Spec.eq`/`isNull` type them against ApiTokenRoot so a typo is a
+// compile error.
+const withId = (id: ApiTokenId): Specification<ApiTokenRoot> =>
+  Spec.eq<ApiTokenRoot, "id">("id", id);
+const withHash = (tokenHash: string): Specification<ApiTokenRoot> =>
+  Spec.eq<ApiTokenRoot, "tokenHash">("tokenHash", tokenHash);
+
+// Active = not revoked. Composed into `forUser` so the owner's listing hides
+// revoked tokens, matching the live `WHERE ... AND revoked_at IS NULL`.
+const isActive = Spec.isNull<ApiTokenRoot>("revokedAt");
+const forUser = (userId: UserId): Specification<ApiTokenRoot> =>
+  Spec.and(Spec.eq<ApiTokenRoot, "userId">("userId", userId), isActive);
+
 // A null `expiresAt` means non-expiring (reserved for later); such a token
-// never lapses on time alone.
+// never lapses on time alone. Eval-only (a plain predicate, not a
+// Specification): DateTime comparison has no Criteria node, so it never needs
+// SQL translation.
 const isExpired = (token: ApiTokenRoot, now: DateTime.Utc): boolean =>
   token.expiresAt !== null && DateTime.isLessThanOrEqualTo(token.expiresAt, now);
 
-export const ApiTokenSpecifications = { isExpired } as const;
+export const ApiTokenSpecifications = { withId, withHash, forUser, isExpired } as const;

--- a/packages/server/src/modules/auth/domain/auth-identity/auth-identity.repository.ts
+++ b/packages/server/src/modules/auth/domain/auth-identity/auth-identity.repository.ts
@@ -1,8 +1,8 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 
-import { type AuthIdentityNotFound } from "@/modules/auth/domain/auth-identity/auth-identity.errors.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
 export type AuthIdentity = {
@@ -11,10 +11,15 @@ export type AuthIdentity = {
   readonly provider: string;
 };
 
+// Dumb persistence: link an external subject to an app user (insertOne) and
+// read the linkage back by a Specification. The subject lookup is expressed as
+// a spec at the call site (AuthIdentitySpecifications.bySubject); absence is a
+// plain `null`, mapped to AuthIdentityNotFound (or JIT provisioning) by the
+// caller.
 export type AuthIdentityRepositoryShape = {
-  readonly findOneBySubject: (
-    subject: string,
-  ) => Effect.Effect<AuthIdentity, AuthIdentityNotFound | PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<AuthIdentity>,
+  ) => Effect.Effect<AuthIdentity | null, PersistenceUnavailable>;
   // Links a verified external subject to an app user. Used by JIT
   // provisioning on first OIDC sign-in. Joins the caller's transaction.
   readonly insertOne: (identity: AuthIdentity) => Effect.Effect<void, PersistenceUnavailable>;

--- a/packages/server/src/modules/auth/domain/auth-identity/auth-identity.specification.test.ts
+++ b/packages/server/src/modules/auth/domain/auth-identity/auth-identity.specification.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { type AuthIdentity } from "./auth-identity.repository.js";
+import { AuthIdentitySpecifications } from "./auth-identity.specification.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const identity: AuthIdentity = { subject: "zitadel-sub-1", userId, provider: "zitadel" };
+
+describe("AuthIdentitySpecifications.bySubject", () => {
+  it("matches the identity with the given subject and no other", () => {
+    deepStrictEqual(AuthIdentitySpecifications.bySubject("zitadel-sub-1")(identity), true);
+    deepStrictEqual(AuthIdentitySpecifications.bySubject("other-sub")(identity), false);
+  });
+
+  it("carries an Eq criteria over the subject column", () => {
+    deepStrictEqual(AuthIdentitySpecifications.bySubject("zitadel-sub-1").criteria, {
+      _tag: "Eq",
+      field: "subject",
+      value: "zitadel-sub-1",
+    });
+  });
+});

--- a/packages/server/src/modules/auth/domain/auth-identity/auth-identity.specification.ts
+++ b/packages/server/src/modules/auth/domain/auth-identity/auth-identity.specification.ts
@@ -1,0 +1,12 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+
+import { type AuthIdentity } from "./auth-identity.repository.js";
+
+// Translatable spec (carries a Criteria → usable as a repository filter and as
+// an in-memory guard). The field-name string lives here and in the mapper's
+// column map; `Spec.eq` types it against AuthIdentity so a typo is a compile
+// error.
+const bySubject = (subject: string): Specification<AuthIdentity> =>
+  Spec.eq<AuthIdentity, "subject">("subject", subject);
+
+export const AuthIdentitySpecifications = { bySubject } as const;

--- a/packages/server/src/modules/auth/domain/device-grant/device-grant.repository.ts
+++ b/packages/server/src/modules/auth/domain/device-grant/device-grant.repository.ts
@@ -5,18 +5,19 @@ import { type DeviceGrantNotFound } from "@/modules/auth/domain/device-grant/dev
 import { type DeviceGrantId } from "@/modules/auth/domain/device-grant/device-grant.id.js";
 import { type DeviceGrantRoot } from "@/modules/auth/domain/device-grant/device-grant.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
-// Dumb collection port (per `feedback_dumb_repositories`). Lookups by the two
-// codes the flow keys on: device_code_hash (CLI poll) and user_code (browser
-// approve).
+// Dumb collection port (per `feedback_dumb_repositories`): insert/update the
+// aggregate, delete by id, and read it back by a Specification. The lookups the
+// flow keys on — device_code_hash (CLI poll) and user_code (browser approve) —
+// are expressed as specs at the call site (DeviceGrantSpecifications) and
+// compiled to a WHERE fragment by the live repository. Absence is a plain
+// `null`, mapped to DeviceGrantNotFound by the caller.
 export type DeviceGrantRepositoryShape = {
   readonly insertOne: (grant: DeviceGrantRoot) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneByCodeHash: (
-    deviceCodeHash: string,
-  ) => Effect.Effect<DeviceGrantRoot, DeviceGrantNotFound | PersistenceUnavailable>;
-  readonly findOneByUserCode: (
-    userCode: string,
-  ) => Effect.Effect<DeviceGrantRoot, DeviceGrantNotFound | PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<DeviceGrantRoot>,
+  ) => Effect.Effect<DeviceGrantRoot | null, PersistenceUnavailable>;
   readonly updateOne: (
     grant: DeviceGrantRoot,
   ) => Effect.Effect<void, DeviceGrantNotFound | PersistenceUnavailable>;

--- a/packages/server/src/modules/auth/domain/device-grant/device-grant.specification.test.ts
+++ b/packages/server/src/modules/auth/domain/device-grant/device-grant.specification.test.ts
@@ -18,6 +18,38 @@ const start = () =>
     ttlSeconds: 600,
   });
 
+describe("DeviceGrantSpecifications.withCodeHash", () => {
+  it("matches the grant with the given device-code hash and no other", () => {
+    const grant = start();
+    deepStrictEqual(DeviceGrantSpecifications.withCodeHash("hash")(grant), true);
+    deepStrictEqual(DeviceGrantSpecifications.withCodeHash("other")(grant), false);
+  });
+
+  it("carries an Eq criteria over the device_code_hash column", () => {
+    deepStrictEqual(DeviceGrantSpecifications.withCodeHash("hash").criteria, {
+      _tag: "Eq",
+      field: "deviceCodeHash",
+      value: "hash",
+    });
+  });
+});
+
+describe("DeviceGrantSpecifications.withUserCode", () => {
+  it("matches the grant with the given user code and no other", () => {
+    const grant = start();
+    deepStrictEqual(DeviceGrantSpecifications.withUserCode("ABCD-2345")(grant), true);
+    deepStrictEqual(DeviceGrantSpecifications.withUserCode("ZZZZ-9999")(grant), false);
+  });
+
+  it("carries an Eq criteria over the user_code column", () => {
+    deepStrictEqual(DeviceGrantSpecifications.withUserCode("ABCD-2345").criteria, {
+      _tag: "Eq",
+      field: "userCode",
+      value: "ABCD-2345",
+    });
+  });
+});
+
 describe("DeviceGrantSpecifications.isExpired", () => {
   it("is false before expiry and true at/after it", () => {
     const grant = start();

--- a/packages/server/src/modules/auth/domain/device-grant/device-grant.specification.ts
+++ b/packages/server/src/modules/auth/domain/device-grant/device-grant.specification.ts
@@ -1,8 +1,22 @@
 import * as DateTime from "effect/DateTime";
 
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+
 import { type DeviceGrantRoot } from "./device-grant.root.js";
 
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The field-name strings live here and in the mapper's
+// column map; `Spec.eq` types them against DeviceGrantRoot so a typo is a
+// compile error.
+const withCodeHash = (deviceCodeHash: string): Specification<DeviceGrantRoot> =>
+  Spec.eq<DeviceGrantRoot, "deviceCodeHash">("deviceCodeHash", deviceCodeHash);
+const withUserCode = (userCode: string): Specification<DeviceGrantRoot> =>
+  Spec.eq<DeviceGrantRoot, "userCode">("userCode", userCode);
+
+// Eval-only (a plain predicate, not a Specification): DateTime comparison has
+// no Criteria node, so it never needs SQL translation. It stays a guard used
+// in the poll/approve handlers.
 const isExpired = (grant: DeviceGrantRoot, now: DateTime.Utc): boolean =>
   DateTime.isLessThanOrEqualTo(grant.expiresAt, now);
 
-export const DeviceGrantSpecifications = { isExpired } as const;
+export const DeviceGrantSpecifications = { withCodeHash, withUserCode, isExpired } as const;

--- a/packages/server/src/modules/auth/domain/session/session.repository.ts
+++ b/packages/server/src/modules/auth/domain/session/session.repository.ts
@@ -8,12 +8,18 @@ import {
 import { type SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { type SessionRoot } from "@/modules/auth/domain/session/session.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
+// Dumb persistence: insert/update the aggregate, soft-delete by id, and read
+// it back by a Specification. The identity lookup is expressed as a spec at the
+// call site (SessionSpecifications.withId) and compiled to a WHERE fragment by
+// the live repository. Absence is a plain `null`; mapping it to a domain 404
+// (SessionNotFound) is the caller's job.
 export type SessionRepositoryShape = {
   readonly insertOne: (session: SessionRoot) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneById: (
-    id: SessionId,
-  ) => Effect.Effect<SessionRoot, SessionNotFound | PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<SessionRoot>,
+  ) => Effect.Effect<SessionRoot | null, PersistenceUnavailable>;
   // Soft-deletes the session by stamping `revoked_at`. Named after the
   // collection operation, not the business meaning ("revoke" is a
   // use-case concern — see `RevokeSessionCommand`). Repository ports

--- a/packages/server/src/modules/auth/domain/session/session.specification.test.ts
+++ b/packages/server/src/modules/auth/domain/session/session.specification.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { SessionId } from "./session.id.js";
+import { SessionRootOps } from "./session.root-ops.js";
+import { SessionSpecifications } from "./session.specification.js";
+
+const sessionId = SessionId.make("11111111-1111-1111-1111-111111111111");
+const otherId = SessionId.make("22222222-2222-2222-2222-222222222222");
+const userId = UserId.make("33333333-3333-3333-3333-333333333333");
+const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
+
+const session = SessionRootOps.create({
+  id: sessionId,
+  userId,
+  subject: "subject-1",
+  now,
+  ttlSeconds: 3600,
+  absoluteTtlSeconds: 43200,
+});
+
+describe("SessionSpecifications.withId", () => {
+  it("matches the session with the given id and no other", () => {
+    deepStrictEqual(SessionSpecifications.withId(sessionId)(session), true);
+    deepStrictEqual(SessionSpecifications.withId(otherId)(session), false);
+  });
+
+  it("carries an Eq criteria over the id column", () => {
+    deepStrictEqual(SessionSpecifications.withId(sessionId).criteria, {
+      _tag: "Eq",
+      field: "id",
+      value: sessionId,
+    });
+  });
+});

--- a/packages/server/src/modules/auth/domain/session/session.specification.ts
+++ b/packages/server/src/modules/auth/domain/session/session.specification.ts
@@ -1,0 +1,12 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+
+import { type SessionId } from "./session.id.js";
+import { type SessionRoot } from "./session.root.js";
+
+// Translatable spec (carries a Criteria → usable as a repository filter and as
+// an in-memory guard). The field-name string lives here and in the mapper's
+// column map; `Spec.eq` types it against SessionRoot so a typo is a compile
+// error.
+const withId = (id: SessionId): Specification<SessionRoot> => Spec.eq<SessionRoot, "id">("id", id);
+
+export const SessionSpecifications = { withId } as const;

--- a/packages/server/src/modules/auth/infrastructure/repositories/api-token.mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/api-token.mapper.ts
@@ -4,6 +4,17 @@ import * as DateTime from "effect/DateTime";
 import { ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRoot } from "@/modules/auth/domain/api-token/api-token.root.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of auth.api_tokens. Only filterable scalar fields need an
+// entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+  tokenHash: "token_hash",
+  userId: "user_id",
+  revokedAt: "revoked_at",
+} as const satisfies Partial<Record<keyof ApiTokenRoot, string>> & ColumnMap;
 
 export const toDomain = (row: RowSchemas.ApiTokenRow): ApiTokenRoot =>
   ApiTokenRoot.make({

--- a/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-fake.test.ts
@@ -1,15 +1,13 @@
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
-import * as Option from "effect/Option";
 
-import { ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token.errors.js";
 import { ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { ApiTokenRootOps } from "@/modules/auth/domain/api-token/api-token.root-ops.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { ApiTokenRepositoryFake } from "./api-token.repository-fake.js";
@@ -35,38 +33,35 @@ const make = (id: ApiTokenId, opts: { userId?: UserId; hash?: string; createdAt?
 const provide = Effect.provide(ApiTokenRepositoryFake);
 
 describe("ApiTokenRepositoryFake", () => {
-  it.effect("insert + findOneById + findOneByHash round-trip", () =>
+  it.effect("insert + findOne by id and by hash round-trip", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
       yield* repo.insertOne(make(idA, { hash: "hash-A" }));
-      deepStrictEqual((yield* repo.findOneById(idA)).id, idA);
-      deepStrictEqual((yield* repo.findOneByHash("hash-A")).id, idA);
+      const byId = yield* repo.findOne(ApiTokenSpecifications.withId(idA));
+      const byHash = yield* repo.findOne(ApiTokenSpecifications.withHash("hash-A"));
+      if (byId === null || byHash === null) throw new Error("expected a token");
+      deepStrictEqual(byId.id, idA);
+      deepStrictEqual(byHash.id, idA);
     }).pipe(provide),
   );
 
-  it.effect("findOneById / findOneByHash fail ApiTokenNotFound when absent", () =>
+  it.effect("findOne returns null when absent (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      const byId = yield* Effect.exit(repo.findOneById(idMissing));
-      const byHash = yield* Effect.exit(repo.findOneByHash("nope"));
-      deepStrictEqual(Exit.isFailure(byId), true);
-      deepStrictEqual(Exit.isFailure(byHash), true);
-      if (Exit.isFailure(byId)) {
-        const error = Cause.hasFails(byId.cause)
-          ? Cause.findErrorOption(byId.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof ApiTokenNotFound, true);
-      }
+      const byId = yield* repo.findOne(ApiTokenSpecifications.withId(idMissing));
+      const byHash = yield* repo.findOne(ApiTokenSpecifications.withHash("nope"));
+      deepStrictEqual(byId, null);
+      deepStrictEqual(byHash, null);
     }).pipe(provide),
   );
 
-  it.effect("findManyByUser returns only the caller's active tokens, newest first", () =>
+  it.effect("findMany(forUser) returns only the caller's active tokens, newest first", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
       yield* repo.insertOne(make(idA, { hash: "a", createdAt: now }));
       yield* repo.insertOne(make(idB, { hash: "b", createdAt: DateTime.add(now, { hours: 1 }) }));
       yield* repo.insertOne(make(idMissing, { userId: otherUserId, hash: "c" }));
-      const mine = yield* repo.findManyByUser(userId);
+      const mine = yield* repo.findMany(ApiTokenSpecifications.forUser(userId));
       deepStrictEqual(
         mine.map((t) => t.id),
         [idB, idA],
@@ -74,13 +69,15 @@ describe("ApiTokenRepositoryFake", () => {
     }).pipe(provide),
   );
 
-  it.effect("delete soft-revokes; a second delete fails NotFound; findManyByUser hides it", () =>
+  it.effect("delete soft-revokes; a second delete fails NotFound; findMany hides it", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
       yield* repo.insertOne(make(idA, { hash: "a" }));
       yield* repo.deleteOne(idA);
-      deepStrictEqual((yield* repo.findOneById(idA)).revokedAt !== null, true);
-      deepStrictEqual((yield* repo.findManyByUser(userId)).length, 0);
+      const found = yield* repo.findOne(ApiTokenSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a token");
+      deepStrictEqual(found.revokedAt !== null, true);
+      deepStrictEqual((yield* repo.findMany(ApiTokenSpecifications.forUser(userId))).length, 0);
       const second = yield* Effect.exit(repo.deleteOne(idA));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(provide),
@@ -93,7 +90,9 @@ describe("ApiTokenRepositoryFake", () => {
       yield* repo.insertOne(seed);
       const later = DateTime.add(now, { hours: 2 });
       yield* repo.updateOne(ApiTokenRootOps.touch({ token: seed, now: later }));
-      deepStrictEqual((yield* repo.findOneById(idA)).lastUsedAt, later);
+      const found = yield* repo.findOne(ApiTokenSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a token");
+      deepStrictEqual(found.lastUsedAt, later);
 
       yield* repo.deleteOne(idA);
       const exit = yield* Effect.exit(

--- a/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-fake.ts
@@ -10,7 +10,7 @@ import { ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token.erro
 import { type ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { ApiTokenRoot } from "@/modules/auth/domain/api-token/api-token.root.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
 export const ApiTokenRepositoryFake = Layer.effect(
   ApiTokenRepository,
@@ -20,25 +20,18 @@ export const ApiTokenRepositoryFake = Layer.effect(
     const insertOne = (token: ApiTokenRoot): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(token.id, token));
 
-    const findOneById = (id: ApiTokenId): Effect.Effect<ApiTokenRoot, ApiTokenNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new ApiTokenNotFound()),
-          onSome: Effect.succeed,
-        }),
-      );
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (spec: Specification<ApiTokenRoot>): Effect.Effect<ApiTokenRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    const findOneByHash = (tokenHash: string): Effect.Effect<ApiTokenRoot, ApiTokenNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        const match = Array.from(HashMap.values(m)).find((t) => t.tokenHash === tokenHash);
-        return match === undefined ? Effect.fail(new ApiTokenNotFound()) : Effect.succeed(match);
-      });
-
-    // Active (non-revoked) tokens, newest first — mirrors the live SQL.
-    const findManyByUser = (userId: UserId): Effect.Effect<ReadonlyArray<ApiTokenRoot>> =>
+    // Newest first, mirroring the live repo's `ORDER BY created_at DESC`.
+    const findMany = (
+      spec: Specification<ApiTokenRoot>,
+    ): Effect.Effect<ReadonlyArray<ApiTokenRoot>> =>
       Effect.map(Ref.get(store), (m) =>
         Array.from(HashMap.values(m))
-          .filter((t) => t.userId === userId && t.revokedAt === null)
+          .filter(spec)
           .sort(Order.flip(Order.mapInput(DateTime.Order, (t: ApiTokenRoot) => t.createdAt))),
       );
 
@@ -78,9 +71,8 @@ export const ApiTokenRepositoryFake = Layer.effect(
 
     return ApiTokenRepository.of({
       insertOne,
-      findOneById,
-      findOneByHash,
-      findManyByUser,
+      findOne,
+      findMany,
       deleteOne: deleteToken,
       updateOne,
     });

--- a/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-live.integration.test.ts
@@ -1,18 +1,16 @@
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
 
-import { ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token.errors.js";
 import { ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { ApiTokenRootOps } from "@/modules/auth/domain/api-token/api-token.root-ops.js";
+import { ApiTokenSpecifications } from "@/modules/auth/domain/api-token/api-token.specification.js";
 import { ApiTokenRepositoryLive } from "@/modules/auth/infrastructure/repositories/api-token.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -53,36 +51,32 @@ suite("ApiTokenRepositoryLive (integration)", () => {
     );
   });
 
-  it.effect("insert + findOneById + findOneByHash round-trip a token through the DB", () =>
+  it.effect("insert + findOne by id and by hash round-trip a token through the DB", () =>
     Effect.gen(function* () {
       yield* insertUserRow;
       const repo = yield* ApiTokenRepository;
       const now = yield* DateTime.now;
       yield* repo.insertOne(make(idA, "hash-A", now));
-      const byId = yield* repo.findOneById(idA);
+      const byId = yield* repo.findOne(ApiTokenSpecifications.withId(idA));
+      const byHash = yield* repo.findOne(ApiTokenSpecifications.withHash("hash-A"));
+      if (byId === null || byHash === null) throw new Error("expected a token");
       deepStrictEqual(byId.id, idA);
       deepStrictEqual(byId.userId, userId);
       deepStrictEqual(byId.tokenHash, "hash-A");
       deepStrictEqual(byId.revokedAt, null);
-      deepStrictEqual((yield* repo.findOneByHash("hash-A")).id, idA);
+      deepStrictEqual(byHash.id, idA);
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findOneByHash fails ApiTokenNotFound for an unknown hash", () =>
+  it.effect("findOne returns null for an unknown hash (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* ApiTokenRepository;
-      const exit = yield* Effect.exit(repo.findOneByHash("missing"));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof ApiTokenNotFound, true);
-      }
+      const found = yield* repo.findOne(ApiTokenSpecifications.withHash("missing"));
+      deepStrictEqual(found, null);
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findManyByUser returns active tokens newest-first and hides revoked", () =>
+  it.effect("findMany(forUser) returns active tokens newest-first and hides revoked", () =>
     Effect.gen(function* () {
       yield* insertUserRow;
       const repo = yield* ApiTokenRepository;
@@ -90,7 +84,7 @@ suite("ApiTokenRepositoryLive (integration)", () => {
       yield* repo.insertOne(make(idA, "a", now, now));
       yield* repo.insertOne(make(idB, "b", now, DateTime.add(now, { hours: 1 })));
       yield* repo.deleteOne(idA);
-      const mine = yield* repo.findManyByUser(userId);
+      const mine = yield* repo.findMany(ApiTokenSpecifications.forUser(userId));
       deepStrictEqual(
         mine.map((t) => t.id),
         [idB],
@@ -105,7 +99,9 @@ suite("ApiTokenRepositoryLive (integration)", () => {
       const now = yield* DateTime.now;
       yield* repo.insertOne(make(idA, "a", now));
       yield* repo.deleteOne(idA);
-      deepStrictEqual((yield* repo.findOneById(idA)).revokedAt !== null, true);
+      const found = yield* repo.findOne(ApiTokenSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a token");
+      deepStrictEqual(found.revokedAt !== null, true);
       const second = yield* Effect.exit(repo.deleteOne(idA));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(Effect.provide(TestLayer)),
@@ -120,7 +116,8 @@ suite("ApiTokenRepositoryLive (integration)", () => {
       yield* repo.insertOne(seed);
       const later = DateTime.add(now, { hours: 2 });
       yield* repo.updateOne(ApiTokenRootOps.touch({ token: seed, now: later }));
-      const found = yield* repo.findOneById(idA);
+      const found = yield* repo.findOne(ApiTokenSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a token");
       deepStrictEqual(found.lastUsedAt, later);
       deepStrictEqual(found.expiresAt, seed.expiresAt);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/api-token.repository-live.ts
@@ -6,7 +6,8 @@ import { ApiTokenNotFound } from "@/modules/auth/domain/api-token/api-token.erro
 import { type ApiTokenId } from "@/modules/auth/domain/api-token/api-token.id.js";
 import { ApiTokenRepository } from "@/modules/auth/domain/api-token/api-token.repository.js";
 import { type ApiTokenRoot } from "@/modules/auth/domain/api-token/api-token.root.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as ApiTokenMapper from "./api-token.mapper.js";
@@ -42,46 +43,38 @@ export const ApiTokenRepositoryLive = Layer.effect(
       );
     });
 
-    const findOneById = db.makeQuery((execute, id: ApiTokenId) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the id primary key, the unique token_hash).
+    const findOne = db.makeQuery((execute, spec: Specification<ApiTokenRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
-          SELECT * FROM auth.api_tokens WHERE id = ${id}
+          SELECT * FROM auth.api_tokens
+          WHERE ${criteriaToWhere(spec.criteria, ApiTokenMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new ApiTokenNotFound()),
-        Effect.map(ApiTokenMapper.toDomain),
+        Effect.map((row) => (row === null ? null : ApiTokenMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.findOneById"),
+        Effect.withSpan("ApiTokenRepository.findOne"),
       ),
     );
 
-    const findOneByHash = db.makeQuery((execute, tokenHash: string) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.ApiTokenRowStd)`
-          SELECT * FROM auth.api_tokens WHERE token_hash = ${tokenHash}
-        `),
-      ).pipe(
-        orFail(() => new ApiTokenNotFound()),
-        Effect.map(ApiTokenMapper.toDomain),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.findOneByHash"),
-      ),
-    );
-
-    const findManyByUser = db.makeQuery((execute, userId: UserId) =>
+    // The repository owns the newest-first ordering; the spec (e.g. forUser)
+    // contributes the WHERE, including the `revoked_at IS NULL` active filter.
+    const findMany = db.makeQuery((execute, spec: Specification<ApiTokenRoot>) =>
       execute((client) =>
         client.any(sql.type(RowSchemas.ApiTokenRowStd)`
           SELECT * FROM auth.api_tokens
-          WHERE user_id = ${userId} AND revoked_at IS NULL
+          WHERE ${criteriaToWhere(spec.criteria, ApiTokenMapper.columns)}
           ORDER BY created_at DESC
         `),
       ).pipe(
         Effect.map((rows) => rows.map(ApiTokenMapper.toDomain)),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("ApiTokenRepository.findManyByUser"),
+        Effect.withSpan("ApiTokenRepository.findMany"),
       ),
     );
 
@@ -121,9 +114,8 @@ export const ApiTokenRepositoryLive = Layer.effect(
 
     return ApiTokenRepository.of({
       insertOne,
-      findOneById,
-      findOneByHash,
-      findManyByUser,
+      findOne,
+      findMany,
       deleteOne: deleteById,
       updateOne,
     });

--- a/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.mapper.ts
@@ -2,6 +2,14 @@ import { type RowSchemas } from "@org/database/index";
 
 import { type AuthIdentity } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of auth.auth_identities. Only filterable scalar fields need
+// an entry; `satisfies` keeps the keys honest against the domain type.
+export const columns = {
+  subject: "subject",
+} as const satisfies Partial<Record<keyof AuthIdentity, string>> & ColumnMap;
 
 export const toDomain = (row: RowSchemas.AuthIdentityRow): AuthIdentity => ({
   subject: row.subject,

--- a/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-fake.test.ts
@@ -1,12 +1,9 @@
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Option from "effect/Option";
 
-import { AuthIdentityNotFound } from "@/modules/auth/domain/auth-identity/auth-identity.errors.js";
 import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
+import { AuthIdentitySpecifications } from "@/modules/auth/domain/auth-identity/auth-identity.specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { makeAuthIdentityRepositoryFake } from "./auth-identity.repository-fake.js";
@@ -18,7 +15,8 @@ describe("AuthIdentityRepositoryFake", () => {
   it.effect("returns the seeded identity for a known subject", () =>
     Effect.gen(function* () {
       const repo = yield* AuthIdentityRepository;
-      const found = yield* repo.findOneBySubject(subject);
+      const found = yield* repo.findOne(AuthIdentitySpecifications.bySubject(subject));
+      if (found === null) throw new Error("expected an identity");
       deepStrictEqual(found.subject, subject);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.provider, "zitadel");
@@ -27,17 +25,11 @@ describe("AuthIdentityRepositoryFake", () => {
     ),
   );
 
-  it.effect("fails AuthIdentityNotFound for an unknown subject", () =>
+  it.effect("returns null for an unknown subject (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* AuthIdentityRepository;
-      const exit = yield* Effect.exit(repo.findOneBySubject("missing-sub"));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof AuthIdentityNotFound, true);
-      }
+      const found = yield* repo.findOne(AuthIdentitySpecifications.bySubject("missing-sub"));
+      deepStrictEqual(found, null);
     }).pipe(Effect.provide(makeAuthIdentityRepositoryFake())),
   );
 });

--- a/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-fake.ts
@@ -1,14 +1,13 @@
 import * as Effect from "effect/Effect";
 import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
-import { AuthIdentityNotFound } from "@/modules/auth/domain/auth-identity/auth-identity.errors.js";
 import {
   type AuthIdentity,
   AuthIdentityRepository,
 } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
 // The fake exposes a constructor that accepts initial state so tests can
 // seed identities up front, and an in-memory `insert` mirroring the live
@@ -22,20 +21,15 @@ export const makeAuthIdentityRepositoryFake = (
       const initial = HashMap.fromIterable(seed.map((i) => [i.subject, i] as const));
       const store = yield* Ref.make(initial);
 
-      const findOneBySubject = (
-        subject: string,
-      ): Effect.Effect<AuthIdentity, AuthIdentityNotFound> =>
-        Effect.flatMap(Ref.get(store), (m) =>
-          Option.match(HashMap.get(m, subject), {
-            onNone: () => Effect.fail(new AuthIdentityNotFound({ subject })),
-            onSome: Effect.succeed,
-          }),
-        );
+      // The spec IS the in-memory predicate — the same object the live repo
+      // compiles to SQL — so fake and live agree by construction.
+      const findOne = (spec: Specification<AuthIdentity>): Effect.Effect<AuthIdentity | null> =>
+        Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
       const insertOne = (identity: AuthIdentity): Effect.Effect<void> =>
         Ref.update(store, (m) => HashMap.set(m, identity.subject, identity));
 
-      return AuthIdentityRepository.of({ findOneBySubject, insertOne });
+      return AuthIdentityRepository.of({ findOne, insertOne });
     }),
   );
 

--- a/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-live.integration.test.ts
@@ -1,15 +1,12 @@
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
 
-import { AuthIdentityNotFound } from "@/modules/auth/domain/auth-identity/auth-identity.errors.js";
 import { AuthIdentityRepository } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
+import { AuthIdentitySpecifications } from "@/modules/auth/domain/auth-identity/auth-identity.specification.js";
 import { AuthIdentityRepositoryLive } from "@/modules/auth/infrastructure/repositories/auth-identity.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -42,18 +39,19 @@ suite("AuthIdentityRepositoryLive (integration)", () => {
     await Effect.runPromise(truncate("user.users").pipe(Effect.provide(TestDatabaseLive)));
   });
 
-  it.effect("findOneBySubject returns the seeded identity", () =>
+  it.effect("findOne(bySubject) returns the seeded identity", () =>
     Effect.gen(function* () {
       yield* seedUserAndIdentity;
       const repo = yield* AuthIdentityRepository;
-      const found = yield* repo.findOneBySubject(subject);
+      const found = yield* repo.findOne(AuthIdentitySpecifications.bySubject(subject));
+      if (found === null) throw new Error("expected an identity");
       deepStrictEqual(found.subject, subject);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.provider, "zitadel");
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("insert links a subject to a user, retrievable via findOneBySubject", () =>
+  it.effect("insert links a subject to a user, retrievable via findOne(bySubject)", () =>
     Effect.gen(function* () {
       // Seed only the user row (the FK target); the identity is created via
       // the repository's write path, mirroring JIT provisioning.
@@ -70,24 +68,19 @@ suite("AuthIdentityRepositoryLive (integration)", () => {
       const repo = yield* AuthIdentityRepository;
       yield* repo.insertOne({ subject: "jit-sub", userId, provider: "zitadel" });
 
-      const found = yield* repo.findOneBySubject("jit-sub");
+      const found = yield* repo.findOne(AuthIdentitySpecifications.bySubject("jit-sub"));
+      if (found === null) throw new Error("expected an identity");
       deepStrictEqual(found.subject, "jit-sub");
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.provider, "zitadel");
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findOneBySubject fails AuthIdentityNotFound for an unknown subject", () =>
+  it.effect("findOne returns null for an unknown subject (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* AuthIdentityRepository;
-      const exit = yield* Effect.exit(repo.findOneBySubject("missing-sub"));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof AuthIdentityNotFound, true);
-      }
+      const found = yield* repo.findOne(AuthIdentitySpecifications.bySubject("missing-sub"));
+      deepStrictEqual(found, null);
     }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/auth-identity.repository-live.ts
@@ -1,12 +1,13 @@
-import { Database, orFail, RowSchemas, sql } from "@org/database/index";
+import { Database, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { AuthIdentityNotFound } from "@/modules/auth/domain/auth-identity/auth-identity.errors.js";
 import {
   type AuthIdentity,
   AuthIdentityRepository,
 } from "@/modules/auth/domain/auth-identity/auth-identity.repository.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as AuthIdentityMapper from "./auth-identity.mapper.js";
@@ -16,17 +17,21 @@ export const AuthIdentityRepositoryLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Database.Database;
 
-    const findOneBySubject = db.makeQuery((execute, subject: string) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the unique subject).
+    const findOne = db.makeQuery((execute, spec: Specification<AuthIdentity>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.AuthIdentityRowStd)`
-          SELECT * FROM auth.auth_identities WHERE subject = ${subject}
+          SELECT * FROM auth.auth_identities
+          WHERE ${criteriaToWhere(spec.criteria, AuthIdentityMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new AuthIdentityNotFound({ subject })),
-        Effect.map(AuthIdentityMapper.toDomain),
+        Effect.map((row) => (row === null ? null : AuthIdentityMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("AuthIdentityRepository.findOneBySubject"),
+        Effect.withSpan("AuthIdentityRepository.findOne"),
       ),
     );
 
@@ -44,6 +49,6 @@ export const AuthIdentityRepositoryLive = Layer.effect(
       ),
     );
 
-    return AuthIdentityRepository.of({ findOneBySubject, insertOne });
+    return AuthIdentityRepository.of({ findOne, insertOne });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/repositories/device-grant.mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/device-grant.mapper.ts
@@ -4,6 +4,15 @@ import * as DateTime from "effect/DateTime";
 import { DeviceGrantId } from "@/modules/auth/domain/device-grant/device-grant.id.js";
 import { DeviceGrantRoot } from "@/modules/auth/domain/device-grant/device-grant.root.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of auth.device_grants. Only filterable scalar fields need an
+// entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  deviceCodeHash: "device_code_hash",
+  userCode: "user_code",
+} as const satisfies Partial<Record<keyof DeviceGrantRoot, string>> & ColumnMap;
 
 export const toDomain = (row: RowSchemas.DeviceGrantRow): DeviceGrantRoot =>
   DeviceGrantRoot.make({

--- a/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-fake.test.ts
@@ -1,15 +1,13 @@
 import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
-import * as Option from "effect/Option";
 
-import { DeviceGrantNotFound } from "@/modules/auth/domain/device-grant/device-grant.errors.js";
 import { DeviceGrantId } from "@/modules/auth/domain/device-grant/device-grant.id.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
 import { DeviceGrantRootOps } from "@/modules/auth/domain/device-grant/device-grant.root-ops.js";
+import { DeviceGrantSpecifications } from "@/modules/auth/domain/device-grant/device-grant.specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { DeviceGrantRepositoryFake } from "./device-grant.repository-fake.js";
@@ -35,26 +33,23 @@ const seed = () =>
 const provide = Effect.provide(DeviceGrantRepositoryFake);
 
 describe("DeviceGrantRepositoryFake", () => {
-  it.effect("insert + lookup by code hash and by user code", () =>
+  it.effect("insert + findOne by code hash and by user code", () =>
     Effect.gen(function* () {
       yield* seed();
       const repo = yield* DeviceGrantRepository;
-      deepStrictEqual((yield* repo.findOneByCodeHash("dc-hash")).id, id);
-      deepStrictEqual((yield* repo.findOneByUserCode("ABCD-2345")).id, id);
+      const byHash = yield* repo.findOne(DeviceGrantSpecifications.withCodeHash("dc-hash"));
+      const byUser = yield* repo.findOne(DeviceGrantSpecifications.withUserCode("ABCD-2345"));
+      if (byHash === null || byUser === null) throw new Error("expected a grant");
+      deepStrictEqual(byHash.id, id);
+      deepStrictEqual(byUser.id, id);
     }).pipe(provide),
   );
 
-  it.effect("lookups fail DeviceGrantNotFound when absent", () =>
+  it.effect("findOne returns null when absent (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* DeviceGrantRepository;
-      const exit = yield* Effect.exit(repo.findOneByUserCode("ZZZZ-9999"));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof DeviceGrantNotFound, true);
-      }
+      const found = yield* repo.findOne(DeviceGrantSpecifications.withUserCode("ZZZZ-9999"));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 
@@ -63,7 +58,8 @@ describe("DeviceGrantRepositoryFake", () => {
       const grant = yield* seed();
       const repo = yield* DeviceGrantRepository;
       yield* repo.updateOne(DeviceGrantRootOps.approve({ grant, userId, now }));
-      const after = yield* repo.findOneByCodeHash("dc-hash");
+      const after = yield* repo.findOne(DeviceGrantSpecifications.withCodeHash("dc-hash"));
+      if (after === null) throw new Error("expected a grant");
       deepStrictEqual(after.status, "approved");
       deepStrictEqual(after.userId, userId);
     }).pipe(provide),
@@ -74,8 +70,8 @@ describe("DeviceGrantRepositoryFake", () => {
       yield* seed();
       const repo = yield* DeviceGrantRepository;
       yield* repo.deleteOne(id);
-      const lookup = yield* Effect.exit(repo.findOneByCodeHash("dc-hash"));
-      deepStrictEqual(Exit.isFailure(lookup), true);
+      const lookup = yield* repo.findOne(DeviceGrantSpecifications.withCodeHash("dc-hash"));
+      deepStrictEqual(lookup, null);
       const second = yield* Effect.exit(repo.deleteOne(id));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(provide),

--- a/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-fake.ts
@@ -8,6 +8,7 @@ import { DeviceGrantNotFound } from "@/modules/auth/domain/device-grant/device-g
 import { type DeviceGrantId } from "@/modules/auth/domain/device-grant/device-grant.id.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
 import { type DeviceGrantRoot } from "@/modules/auth/domain/device-grant/device-grant.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
 export const DeviceGrantRepositoryFake = Layer.effect(
   DeviceGrantRepository,
@@ -17,18 +18,10 @@ export const DeviceGrantRepositoryFake = Layer.effect(
     const insertOne = (grant: DeviceGrantRoot): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(grant.id, grant));
 
-    const findBy = (
-      pred: (g: DeviceGrantRoot) => boolean,
-    ): Effect.Effect<DeviceGrantRoot, DeviceGrantNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        const match = Array.from(HashMap.values(m)).find(pred);
-        return match === undefined ? Effect.fail(new DeviceGrantNotFound()) : Effect.succeed(match);
-      });
-
-    const findOneByCodeHash = (deviceCodeHash: string) =>
-      findBy((g) => g.deviceCodeHash === deviceCodeHash);
-
-    const findOneByUserCode = (userCode: string) => findBy((g) => g.userCode === userCode);
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (spec: Specification<DeviceGrantRoot>): Effect.Effect<DeviceGrantRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
     const updateOne = (grant: DeviceGrantRoot): Effect.Effect<void, DeviceGrantNotFound> =>
       Effect.gen(function* () {
@@ -50,8 +43,7 @@ export const DeviceGrantRepositoryFake = Layer.effect(
 
     return DeviceGrantRepository.of({
       insertOne,
-      findOneByCodeHash,
-      findOneByUserCode,
+      findOne,
       updateOne,
       deleteOne: deleteGrant,
     });

--- a/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-live.integration.test.ts
@@ -1,18 +1,16 @@
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
 
-import { DeviceGrantNotFound } from "@/modules/auth/domain/device-grant/device-grant.errors.js";
 import { DeviceGrantId } from "@/modules/auth/domain/device-grant/device-grant.id.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
 import { DeviceGrantRootOps } from "@/modules/auth/domain/device-grant/device-grant.root-ops.js";
+import { DeviceGrantSpecifications } from "@/modules/auth/domain/device-grant/device-grant.specification.js";
 import { DeviceGrantRepositoryLive } from "@/modules/auth/infrastructure/repositories/device-grant.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -50,13 +48,15 @@ suite("DeviceGrantRepositoryLive (integration)", () => {
     );
   });
 
-  it.effect("insert + findOneByCodeHash + findOneByUserCode round-trip", () =>
+  it.effect("insert + findOne by code hash and by user code round-trip", () =>
     Effect.gen(function* () {
       const repo = yield* DeviceGrantRepository;
       const now = yield* DateTime.now;
       yield* repo.insertOne(start(now));
-      deepStrictEqual((yield* repo.findOneByCodeHash("dc-hash")).id, id);
-      const byUser = yield* repo.findOneByUserCode("ABCD-2345");
+      const byHash = yield* repo.findOne(DeviceGrantSpecifications.withCodeHash("dc-hash"));
+      const byUser = yield* repo.findOne(DeviceGrantSpecifications.withUserCode("ABCD-2345"));
+      if (byHash === null || byUser === null) throw new Error("expected a grant");
+      deepStrictEqual(byHash.id, id);
       deepStrictEqual(byUser.status, "pending");
       deepStrictEqual(byUser.userId, null);
     }).pipe(Effect.provide(TestLayer)),
@@ -70,7 +70,8 @@ suite("DeviceGrantRepositoryLive (integration)", () => {
       const grant = start(now);
       yield* repo.insertOne(grant);
       yield* repo.updateOne(DeviceGrantRootOps.approve({ grant, userId, now }));
-      const after = yield* repo.findOneByCodeHash("dc-hash");
+      const after = yield* repo.findOne(DeviceGrantSpecifications.withCodeHash("dc-hash"));
+      if (after === null) throw new Error("expected a grant");
       deepStrictEqual(after.status, "approved");
       deepStrictEqual(after.userId, userId);
       deepStrictEqual(after.approvedAt !== null, true);
@@ -83,14 +84,8 @@ suite("DeviceGrantRepositoryLive (integration)", () => {
       const now = yield* DateTime.now;
       yield* repo.insertOne(start(now));
       yield* repo.deleteOne(id);
-      const lookup = yield* Effect.exit(repo.findOneByCodeHash("dc-hash"));
-      deepStrictEqual(Exit.isFailure(lookup), true);
-      if (Exit.isFailure(lookup)) {
-        const error = Cause.hasFails(lookup.cause)
-          ? Cause.findErrorOption(lookup.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof DeviceGrantNotFound, true);
-      }
+      const lookup = yield* repo.findOne(DeviceGrantSpecifications.withCodeHash("dc-hash"));
+      deepStrictEqual(lookup, null);
       const second = yield* Effect.exit(repo.deleteOne(id));
       deepStrictEqual(Exit.isFailure(second), true);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/device-grant.repository-live.ts
@@ -6,6 +6,8 @@ import { DeviceGrantNotFound } from "@/modules/auth/domain/device-grant/device-g
 import { type DeviceGrantId } from "@/modules/auth/domain/device-grant/device-grant.id.js";
 import { DeviceGrantRepository } from "@/modules/auth/domain/device-grant/device-grant.repository.js";
 import { type DeviceGrantRoot } from "@/modules/auth/domain/device-grant/device-grant.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as DeviceGrantMapper from "./device-grant.mapper.js";
@@ -40,31 +42,21 @@ export const DeviceGrantRepositoryLive = Layer.effect(
       );
     });
 
-    const findOneByCodeHash = db.makeQuery((execute, deviceCodeHash: string) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the unique device_code_hash / user_code).
+    const findOne = db.makeQuery((execute, spec: Specification<DeviceGrantRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
-          SELECT * FROM auth.device_grants WHERE device_code_hash = ${deviceCodeHash}
+          SELECT * FROM auth.device_grants
+          WHERE ${criteriaToWhere(spec.criteria, DeviceGrantMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new DeviceGrantNotFound()),
-        Effect.map(DeviceGrantMapper.toDomain),
+        Effect.map((row) => (row === null ? null : DeviceGrantMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.findOneByCodeHash"),
-      ),
-    );
-
-    const findOneByUserCode = db.makeQuery((execute, userCode: string) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.DeviceGrantRowStd)`
-          SELECT * FROM auth.device_grants WHERE user_code = ${userCode}
-        `),
-      ).pipe(
-        orFail(() => new DeviceGrantNotFound()),
-        Effect.map(DeviceGrantMapper.toDomain),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("DeviceGrantRepository.findOneByUserCode"),
+        Effect.withSpan("DeviceGrantRepository.findOne"),
       ),
     );
 
@@ -104,8 +96,7 @@ export const DeviceGrantRepositoryLive = Layer.effect(
 
     return DeviceGrantRepository.of({
       insertOne,
-      findOneByCodeHash,
-      findOneByUserCode,
+      findOne,
       updateOne,
       deleteOne: deleteById,
     });

--- a/packages/server/src/modules/auth/infrastructure/repositories/session.mapper.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/session.mapper.ts
@@ -4,6 +4,14 @@ import * as DateTime from "effect/DateTime";
 import { SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRoot } from "@/modules/auth/domain/session/session.root.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of auth.sessions. Only filterable scalar fields need an
+// entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+} as const satisfies Partial<Record<keyof SessionRoot, string>> & ColumnMap;
 
 export const toDomain = (row: RowSchemas.SessionRow): SessionRoot =>
   SessionRoot.make({

--- a/packages/server/src/modules/auth/infrastructure/repositories/session.repository-fake.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/session.repository-fake.test.ts
@@ -10,6 +10,7 @@ import { SessionNotFound } from "@/modules/auth/domain/session/session.errors.js
 import { SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.js";
+import { SessionSpecifications } from "@/modules/auth/domain/session/session.specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { SessionRepositoryFake } from "./session.repository-fake.js";
@@ -32,27 +33,22 @@ const makeSession = (id: SessionId) =>
 const provide = Effect.provide(SessionRepositoryFake);
 
 describe("SessionRepositoryFake", () => {
-  it.effect("insert + findOneById round-trip", () =>
+  it.effect("insert + findOne(withId) round-trip", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
       yield* repo.insertOne(makeSession(idA));
-      const found = yield* repo.findOneById(idA);
+      const found = yield* repo.findOne(SessionSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a session");
       deepStrictEqual(found.id, idA);
       deepStrictEqual(found.revokedAt, null);
     }).pipe(provide),
   );
 
-  it.effect("findOneById fails SessionNotFound for an unknown id", () =>
+  it.effect("findOne returns null for an unknown id (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      const exit = yield* Effect.exit(repo.findOneById(idMissing));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof SessionNotFound, true);
-      }
+      const found = yield* repo.findOne(SessionSpecifications.withId(idMissing));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 
@@ -61,7 +57,8 @@ describe("SessionRepositoryFake", () => {
       const repo = yield* SessionRepository;
       yield* repo.insertOne(makeSession(idA));
       yield* repo.deleteOne(idA);
-      const found = yield* repo.findOneById(idA);
+      const found = yield* repo.findOne(SessionSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a session");
       deepStrictEqual(found.revokedAt !== null, true);
     }).pipe(provide),
   );
@@ -92,7 +89,8 @@ describe("SessionRepositoryFake", () => {
       const later = DateTime.add(now, { seconds: 1800 });
       const touched = SessionRootOps.touch({ session: seed, now: later, ttlSeconds: 3600 });
       yield* repo.updateOne(touched);
-      const found = yield* repo.findOneById(idA);
+      const found = yield* repo.findOne(SessionSpecifications.withId(idA));
+      if (found === null) throw new Error("expected a session");
       deepStrictEqual(found.expiresAt, touched.expiresAt);
       deepStrictEqual(found.lastUsedAt, touched.lastUsedAt);
       deepStrictEqual(found.createdAt, seed.createdAt);

--- a/packages/server/src/modules/auth/infrastructure/repositories/session.repository-fake.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/session.repository-fake.ts
@@ -9,6 +9,7 @@ import { SessionNotFound } from "@/modules/auth/domain/session/session.errors.js
 import { type SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRoot } from "@/modules/auth/domain/session/session.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
 export const SessionRepositoryFake = Layer.effect(
   SessionRepository,
@@ -18,13 +19,10 @@ export const SessionRepositoryFake = Layer.effect(
     const insertOne = (session: SessionRoot): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(session.id, session));
 
-    const findOneById = (id: SessionId): Effect.Effect<SessionRoot, SessionNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new SessionNotFound({ sessionId: id })),
-          onSome: Effect.succeed,
-        }),
-      );
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (spec: Specification<SessionRoot>): Effect.Effect<SessionRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
     // Mirrors the live impl: a re-delete on an already-soft-deleted
     // session is reported as SessionNotFound (the SQL UPDATE matches
@@ -84,6 +82,6 @@ export const SessionRepositoryFake = Layer.effect(
         );
       });
 
-    return SessionRepository.of({ insertOne, findOneById, deleteOne: deleteSession, updateOne });
+    return SessionRepository.of({ insertOne, findOne, deleteOne: deleteSession, updateOne });
   }),
 );

--- a/packages/server/src/modules/auth/infrastructure/repositories/session.repository-live.integration.test.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/session.repository-live.integration.test.ts
@@ -1,18 +1,16 @@
 import { describe, it } from "@effect/vitest";
 import { Database, sql } from "@org/database/index";
 import { deepStrictEqual } from "assert";
-import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import { beforeEach } from "vitest";
 
-import { SessionNotFound } from "@/modules/auth/domain/session/session.errors.js";
 import { SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { SessionRootOps } from "@/modules/auth/domain/session/session.root-ops.js";
+import { SessionSpecifications } from "@/modules/auth/domain/session/session.specification.js";
 import { SessionRepositoryLive } from "@/modules/auth/infrastructure/repositories/session.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -50,14 +48,15 @@ suite("SessionRepositoryLive (integration)", () => {
     await Effect.runPromise(truncate("user.users").pipe(Effect.provide(TestDatabaseLive)));
   });
 
-  it.effect("insert + findOneById round-trips a Session through the DB", () =>
+  it.effect("insert + findOne(withId) round-trips a Session through the DB", () =>
     Effect.gen(function* () {
       yield* insertUserRow;
       const repo = yield* SessionRepository;
       const now = yield* DateTime.now;
       const session = makeSession(now);
       yield* repo.insertOne(session);
-      const found = yield* repo.findOneById(sessionId);
+      const found = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      if (found === null) throw new Error("expected a session");
       deepStrictEqual(found.id, sessionId);
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.subject, subject);
@@ -65,17 +64,11 @@ suite("SessionRepositoryLive (integration)", () => {
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("findOneById fails SessionNotFound for an unknown id", () =>
+  it.effect("findOne returns null for an unknown id (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* SessionRepository;
-      const exit = yield* Effect.exit(repo.findOneById(sessionId));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof SessionNotFound, true);
-      }
+      const found = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      deepStrictEqual(found, null);
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -86,7 +79,8 @@ suite("SessionRepositoryLive (integration)", () => {
       const now = yield* DateTime.now;
       yield* repo.insertOne(makeSession(now));
       yield* repo.deleteOne(sessionId);
-      const found = yield* repo.findOneById(sessionId);
+      const found = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      if (found === null) throw new Error("expected a session");
       deepStrictEqual(found.revokedAt !== null, true);
 
       const second = yield* Effect.exit(repo.deleteOne(sessionId));
@@ -104,7 +98,8 @@ suite("SessionRepositoryLive (integration)", () => {
       const later = DateTime.add(now, { seconds: 1800 });
       const touched = SessionRootOps.touch({ session: seed, now: later, ttlSeconds: 3600 });
       yield* repo.updateOne(touched);
-      const found = yield* repo.findOneById(sessionId);
+      const found = yield* repo.findOne(SessionSpecifications.withId(sessionId));
+      if (found === null) throw new Error("expected a session");
       deepStrictEqual(found.expiresAt, touched.expiresAt);
       deepStrictEqual(found.lastUsedAt, touched.lastUsedAt);
       deepStrictEqual(found.absoluteExpiresAt, seed.absoluteExpiresAt);

--- a/packages/server/src/modules/auth/infrastructure/repositories/session.repository-live.ts
+++ b/packages/server/src/modules/auth/infrastructure/repositories/session.repository-live.ts
@@ -6,6 +6,8 @@ import { SessionNotFound } from "@/modules/auth/domain/session/session.errors.js
 import { type SessionId } from "@/modules/auth/domain/session/session.id.js";
 import { SessionRepository } from "@/modules/auth/domain/session/session.repository.js";
 import { type SessionRoot } from "@/modules/auth/domain/session/session.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as SessionMapper from "./session.mapper.js";
@@ -40,17 +42,21 @@ export const SessionRepositoryLive = Layer.effect(
       );
     });
 
-    const findOneById = db.makeQuery((execute, id: SessionId) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the id primary key).
+    const findOne = db.makeQuery((execute, spec: Specification<SessionRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.SessionRowStd)`
-          SELECT * FROM auth.sessions WHERE id = ${id}
+          SELECT * FROM auth.sessions
+          WHERE ${criteriaToWhere(spec.criteria, SessionMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new SessionNotFound({ sessionId: id })),
-        Effect.map(SessionMapper.toDomain),
+        Effect.map((row) => (row === null ? null : SessionMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SessionRepository.findOneById"),
+        Effect.withSpan("SessionRepository.findOne"),
       ),
     );
 
@@ -89,6 +95,6 @@ export const SessionRepositoryLive = Layer.effect(
       );
     });
 
-    return SessionRepository.of({ insertOne, findOneById, deleteOne: deleteById, updateOne });
+    return SessionRepository.of({ insertOne, findOne, deleteOne: deleteById, updateOne });
   }),
 );

--- a/packages/server/src/modules/billing/commands/cancel-subscription.handler.test.ts
+++ b/packages/server/src/modules/billing/commands/cancel-subscription.handler.test.ts
@@ -14,6 +14,7 @@ import { type SubscriptionCanceled } from "@/modules/billing/domain/subscription
 import { SubscriptionId } from "@/modules/billing/domain/subscription/subscription.id.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { BillingGatewayFake } from "@/modules/billing/infrastructure/clients/billing-gateway.client-fake.js";
 import { SubscriptionRepositoryFake } from "@/modules/billing/infrastructure/repositories/subscription.repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
@@ -58,9 +59,9 @@ describe("cancelSubscription", () => {
       );
       deepStrictEqual(result.status, "canceled");
 
-      const found = yield* repo.findOneByOrganizationId(acme);
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.status, "canceled");
+      const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      ok(found !== null);
+      deepStrictEqual(found.status, "canceled");
 
       const events = yield* rec.byTag<SubscriptionCanceled>("SubscriptionCanceled");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/billing/commands/cancel-subscription.handler.ts
+++ b/packages/server/src/modules/billing/commands/cancel-subscription.handler.ts
@@ -1,11 +1,11 @@
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
 
 import { BillingGateway } from "@/modules/billing/domain/ports/clients/billing-gateway.client.js";
 import { SubscriptionNotFound } from "@/modules/billing/domain/subscription/subscription.errors.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -23,11 +23,12 @@ export const cancelSubscription = Effect.fn("cancelSubscription")(function* (
   const gateway = yield* BillingGateway;
   const bus = yield* DomainEventBus;
 
-  const found = yield* repo.findOneByOrganizationId(cmd.organizationId);
-  if (Option.isNone(found)) {
+  const existing = yield* repo.findOne(
+    SubscriptionSpecifications.forOrganization(cmd.organizationId),
+  );
+  if (existing === null) {
     return yield* new SubscriptionNotFound({ organizationId: cmd.organizationId });
   }
-  const existing = found.value;
 
   yield* gateway.cancelSubscription({
     stripeSubscriptionId: existing.stripeSubscriptionId,

--- a/packages/server/src/modules/billing/commands/ingest-stripe-webhook.handler.test.ts
+++ b/packages/server/src/modules/billing/commands/ingest-stripe-webhook.handler.test.ts
@@ -12,6 +12,7 @@ import { InvalidWebhookSignature } from "@/modules/billing/domain/subscription/s
 import { type StripeWebhookIngested } from "@/modules/billing/domain/webhook-event/stripe-webhook.events.js";
 import { type StripeWebhookEvent } from "@/modules/billing/domain/webhook-event/stripe-webhook.value-object.js";
 import { WebhookEventRepository } from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import { WebhookEventSpecifications } from "@/modules/billing/domain/webhook-event/webhook-event.specification.js";
 import {
   BillingGatewayFake,
   FAKE_WEBHOOK_SIGNATURE,
@@ -53,8 +54,8 @@ describe("ingestStripeWebhook", () => {
 
         yield* ingestStripeWebhook(cmd("evt_new"));
 
-        const seen = yield* repo.findOneByStripeEventId("evt_new");
-        ok(Option.isSome(seen));
+        const seen = yield* repo.findOne(WebhookEventSpecifications.withStripeEventId("evt_new"));
+        ok(seen !== null);
 
         const events = yield* rec.byTag<StripeWebhookIngested>("StripeWebhookIngested");
         deepStrictEqual(events.length, 1);
@@ -78,8 +79,8 @@ describe("ingestStripeWebhook", () => {
         );
       }
 
-      const seen = yield* repo.findOneByStripeEventId("evt_bad_sig");
-      ok(Option.isNone(seen));
+      const seen = yield* repo.findOne(WebhookEventSpecifications.withStripeEventId("evt_bad_sig"));
+      deepStrictEqual(seen, null);
       const events = yield* rec.byTag<StripeWebhookIngested>("StripeWebhookIngested");
       deepStrictEqual(events.length, 0);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/billing/commands/ingest-stripe-webhook.handler.ts
+++ b/packages/server/src/modules/billing/commands/ingest-stripe-webhook.handler.ts
@@ -20,10 +20,9 @@ import { type IngestStripeWebhookCommand } from "./ingest-stripe-webhook.command
 // downstream subscribers (subscription status sync) never fire twice
 // for the same delivery.
 //
-// The repository's `findOneByStripeEventId` exists for audit/dashboard
-// read paths; the write path here intentionally skips it because
-// "find then insert" introduces a race window. Postgres' unique
-// constraint is the arbiter.
+// The repository's read side exists for audit/dashboard read paths;
+// the write path here intentionally skips it because "find then insert"
+// introduces a race window. Postgres' unique constraint is the arbiter.
 export const ingestStripeWebhook = Effect.fn("ingestStripeWebhook")(function* (
   cmd: IngestStripeWebhookCommand,
 ) {

--- a/packages/server/src/modules/billing/commands/start-subscription.handler.test.ts
+++ b/packages/server/src/modules/billing/commands/start-subscription.handler.test.ts
@@ -11,6 +11,7 @@ import { startSubscription } from "@/modules/billing/commands/start-subscription
 import { SubscriptionAlreadyExistsForOrganization } from "@/modules/billing/domain/subscription/subscription.errors.js";
 import { type SubscriptionStarted } from "@/modules/billing/domain/subscription/subscription.events.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { BillingGatewayFake } from "@/modules/billing/infrastructure/clients/billing-gateway.client-fake.js";
 import { SubscriptionRepositoryFake } from "@/modules/billing/infrastructure/repositories/subscription.repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
@@ -42,8 +43,8 @@ describe("startSubscription", () => {
         ok(sub.stripeSubscriptionId.startsWith("sub_test_"));
         deepStrictEqual(sub.status, "active");
 
-        const stored = yield* repo.findOneByOrganizationId(acme);
-        ok(Option.isSome(stored));
+        const stored = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+        ok(stored !== null);
 
         const events = yield* rec.byTag<SubscriptionStarted>("SubscriptionStarted");
         deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/billing/commands/start-subscription.handler.ts
+++ b/packages/server/src/modules/billing/commands/start-subscription.handler.ts
@@ -1,12 +1,12 @@
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
 
 import { BillingGateway } from "@/modules/billing/domain/ports/clients/billing-gateway.client.js";
 import { SubscriptionAlreadyExistsForOrganization } from "@/modules/billing/domain/subscription/subscription.errors.js";
 import { SubscriptionId } from "@/modules/billing/domain/subscription/subscription.id.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -27,8 +27,10 @@ export const startSubscription = Effect.fn("startSubscription")(function* (
 
   // Idempotency check at the use-case layer: avoid a Stripe-side
   // double-charge if a caller retries POST after a network blip.
-  const existing = yield* repo.findOneByOrganizationId(cmd.organizationId);
-  if (Option.isSome(existing)) {
+  const existing = yield* repo.findOne(
+    SubscriptionSpecifications.forOrganization(cmd.organizationId),
+  );
+  if (existing !== null) {
     return yield* new SubscriptionAlreadyExistsForOrganization({
       organizationId: cmd.organizationId,
     });

--- a/packages/server/src/modules/billing/commands/sync-subscription.handler.test.ts
+++ b/packages/server/src/modules/billing/commands/sync-subscription.handler.test.ts
@@ -3,13 +3,13 @@ import { deepStrictEqual, ok } from "assert";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import { SyncSubscriptionCommand } from "@/modules/billing/commands/sync-subscription.command.js";
 import { syncSubscription } from "@/modules/billing/commands/sync-subscription.handler.js";
 import { SubscriptionId } from "@/modules/billing/domain/subscription/subscription.id.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { SubscriptionRepositoryFake } from "@/modules/billing/infrastructure/repositories/subscription.repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -52,9 +52,9 @@ describe("syncSubscription", () => {
       );
 
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findOneByOrganizationId(acme);
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.status, "active");
+      const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      ok(found !== null);
+      deepStrictEqual(found.status, "active");
 
       const tags = (yield* rec.all).map((e) => e._tag);
       deepStrictEqual(tags, ["SubscriptionStatusChanged"]);
@@ -73,8 +73,8 @@ describe("syncSubscription", () => {
         }),
       );
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findOneByOrganizationId(acme);
-      deepStrictEqual(Option.isNone(found), true);
+      const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      deepStrictEqual(found, null);
       deepStrictEqual((yield* rec.all).length, 0);
     }).pipe(Effect.provide(TestLayer)),
   );

--- a/packages/server/src/modules/billing/commands/sync-subscription.handler.ts
+++ b/packages/server/src/modules/billing/commands/sync-subscription.handler.ts
@@ -1,10 +1,10 @@
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
 
 import { type SyncSubscriptionCommand } from "@/modules/billing/commands/sync-subscription.command.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -19,10 +19,12 @@ export const syncSubscription = Effect.fn("syncSubscription")(function* (
 ) {
   const repo = yield* SubscriptionRepository;
   const bus = yield* DomainEventBus;
-  const found = yield* repo.findOneByStripeSubscriptionId(cmd.stripeSubscriptionId);
-  if (Option.isNone(found)) return;
+  const found = yield* repo.findOne(
+    SubscriptionSpecifications.withStripeSubscriptionId(cmd.stripeSubscriptionId),
+  );
+  if (found === null) return;
   const now = yield* DateTime.now;
-  const { events, subscription } = SubscriptionRootOps.applyStatus(found.value, {
+  const { events, subscription } = SubscriptionRootOps.applyStatus(found, {
     status: cmd.status,
     currentPeriodEnd: cmd.currentPeriodEnd,
     now,

--- a/packages/server/src/modules/billing/domain/subscription/subscription.repository.ts
+++ b/packages/server/src/modules/billing/domain/subscription/subscription.repository.ts
@@ -1,12 +1,17 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
-import type * as Option from "effect/Option";
 
 import { type SubscriptionAlreadyExistsForOrganization } from "@/modules/billing/domain/subscription/subscription.errors.js";
 import { type SubscriptionRoot } from "@/modules/billing/domain/subscription/subscription.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
+// Dumb persistence, collapsed to the minimal vocabulary: insert/update the
+// aggregate, and read it back by a Specification. Identity and natural-key
+// lookups — by organization, by Stripe subscription id — are expressed as a
+// spec at the call site (see SubscriptionSpecifications) and compiled to a
+// WHERE fragment by the live repository. Absence is a plain `null`; mapping it
+// to a domain error (SubscriptionNotFound) is the handler's job.
 export type SubscriptionRepositoryShape = {
   readonly insertOne: (
     subscription: SubscriptionRoot,
@@ -14,12 +19,9 @@ export type SubscriptionRepositoryShape = {
   readonly updateOne: (
     subscription: SubscriptionRoot,
   ) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneByOrganizationId: (
-    organizationId: OrganizationId,
-  ) => Effect.Effect<Option.Option<SubscriptionRoot>, PersistenceUnavailable>;
-  readonly findOneByStripeSubscriptionId: (
-    stripeSubscriptionId: string,
-  ) => Effect.Effect<Option.Option<SubscriptionRoot>, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<SubscriptionRoot>,
+  ) => Effect.Effect<SubscriptionRoot | null, PersistenceUnavailable>;
 };
 
 export class SubscriptionRepository extends Context.Service<

--- a/packages/server/src/modules/billing/domain/subscription/subscription.specification.test.ts
+++ b/packages/server/src/modules/billing/domain/subscription/subscription.specification.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+
+import { SubscriptionId } from "./subscription.id.js";
+import { SubscriptionRootOps } from "./subscription.root-ops.js";
+import { SubscriptionSpecifications } from "./subscription.specification.js";
+
+const acme = OrganizationId.make("11111111-1111-1111-1111-111111111111");
+const beta = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const subId = SubscriptionId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
+
+const acmeSub = SubscriptionRootOps.create({
+  id: subId,
+  organizationId: acme,
+  stripeCustomerId: "cus_x",
+  stripeSubscriptionId: "sub_x",
+  status: "active",
+  currentPeriodEnd: null,
+  now,
+}).subscription;
+
+describe("SubscriptionSpecifications.forOrganization", () => {
+  it("matches the subscription for the given organization and no other", () => {
+    deepStrictEqual(SubscriptionSpecifications.forOrganization(acme)(acmeSub), true);
+    deepStrictEqual(SubscriptionSpecifications.forOrganization(beta)(acmeSub), false);
+  });
+
+  it("carries an Eq criteria over the organization_id column", () => {
+    deepStrictEqual(SubscriptionSpecifications.forOrganization(acme).criteria, {
+      _tag: "Eq",
+      field: "organizationId",
+      value: acme,
+    });
+  });
+});
+
+describe("SubscriptionSpecifications.withStripeSubscriptionId", () => {
+  it("matches the subscription with the given Stripe subscription id and no other", () => {
+    deepStrictEqual(SubscriptionSpecifications.withStripeSubscriptionId("sub_x")(acmeSub), true);
+    deepStrictEqual(SubscriptionSpecifications.withStripeSubscriptionId("sub_y")(acmeSub), false);
+  });
+
+  it("carries an Eq criteria over the stripe_subscription_id column", () => {
+    deepStrictEqual(SubscriptionSpecifications.withStripeSubscriptionId("sub_x").criteria, {
+      _tag: "Eq",
+      field: "stripeSubscriptionId",
+      value: "sub_x",
+    });
+  });
+});

--- a/packages/server/src/modules/billing/domain/subscription/subscription.specification.ts
+++ b/packages/server/src/modules/billing/domain/subscription/subscription.specification.ts
@@ -1,0 +1,16 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
+import { type SubscriptionRoot } from "./subscription.root.js";
+
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The field-name strings live here and in the mapper's
+// column map; `Spec.eq` types them against SubscriptionRoot so a typo is a
+// compile error.
+const forOrganization = (organizationId: OrganizationId): Specification<SubscriptionRoot> =>
+  Spec.eq<SubscriptionRoot, "organizationId">("organizationId", organizationId);
+
+const withStripeSubscriptionId = (stripeSubscriptionId: string): Specification<SubscriptionRoot> =>
+  Spec.eq<SubscriptionRoot, "stripeSubscriptionId">("stripeSubscriptionId", stripeSubscriptionId);
+
+export const SubscriptionSpecifications = { forOrganization, withStripeSubscriptionId } as const;

--- a/packages/server/src/modules/billing/domain/webhook-event/webhook-event.repository.ts
+++ b/packages/server/src/modules/billing/domain/webhook-event/webhook-event.repository.ts
@@ -1,19 +1,22 @@
 import * as Context from "effect/Context";
 import type * as DateTime from "effect/DateTime";
 import type * as Effect from "effect/Effect";
-import type * as Option from "effect/Option";
 
 import { type WebhookEventAlreadyRecorded } from "@/modules/billing/domain/webhook-event/webhook-event.errors.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
 // Dumb idempotency log for Stripe webhook deliveries: write-once,
 // keyed by Stripe's event id. No aggregate — the row carries no
 // state worth modeling beyond "have we seen this id before?".
 //
-// `insert` is the claim; if Stripe redelivers the same event, the
+// `insertOne` is the claim; if Stripe redelivers the same event, the
 // unique-key violation surfaces as `WebhookEventAlreadyRecorded` and
 // the caller (the webhook endpoint) decides to short-circuit. The
 // race-free idempotency comes from the database, not the use case.
+//
+// The read side is a plain `findOne` over a Specification (see
+// WebhookEventSpecifications); absence is a plain `null`.
 export type WebhookEventRecord = {
   readonly stripeEventId: string;
   readonly receivedAt: DateTime.Utc;
@@ -23,9 +26,9 @@ export type WebhookEventRepositoryShape = {
   readonly insertOne: (
     stripeEventId: string,
   ) => Effect.Effect<void, WebhookEventAlreadyRecorded | PersistenceUnavailable>;
-  readonly findOneByStripeEventId: (
-    stripeEventId: string,
-  ) => Effect.Effect<Option.Option<WebhookEventRecord>, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<WebhookEventRecord>,
+  ) => Effect.Effect<WebhookEventRecord | null, PersistenceUnavailable>;
 };
 
 export class WebhookEventRepository extends Context.Service<

--- a/packages/server/src/modules/billing/domain/webhook-event/webhook-event.specification.test.ts
+++ b/packages/server/src/modules/billing/domain/webhook-event/webhook-event.specification.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { type WebhookEventRecord } from "./webhook-event.repository.js";
+import { WebhookEventSpecifications } from "./webhook-event.specification.js";
+
+const record: WebhookEventRecord = {
+  stripeEventId: "evt_abc",
+  receivedAt: DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z")),
+};
+
+describe("WebhookEventSpecifications.withStripeEventId", () => {
+  it("matches the record with the given Stripe event id and no other", () => {
+    deepStrictEqual(WebhookEventSpecifications.withStripeEventId("evt_abc")(record), true);
+    deepStrictEqual(WebhookEventSpecifications.withStripeEventId("evt_other")(record), false);
+  });
+
+  it("carries an Eq criteria over the stripe_event_id column", () => {
+    deepStrictEqual(WebhookEventSpecifications.withStripeEventId("evt_abc").criteria, {
+      _tag: "Eq",
+      field: "stripeEventId",
+      value: "evt_abc",
+    });
+  });
+});

--- a/packages/server/src/modules/billing/domain/webhook-event/webhook-event.specification.ts
+++ b/packages/server/src/modules/billing/domain/webhook-event/webhook-event.specification.ts
@@ -1,0 +1,12 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+
+import { type WebhookEventRecord } from "./webhook-event.repository.js";
+
+// Translatable spec (carries a Criteria → usable as a repository filter and as
+// an in-memory guard). The field-name string lives here and in the mapper's
+// column map; `Spec.eq` types it against WebhookEventRecord so a typo is a
+// compile error.
+const withStripeEventId = (stripeEventId: string): Specification<WebhookEventRecord> =>
+  Spec.eq<WebhookEventRecord, "stripeEventId">("stripeEventId", stripeEventId);
+
+export const WebhookEventSpecifications = { withStripeEventId } as const;

--- a/packages/server/src/modules/billing/infrastructure/repositories/subscription.mapper.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/subscription.mapper.ts
@@ -4,8 +4,17 @@ import * as DateTime from "effect/DateTime";
 import { SubscriptionId } from "@/modules/billing/domain/subscription/subscription.id.js";
 import { SubscriptionRoot } from "@/modules/billing/domain/subscription/subscription.root.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.SubscriptionRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of billing.subscriptions. Only filterable scalar fields
+// need an entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  organizationId: "organization_id",
+  stripeSubscriptionId: "stripe_subscription_id",
+} as const satisfies Partial<Record<keyof SubscriptionRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): SubscriptionRoot =>
   new SubscriptionRoot({

--- a/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-fake.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-fake.test.ts
@@ -10,6 +10,7 @@ import { SubscriptionAlreadyExistsForOrganization } from "@/modules/billing/doma
 import { SubscriptionId } from "@/modules/billing/domain/subscription/subscription.id.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { SubscriptionRepositoryFake } from "@/modules/billing/infrastructure/repositories/subscription.repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 
@@ -33,13 +34,13 @@ const mk = (id: SubscriptionId, organizationId: OrganizationId, stripeSub = "sub
   }).subscription;
 
 describe("SubscriptionRepositoryFake.insert", () => {
-  it.effect("stores a subscription and makes it findable by organizationId", () =>
+  it.effect("stores a subscription and makes it findable by organization", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
       yield* repo.insertOne(mk(subA, acme));
-      const found = yield* repo.findOneByOrganizationId(acme);
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.id, subA);
+      const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      ok(found !== null);
+      deepStrictEqual(found.id, subA);
     }).pipe(provide),
   );
 
@@ -63,9 +64,9 @@ describe("SubscriptionRepositoryFake.insert", () => {
       const repo = yield* SubscriptionRepository;
       yield* repo.insertOne(mk(subA, acme, "sub_a"));
       yield* repo.insertOne(mk(subB, beta, "sub_b"));
-      const a = yield* repo.findOneByOrganizationId(acme);
-      const b = yield* repo.findOneByOrganizationId(beta);
-      ok(Option.isSome(a) && Option.isSome(b));
+      const a = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      const b = yield* repo.findOne(SubscriptionSpecifications.forOrganization(beta));
+      ok(a !== null && b !== null);
     }).pipe(provide),
   );
 });
@@ -78,39 +79,43 @@ describe("SubscriptionRepositoryFake.update", () => {
       yield* repo.insertOne(sub);
       const { subscription: canceled } = SubscriptionRootOps.cancel(sub, now);
       yield* repo.updateOne(canceled);
-      const found = yield* repo.findOneByOrganizationId(acme);
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.status, "canceled");
+      const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      ok(found !== null);
+      deepStrictEqual(found.status, "canceled");
     }).pipe(provide),
   );
 });
 
-describe("SubscriptionRepositoryFake.findOneByStripeSubscriptionId", () => {
+describe("SubscriptionRepositoryFake.findOne by Stripe subscription id", () => {
   it.effect("returns the subscription that has the matching Stripe id", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
       yield* repo.insertOne(mk(subA, acme, "sub_unique"));
-      const found = yield* repo.findOneByStripeSubscriptionId("sub_unique");
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.id, subA);
+      const found = yield* repo.findOne(
+        SubscriptionSpecifications.withStripeSubscriptionId("sub_unique"),
+      );
+      ok(found !== null);
+      deepStrictEqual(found.id, subA);
     }).pipe(provide),
   );
 
-  it.effect("returns None when no subscription has the given Stripe id", () =>
+  it.effect("returns null when no subscription has the given Stripe id", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findOneByStripeSubscriptionId("sub_does_not_exist");
-      ok(Option.isNone(found));
+      const found = yield* repo.findOne(
+        SubscriptionSpecifications.withStripeSubscriptionId("sub_does_not_exist"),
+      );
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 });
 
-describe("SubscriptionRepositoryFake.findOneByOrganizationId", () => {
-  it.effect("returns None for an org with no subscription", () =>
+describe("SubscriptionRepositoryFake.findOne by organization", () => {
+  it.effect("returns null for an org with no subscription", () =>
     Effect.gen(function* () {
       const repo = yield* SubscriptionRepository;
-      const found = yield* repo.findOneByOrganizationId(acme);
-      ok(Option.isNone(found));
+      const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 });

--- a/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-fake.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-fake.ts
@@ -8,6 +8,7 @@ import { SubscriptionAlreadyExistsForOrganization } from "@/modules/billing/doma
 import { type SubscriptionId } from "@/modules/billing/domain/subscription/subscription.id.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { type SubscriptionRoot } from "@/modules/billing/domain/subscription/subscription.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 const findByOrgIn = (
@@ -16,16 +17,6 @@ const findByOrgIn = (
 ): Option.Option<SubscriptionRoot> => {
   for (const sub of HashMap.values(store)) {
     if (sub.organizationId === organizationId) return Option.some(sub);
-  }
-  return Option.none();
-};
-
-const findByStripeIdIn = (
-  store: HashMap.HashMap<SubscriptionId, SubscriptionRoot>,
-  stripeSubscriptionId: string,
-): Option.Option<SubscriptionRoot> => {
-  for (const sub of HashMap.values(store)) {
-    if (sub.stripeSubscriptionId === stripeSubscriptionId) return Option.some(sub);
   }
   return Option.none();
 };
@@ -51,21 +42,17 @@ export const SubscriptionRepositoryFake = Layer.effect(
     const updateOne = (sub: SubscriptionRoot): Effect.Effect<void> =>
       Ref.update(store, HashMap.set(sub.id, sub));
 
-    const findOneByOrganizationId = (
-      organizationId: OrganizationId,
-    ): Effect.Effect<Option.Option<SubscriptionRoot>> =>
-      Effect.map(Ref.get(store), (m) => findByOrgIn(m, organizationId));
-
-    const findOneByStripeSubscriptionId = (
-      stripeSubscriptionId: string,
-    ): Effect.Effect<Option.Option<SubscriptionRoot>> =>
-      Effect.map(Ref.get(store), (m) => findByStripeIdIn(m, stripeSubscriptionId));
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (
+      spec: Specification<SubscriptionRoot>,
+    ): Effect.Effect<SubscriptionRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
     return SubscriptionRepository.of({
       insertOne,
       updateOne,
-      findOneByOrganizationId,
-      findOneByStripeSubscriptionId,
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-live.integration.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-live.integration.test.ts
@@ -14,6 +14,7 @@ import { SubscriptionId } from "@/modules/billing/domain/subscription/subscripti
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { type SubscriptionRoot } from "@/modules/billing/domain/subscription/subscription.root.js";
 import { SubscriptionRootOps } from "@/modules/billing/domain/subscription/subscription.root-ops.js";
+import { SubscriptionSpecifications } from "@/modules/billing/domain/subscription/subscription.specification.js";
 import { SubscriptionRepositoryLive } from "@/modules/billing/infrastructure/repositories/subscription.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -70,18 +71,16 @@ suite("SubscriptionRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists and decodes back via findOneByOrganizationId", () =>
+    it.effect("persists and decodes back via findOne(forOrganization)", () =>
       Effect.gen(function* () {
         yield* seedOrgRow(acme, "Acme");
         const repo = yield* SubscriptionRepository;
         yield* repo.insertOne(mk(subA, acme, "sub_acme"));
-        const found = yield* repo.findOneByOrganizationId(acme);
-        ok(Option.isSome(found));
-        if (Option.isSome(found)) {
-          deepStrictEqual(found.value.id, subA);
-          deepStrictEqual(found.value.stripeSubscriptionId, "sub_acme");
-          deepStrictEqual(found.value.status, "active");
-        }
+        const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+        ok(found !== null);
+        deepStrictEqual(found.id, subA);
+        deepStrictEqual(found.stripeSubscriptionId, "sub_acme");
+        deepStrictEqual(found.status, "active");
       }).pipe(Effect.provide(TestLayer)),
     );
 
@@ -111,14 +110,14 @@ suite("SubscriptionRepositoryLive (integration)", () => {
         yield* repo.insertOne(sub);
         const { subscription: canceled } = SubscriptionRootOps.cancel(sub, now);
         yield* repo.updateOne(canceled);
-        const found = yield* repo.findOneByOrganizationId(acme);
-        ok(Option.isSome(found));
-        if (Option.isSome(found)) deepStrictEqual(found.value.status, "canceled");
+        const found = yield* repo.findOne(SubscriptionSpecifications.forOrganization(acme));
+        ok(found !== null);
+        deepStrictEqual(found.status, "canceled");
       }).pipe(Effect.provide(TestLayer)),
     );
   });
 
-  describe("findOneByStripeSubscriptionId", () => {
+  describe("findOne by Stripe subscription id", () => {
     it.effect("returns the subscription that has the matching Stripe id (cross-tenant safe)", () =>
       Effect.gen(function* () {
         yield* seedOrgRow(acme, "Acme");
@@ -126,20 +125,22 @@ suite("SubscriptionRepositoryLive (integration)", () => {
         const repo = yield* SubscriptionRepository;
         yield* repo.insertOne(mk(subA, acme, "sub_acme_id"));
         yield* repo.insertOne(mk(subB, beta, "sub_beta_id"));
-        const found = yield* repo.findOneByStripeSubscriptionId("sub_beta_id");
-        ok(Option.isSome(found));
-        if (Option.isSome(found)) {
-          deepStrictEqual(found.value.id, subB);
-          deepStrictEqual(found.value.organizationId, beta);
-        }
+        const found = yield* repo.findOne(
+          SubscriptionSpecifications.withStripeSubscriptionId("sub_beta_id"),
+        );
+        ok(found !== null);
+        deepStrictEqual(found.id, subB);
+        deepStrictEqual(found.organizationId, beta);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("returns None when no subscription matches", () =>
+    it.effect("returns null when no subscription matches", () =>
       Effect.gen(function* () {
         const repo = yield* SubscriptionRepository;
-        const found = yield* repo.findOneByStripeSubscriptionId("sub_unknown");
-        ok(Option.isNone(found));
+        const found = yield* repo.findOne(
+          SubscriptionSpecifications.withStripeSubscriptionId("sub_unknown"),
+        );
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-live.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/subscription.repository-live.ts
@@ -1,12 +1,12 @@
 import { Database, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import { SubscriptionAlreadyExistsForOrganization } from "@/modules/billing/domain/subscription/subscription.errors.js";
 import { SubscriptionRepository } from "@/modules/billing/domain/subscription/subscription.repository.js";
 import { type SubscriptionRoot } from "@/modules/billing/domain/subscription/subscription.root.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as SubscriptionMapper from "./subscription.mapper.js";
@@ -78,41 +78,29 @@ export const SubscriptionRepositoryLive = Layer.effect(
       );
     });
 
-    const findOneByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the unique organization_id, the unique
+    // stripe_subscription_id).
+    const findOne = db.makeQuery((execute, spec: Specification<SubscriptionRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.SubscriptionRowStd)`
-          SELECT * FROM billing.subscriptions WHERE organization_id = ${organizationId}
+          SELECT * FROM billing.subscriptions
+          WHERE ${criteriaToWhere(spec.criteria, SubscriptionMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        Effect.map((row) =>
-          row === null ? Option.none() : Option.some(SubscriptionMapper.toDomain(row)),
-        ),
+        Effect.map((row) => (row === null ? null : SubscriptionMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("SubscriptionRepository.findOneByOrganizationId"),
-      ),
-    );
-
-    const findOneByStripeSubscriptionId = db.makeQuery((execute, stripeSubscriptionId: string) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.SubscriptionRowStd)`
-          SELECT * FROM billing.subscriptions WHERE stripe_subscription_id = ${stripeSubscriptionId}
-        `),
-      ).pipe(
-        Effect.map((row) =>
-          row === null ? Option.none() : Option.some(SubscriptionMapper.toDomain(row)),
-        ),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("SubscriptionRepository.findOneByStripeSubscriptionId"),
+        Effect.withSpan("SubscriptionRepository.findOne"),
       ),
     );
 
     return SubscriptionRepository.of({
       insertOne,
       updateOne,
-      findOneByOrganizationId,
-      findOneByStripeSubscriptionId,
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.mapper.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.mapper.ts
@@ -1,8 +1,16 @@
 import { type RowSchemas } from "@org/database/index";
 
 import { type WebhookEventRecord } from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.WebhookEventRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of billing.webhook_events. Only filterable scalar fields
+// need an entry; `satisfies` keeps the keys honest against the record.
+export const columns = {
+  stripeEventId: "stripe_event_id",
+} as const satisfies Partial<Record<keyof WebhookEventRecord, string>> & ColumnMap;
 
 export const toDomain = (row: Row): WebhookEventRecord => ({
   stripeEventId: row.stripe_event_id,

--- a/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-fake.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-fake.test.ts
@@ -7,6 +7,7 @@ import * as Option from "effect/Option";
 
 import { WebhookEventAlreadyRecorded } from "@/modules/billing/domain/webhook-event/webhook-event.errors.js";
 import { WebhookEventRepository } from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import { WebhookEventSpecifications } from "@/modules/billing/domain/webhook-event/webhook-event.specification.js";
 import { WebhookEventRepositoryFake } from "@/modules/billing/infrastructure/repositories/webhook-event.repository-fake.js";
 
 const provide = Effect.provide(WebhookEventRepositoryFake);
@@ -16,9 +17,9 @@ describe("WebhookEventRepositoryFake.insert", () => {
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
       yield* repo.insertOne("evt_abc");
-      const found = yield* repo.findOneByStripeEventId("evt_abc");
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.stripeEventId, "evt_abc");
+      const found = yield* repo.findOne(WebhookEventSpecifications.withStripeEventId("evt_abc"));
+      ok(found !== null);
+      deepStrictEqual(found.stripeEventId, "evt_abc");
     }).pipe(provide),
   );
 
@@ -42,19 +43,21 @@ describe("WebhookEventRepositoryFake.insert", () => {
       const repo = yield* WebhookEventRepository;
       yield* repo.insertOne("evt_a");
       yield* repo.insertOne("evt_b");
-      const a = yield* repo.findOneByStripeEventId("evt_a");
-      const b = yield* repo.findOneByStripeEventId("evt_b");
-      ok(Option.isSome(a) && Option.isSome(b));
+      const a = yield* repo.findOne(WebhookEventSpecifications.withStripeEventId("evt_a"));
+      const b = yield* repo.findOne(WebhookEventSpecifications.withStripeEventId("evt_b"));
+      ok(a !== null && b !== null);
     }).pipe(provide),
   );
 });
 
-describe("WebhookEventRepositoryFake.findOneByStripeEventId", () => {
-  it.effect("returns None when no event has been recorded for the id", () =>
+describe("WebhookEventRepositoryFake.findOne", () => {
+  it.effect("returns null when no event has been recorded for the id", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      const found = yield* repo.findOneByStripeEventId("evt_unknown");
-      ok(Option.isNone(found));
+      const found = yield* repo.findOne(
+        WebhookEventSpecifications.withStripeEventId("evt_unknown"),
+      );
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 });

--- a/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-fake.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-fake.ts
@@ -2,7 +2,6 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import type * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
 import { WebhookEventAlreadyRecorded } from "@/modules/billing/domain/webhook-event/webhook-event.errors.js";
@@ -10,6 +9,7 @@ import {
   type WebhookEventRecord,
   WebhookEventRepository,
 } from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
 export const WebhookEventRepositoryFake = Layer.effect(
   WebhookEventRepository,
@@ -25,11 +25,13 @@ export const WebhookEventRepositoryFake = Layer.effect(
             ),
       );
 
-    const findOneByStripeEventId = (
-      stripeEventId: string,
-    ): Effect.Effect<Option.Option<WebhookEventRecord>> =>
-      Effect.map(Ref.get(store), (m) => HashMap.get(m, stripeEventId));
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (
+      spec: Specification<WebhookEventRecord>,
+    ): Effect.Effect<WebhookEventRecord | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    return WebhookEventRepository.of({ insertOne, findOneByStripeEventId });
+    return WebhookEventRepository.of({ insertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-live.integration.test.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-live.integration.test.ts
@@ -9,6 +9,7 @@ import { beforeEach } from "vitest";
 
 import { WebhookEventAlreadyRecorded } from "@/modules/billing/domain/webhook-event/webhook-event.errors.js";
 import { WebhookEventRepository } from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import { WebhookEventSpecifications } from "@/modules/billing/domain/webhook-event/webhook-event.specification.js";
 import { WebhookEventRepositoryLive } from "@/modules/billing/infrastructure/repositories/webhook-event.repository-live.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
@@ -22,13 +23,13 @@ suite("WebhookEventRepositoryLive (integration)", () => {
     );
   });
 
-  it.effect("inserts an event id and decodes it back via findOneByStripeEventId", () =>
+  it.effect("inserts an event id and decodes it back via findOne", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
       yield* repo.insertOne("evt_test_1");
-      const found = yield* repo.findOneByStripeEventId("evt_test_1");
-      ok(Option.isSome(found));
-      if (Option.isSome(found)) deepStrictEqual(found.value.stripeEventId, "evt_test_1");
+      const found = yield* repo.findOne(WebhookEventSpecifications.withStripeEventId("evt_test_1"));
+      ok(found !== null);
+      deepStrictEqual(found.stripeEventId, "evt_test_1");
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -49,11 +50,13 @@ suite("WebhookEventRepositoryLive (integration)", () => {
       }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("returns None for an unrecorded event id", () =>
+  it.effect("returns null for an unrecorded event id", () =>
     Effect.gen(function* () {
       const repo = yield* WebhookEventRepository;
-      const found = yield* repo.findOneByStripeEventId("evt_does_not_exist");
-      ok(Option.isNone(found));
+      const found = yield* repo.findOne(
+        WebhookEventSpecifications.withStripeEventId("evt_does_not_exist"),
+      );
+      deepStrictEqual(found, null);
     }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-live.ts
+++ b/packages/server/src/modules/billing/infrastructure/repositories/webhook-event.repository-live.ts
@@ -1,10 +1,14 @@
 import { Database, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import { WebhookEventAlreadyRecorded } from "@/modules/billing/domain/webhook-event/webhook-event.errors.js";
-import { WebhookEventRepository } from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import {
+  type WebhookEventRecord,
+  WebhookEventRepository,
+} from "@/modules/billing/domain/webhook-event/webhook-event.repository.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as WebhookEventMapper from "./webhook-event.mapper.js";
@@ -37,21 +41,24 @@ export const WebhookEventRepositoryLive = Layer.effect(
       ),
     );
 
-    const findOneByStripeEventId = db.makeQuery((execute, stripeEventId: string) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the unique stripe_event_id).
+    const findOne = db.makeQuery((execute, spec: Specification<WebhookEventRecord>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.WebhookEventRowStd)`
-          SELECT * FROM billing.webhook_events WHERE stripe_event_id = ${stripeEventId}
+          SELECT * FROM billing.webhook_events
+          WHERE ${criteriaToWhere(spec.criteria, WebhookEventMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        Effect.map((row) =>
-          row === null ? Option.none() : Option.some(WebhookEventMapper.toDomain(row)),
-        ),
+        Effect.map((row) => (row === null ? null : WebhookEventMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("WebhookEventRepository.findOneByStripeEventId"),
+        Effect.withSpan("WebhookEventRepository.findOne"),
       ),
     );
 
-    return WebhookEventRepository.of({ insertOne, findOneByStripeEventId });
+    return WebhookEventRepository.of({ insertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/organization/commands/accept-invitation.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/accept-invitation.handler.test.ts
@@ -19,11 +19,14 @@ import {
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { type MembershipCreated } from "@/modules/organization/domain/membership/membership.events.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
 import { SuperAdminCannotOwnOrganization } from "@/modules/organization/domain/organization/organization.errors.js";
 import { InvitationRepositoryFake } from "@/modules/organization/infrastructure/repositories/invitation.repository-fake.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/repositories/membership.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -71,10 +74,17 @@ describe("acceptInvitation", () => {
       );
       deepStrictEqual(orgId, organizationId);
 
-      const updated = yield* inv.findOneById(invitationId);
+      const updated = yield* inv.findOne(InvitationSpecifications.withId(invitationId));
+      if (updated === null) throw new Error("expected invitation");
       deepStrictEqual(updated.acceptedAt !== null, true);
 
-      const membership = yield* members.findOneByUserIdAndOrgId(userId, organizationId);
+      const membership = yield* members.findOne(
+        Spec.and(
+          MembershipSpecifications.forUser(userId),
+          MembershipSpecifications.forOrganization(organizationId),
+        ),
+      );
+      if (membership === null) throw new Error("expected membership");
       deepStrictEqual(membership.userId, userId);
 
       const tags = (yield* rec.all).map((e) => e._tag);

--- a/packages/server/src/modules/organization/commands/accept-invitation.handler.ts
+++ b/packages/server/src/modules/organization/commands/accept-invitation.handler.ts
@@ -3,7 +3,9 @@ import * as Effect from "effect/Effect";
 
 import { type AcceptInvitationCommand } from "@/modules/organization/commands/accept-invitation.command.js";
 import { InvitationAcceptance } from "@/modules/organization/domain/domain-services/invitation-acceptance.domain-service.js";
+import { InvitationTokenNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { SuperAdminCannotOwnOrganization } from "@/modules/organization/domain/organization/organization.errors.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
@@ -26,7 +28,10 @@ export const acceptInvitation = Effect.fn("acceptInvitation")(
     const bus = yield* DomainEventBus;
     const now = yield* DateTime.now;
 
-    const invitation = yield* invRepo.findOneByToken(cmd.token);
+    const invitation = yield* invRepo.findOne(InvitationSpecifications.withToken(cmd.token));
+    if (invitation === null) {
+      return yield* new InvitationTokenNotFound();
+    }
     const result = yield* Effect.fromResult(
       InvitationAcceptance.accept(invitation, { userId: cmd.userId, now }),
     );
@@ -36,9 +41,9 @@ export const acceptInvitation = Effect.fn("acceptInvitation")(
     yield* invRepo.updateOne(result.invitation);
     yield* memberRepo.insertOne(result.membership);
     yield* bus.dispatch(result.events);
-    // Concurrent revoke between findOneByToken and update would surface as
-    // InvitationNotFound from `update` — treat as a defect (the token
-    // was valid moments ago; the operator should look at the trace).
+    // Concurrent revoke between the findOne(withToken) read and update would
+    // surface as InvitationNotFound from `update` — treat as a defect (the
+    // token was valid moments ago; the operator should look at the trace).
     // For normal use, the aggregate's accept() catches expired/revoked.
 
     return invitation.organizationId;

--- a/packages/server/src/modules/organization/commands/create-organization.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/create-organization.handler.test.ts
@@ -10,14 +10,18 @@ import { CreateOrganizationCommand } from "@/modules/organization/commands/creat
 import { createOrganization } from "@/modules/organization/commands/create-organization.handler.js";
 import { type MembershipCreated } from "@/modules/organization/domain/membership/membership.events.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
 import { SuperAdminCannotOwnOrganization } from "@/modules/organization/domain/organization/organization.errors.js";
 import { type OrganizationCreated } from "@/modules/organization/domain/organization/organization.events.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
 import { type OrganizationRoleGranted } from "@/modules/organization/domain/organization-roles/organization-role.events.js";
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/repositories/membership.repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization.repository-fake.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
@@ -45,7 +49,8 @@ describe("createOrganization", () => {
       const id = yield* createOrganization(
         CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
       );
-      const stored = yield* repo.findOneById(id);
+      const stored = yield* repo.findOne(OrganizationSpecifications.withId(id));
+      if (stored === null) throw new Error("expected organization");
       deepStrictEqual(stored.name, "Acme");
       const events = yield* rec.byTag<OrganizationCreated>("OrganizationCreated");
       deepStrictEqual(events.length, 1);
@@ -63,7 +68,13 @@ describe("createOrganization", () => {
       const id = yield* createOrganization(
         CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
       );
-      const membership = yield* memberships.findOneByUserIdAndOrgId(actorUserId, id);
+      const membership = yield* memberships.findOne(
+        Spec.and(
+          MembershipSpecifications.forUser(actorUserId),
+          MembershipSpecifications.forOrganization(id),
+        ),
+      );
+      if (membership === null) throw new Error("expected membership");
       deepStrictEqual(membership.userId, actorUserId);
       deepStrictEqual(membership.organizationId, id);
       const events = yield* rec.byTag<MembershipCreated>("MembershipCreated");
@@ -84,7 +95,13 @@ describe("createOrganization", () => {
         const id = yield* createOrganization(
           CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
         );
-        const roles = yield* orgRolesRepo.findOneByUserIdAndOrgId(actorUserId, id);
+        const roles = yield* orgRolesRepo.findOne(
+          Spec.and(
+            OrganizationRolesSpecifications.forUser(actorUserId),
+            OrganizationRolesSpecifications.forOrganization(id),
+          ),
+        );
+        if (roles === null) throw new Error("expected aggregate");
         deepStrictEqual(
           roles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
           [{ role: "admin", issuedBy: actorUserId }],

--- a/packages/server/src/modules/organization/commands/grant-organization-role.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role.handler.test.ts
@@ -14,7 +14,9 @@ import {
 } from "@/modules/organization/domain/organization-roles/organization-role.errors.js";
 import { type OrganizationRoleGranted } from "@/modules/organization/domain/organization-roles/organization-role.events.js";
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -45,7 +47,13 @@ describe("grantOrganizationRole", () => {
         }),
       );
 
-      const roles = yield* repo.findOneByUserIdAndOrgId(targetId, orgId);
+      const roles = yield* repo.findOne(
+        Spec.and(
+          OrganizationRolesSpecifications.forUser(targetId),
+          OrganizationRolesSpecifications.forOrganization(orgId),
+        ),
+      );
+      if (roles === null) throw new Error("expected aggregate");
       deepStrictEqual(
         roles.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
         [{ role: "admin", issuedBy: actorId }],

--- a/packages/server/src/modules/organization/commands/grant-organization-role.handler.ts
+++ b/packages/server/src/modules/organization/commands/grant-organization-role.handler.ts
@@ -4,6 +4,8 @@ import { type GrantOrganizationRoleCommand } from "@/modules/organization/comman
 import { CannotPromoteSelfInOrganization } from "@/modules/organization/domain/organization-roles/organization-role.errors.js";
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
 import { OrganizationRolesRootOps } from "@/modules/organization/domain/organization-roles/organization-roles.root-ops.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -23,7 +25,13 @@ export const grantOrganizationRole = Effect.fn("grantOrganizationRole")(function
   const repo = yield* OrganizationRolesRepository;
   const bus = yield* DomainEventBus;
 
-  const aggregate = yield* repo.findOneByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+  const aggregate =
+    (yield* repo.findOne(
+      Spec.and(
+        OrganizationRolesSpecifications.forUser(cmd.userId),
+        OrganizationRolesSpecifications.forOrganization(cmd.organizationId),
+      ),
+    )) ?? OrganizationRolesRootOps.empty(cmd.userId, cmd.organizationId);
   const result = yield* Effect.fromResult(
     OrganizationRolesRootOps.grantRole(aggregate, cmd.role, cmd.actorUserId),
   );

--- a/packages/server/src/modules/organization/commands/invite-user.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/invite-user.handler.test.ts
@@ -7,6 +7,7 @@ import { InviteUserCommand } from "@/modules/organization/commands/invite-user.c
 import { inviteUser } from "@/modules/organization/commands/invite-user.handler.js";
 import { type InvitationIssued } from "@/modules/organization/domain/invitation/invitation.events.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import {
   InvitationMailerFake,
   SentInvitations,
@@ -41,7 +42,8 @@ describe("inviteUser", () => {
           actorUserId,
         }),
       );
-      const stored = yield* repo.findOneById(id);
+      const stored = yield* repo.findOne(InvitationSpecifications.withId(id));
+      if (stored === null) throw new Error("expected invitation");
       deepStrictEqual(stored.organizationId, organizationId);
       deepStrictEqual(stored.inviteeEmail, "alice@example.com");
       ok(stored.token.length > 0);
@@ -79,13 +81,15 @@ describe("inviteUser", () => {
         });
 
       const firstId = yield* inviteUser(make());
-      const firstToken = (yield* repo.findOneById(firstId)).token;
+      const first = yield* repo.findOne(InvitationSpecifications.withId(firstId));
+      if (first === null) throw new Error("expected invitation");
+      const firstToken = first.token;
 
       const secondId = yield* inviteUser(make());
 
       // Same invitation row (dedup), with a rotated token.
       deepStrictEqual(secondId, firstId);
-      const all = yield* repo.findManyByOrganizationId(organizationId);
+      const all = yield* repo.findMany(InvitationSpecifications.forOrganization(organizationId));
       deepStrictEqual(all.length, 1);
       ok(all[0]?.token !== firstToken, "token should be rotated on reissue");
 

--- a/packages/server/src/modules/organization/commands/invite-user.handler.ts
+++ b/packages/server/src/modules/organization/commands/invite-user.handler.ts
@@ -7,7 +7,9 @@ import * as Result from "effect/Result";
 import { type InviteUserCommand } from "@/modules/organization/commands/invite-user.command.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { InvitationMailer } from "@/modules/organization/domain/ports/clients/invitation-mailer.client.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 import { InvitationId } from "@/platform/ids/invitation-id.js";
@@ -27,13 +29,18 @@ export const inviteUser = Effect.fn("inviteUser")(function* (cmd: InviteUserComm
     // Invite-again-becomes-resend: if an open invite already exists for
     // this (org, email), reissue it (fresh token + expiry) instead of
     // creating a duplicate row, so the pending list stays one-per-email.
-    const existing = yield* repo.findOneOpenByOrganizationIdAndEmail(
-      cmd.organizationId,
-      cmd.inviteeEmail,
+    // Key eqs + the `isOpen` variant compose into one spec; the repository
+    // compiles the whole predicate to SQL and returns at most one row.
+    const openInvite = yield* repo.findOne(
+      Spec.and(
+        InvitationSpecifications.forOrganization(cmd.organizationId),
+        InvitationSpecifications.withInviteeEmail(cmd.inviteeEmail),
+        InvitationSpecifications.isOpen,
+      ),
     );
-    if (existing !== null) {
-      const result = InvitationRootOps.reissue(existing, { token, expiresAt, now });
-      // `existing` is open by construction, so reissue can't reject it;
+    if (openInvite !== null) {
+      const result = InvitationRootOps.reissue(openInvite, { token, expiresAt, now });
+      // `openInvite` is open by construction, so reissue can't reject it;
       // a Left here would mean a concurrent accept/revoke — treat as a
       // defect (same posture as the accept handler's concurrent-revoke).
       if (Result.isFailure(result)) return yield* Effect.die(result.failure);
@@ -44,7 +51,7 @@ export const inviteUser = Effect.fn("inviteUser")(function* (cmd: InviteUserComm
         .updateOne(result.success.invitation)
         .pipe(Effect.catchTag("InvitationNotFound", Effect.die));
       yield* bus.dispatch(result.success.events);
-      return existing.id;
+      return openInvite.id;
     }
     const id = InvitationId.make(crypto.randomUUID());
     const { events, invitation } = InvitationRootOps.issue({

--- a/packages/server/src/modules/organization/commands/leave-organization.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/leave-organization.handler.test.ts
@@ -13,9 +13,11 @@ import { leaveOrganization } from "@/modules/organization/commands/leave-organiz
 import { MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { type MembershipRevoked } from "@/modules/organization/domain/membership/membership.events.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/repositories/membership.repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization.repository-fake.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -46,8 +48,13 @@ describe("leaveOrganization", () => {
 
       yield* leaveOrganization(LeaveOrganizationCommand.make({ userId, organizationId: orgId }));
 
-      const exit = yield* Effect.exit(memberships.findOneByUserIdAndOrgId(userId, orgId));
-      deepStrictEqual(Exit.isFailure(exit), true);
+      const found = yield* memberships.findOne(
+        Spec.and(
+          MembershipSpecifications.forUser(userId),
+          MembershipSpecifications.forOrganization(orgId),
+        ),
+      );
+      deepStrictEqual(found, null);
 
       const events = yield* rec.byTag<MembershipRevoked>("MembershipRevoked");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/leave-organization.handler.ts
+++ b/packages/server/src/modules/organization/commands/leave-organization.handler.ts
@@ -1,8 +1,11 @@
 import * as Effect from "effect/Effect";
 
 import { type LeaveOrganizationCommand } from "@/modules/organization/commands/leave-organization.command.js";
+import { MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { MembershipRootOps } from "@/modules/organization/domain/membership/membership.root-ops.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -11,7 +14,18 @@ export const leaveOrganization = Effect.fn("leaveOrganization")(function* (
 ) {
   const repo = yield* MembershipRepository;
   const bus = yield* DomainEventBus;
-  const membership = yield* repo.findOneByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+  const membership = yield* repo.findOne(
+    Spec.and(
+      MembershipSpecifications.forUser(cmd.userId),
+      MembershipSpecifications.forOrganization(cmd.organizationId),
+    ),
+  );
+  if (membership === null) {
+    return yield* new MembershipNotFound({
+      userId: cmd.userId,
+      organizationId: cmd.organizationId,
+    });
+  }
   const { events } = MembershipRootOps.revoke(membership);
   yield* repo.deleteOne(cmd.userId, cmd.organizationId);
   yield* bus.dispatch(events);

--- a/packages/server/src/modules/organization/commands/remove-member.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/remove-member.handler.test.ts
@@ -15,9 +15,11 @@ import { MembershipNotFound } from "@/modules/organization/domain/membership/mem
 import { type MembershipRevoked } from "@/modules/organization/domain/membership/membership.events.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { MembershipRootOps } from "@/modules/organization/domain/membership/membership.root-ops.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/repositories/membership.repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization.repository-fake.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -62,8 +64,13 @@ describe("removeMember", () => {
         }),
       );
 
-      const exit = yield* Effect.exit(memberships.findOneByUserIdAndOrgId(otherUserId, orgId));
-      deepStrictEqual(Exit.isFailure(exit), true);
+      const found = yield* memberships.findOne(
+        Spec.and(
+          MembershipSpecifications.forUser(otherUserId),
+          MembershipSpecifications.forOrganization(orgId),
+        ),
+      );
+      deepStrictEqual(found, null);
 
       const events = yield* rec.byTag<MembershipRevoked>("MembershipRevoked");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/remove-member.handler.ts
+++ b/packages/server/src/modules/organization/commands/remove-member.handler.ts
@@ -1,15 +1,29 @@
 import * as Effect from "effect/Effect";
 
 import { type RemoveMemberCommand } from "@/modules/organization/commands/remove-member.command.js";
+import { MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { MembershipRootOps } from "@/modules/organization/domain/membership/membership.root-ops.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
 export const removeMember = Effect.fn("removeMember")(function* (cmd: RemoveMemberCommand) {
   const repo = yield* MembershipRepository;
   const bus = yield* DomainEventBus;
-  const membership = yield* repo.findOneByUserIdAndOrgId(cmd.targetUserId, cmd.organizationId);
+  const membership = yield* repo.findOne(
+    Spec.and(
+      MembershipSpecifications.forUser(cmd.targetUserId),
+      MembershipSpecifications.forOrganization(cmd.organizationId),
+    ),
+  );
+  if (membership === null) {
+    return yield* new MembershipNotFound({
+      userId: cmd.targetUserId,
+      organizationId: cmd.organizationId,
+    });
+  }
   const { events } = MembershipRootOps.revoke(membership);
   yield* repo.deleteOne(cmd.targetUserId, cmd.organizationId);
   yield* bus.dispatch(events);

--- a/packages/server/src/modules/organization/commands/resend-invitation.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/resend-invitation.handler.test.ts
@@ -18,6 +18,7 @@ import {
 import { type InvitationReissued } from "@/modules/organization/domain/invitation/invitation.events.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import {
   InvitationMailerFake,
   SentInvitations,
@@ -72,7 +73,8 @@ describe("resendInvitation", () => {
 
       yield* resendInvitation(cmd);
 
-      const stored = yield* repo.findOneById(invitationId);
+      const stored = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+      if (stored === null) throw new Error("expected invitation");
       ok(stored.token !== "tok-original", "token should be rotated");
       ok(DateTime.isGreaterThan(stored.expiresAt, originalExpiry), "expiry should be pushed out");
       deepStrictEqual(stored.acceptedAt, null);

--- a/packages/server/src/modules/organization/commands/resend-invitation.handler.ts
+++ b/packages/server/src/modules/organization/commands/resend-invitation.handler.ts
@@ -4,8 +4,10 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type ResendInvitationCommand } from "@/modules/organization/commands/resend-invitation.command.js";
+import { InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { InvitationMailer } from "@/modules/organization/domain/ports/clients/invitation-mailer.client.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
@@ -28,7 +30,10 @@ export const resendInvitation = Effect.fn("resendInvitation")(function* (
   const expiresAt = DateTime.add(now, { seconds: cmd.ttlSeconds });
 
   const reissued = yield* Effect.gen(function* () {
-    const invitation = yield* repo.findOneById(cmd.invitationId);
+    const invitation = yield* repo.findOne(InvitationSpecifications.withId(cmd.invitationId));
+    if (invitation === null) {
+      return yield* new InvitationNotFound({ invitationId: cmd.invitationId });
+    }
     const result = yield* Effect.fromResult(
       InvitationRootOps.reissue(invitation, { token, expiresAt, now }),
     );

--- a/packages/server/src/modules/organization/commands/restore-organization.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/restore-organization.handler.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/modules/organization/domain/organization/organization.errors.js";
 import { type OrganizationRestored } from "@/modules/organization/domain/organization/organization.events.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/repositories/membership.repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization.repository-fake.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
@@ -48,7 +49,8 @@ describe("restoreOrganization", () => {
       );
       yield* softDeleteOrganization(SoftDeleteOrganizationCommand.make({ organizationId: id }));
       yield* restoreOrganization(RestoreOrganizationCommand.make({ organizationId: id }));
-      const stored = yield* repo.findOneById(id);
+      const stored = yield* repo.findOne(OrganizationSpecifications.withId(id));
+      if (stored === null) throw new Error("expected organization");
       deepStrictEqual(stored.deletedAt, null);
       const events = yield* rec.byTag<OrganizationRestored>("OrganizationRestored");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/restore-organization.handler.ts
+++ b/packages/server/src/modules/organization/commands/restore-organization.handler.ts
@@ -2,8 +2,10 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type RestoreOrganizationCommand } from "@/modules/organization/commands/restore-organization.command.js";
+import { OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
 import { OrganizationRootOps } from "@/modules/organization/domain/organization/organization.root-ops.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -14,8 +16,11 @@ export const restoreOrganization = Effect.fn("restoreOrganization")(function* (
   const bus = yield* DomainEventBus;
   const now = yield* DateTime.now;
   // Restore is the one write path that needs to load the tombstoned
-  // row; the default `findOneById` filters it out.
-  const organization = yield* repo.findOneByIdIncludingDeleted(cmd.organizationId);
+  // row; `withId` alone (no `notDeleted`) keeps it visible.
+  const organization = yield* repo.findOne(OrganizationSpecifications.withId(cmd.organizationId));
+  if (organization === null) {
+    return yield* new OrganizationNotFound({ organizationId: cmd.organizationId });
+  }
   const result = yield* Effect.fromResult(OrganizationRootOps.restore(organization, { now }));
   yield* repo.updateOne(result.organization);
   yield* bus.dispatch(result.events);

--- a/packages/server/src/modules/organization/commands/revoke-invitation.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/revoke-invitation.handler.test.ts
@@ -19,6 +19,7 @@ import { type InvitationRevoked } from "@/modules/organization/domain/invitation
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { InvitationRepositoryFake } from "@/modules/organization/infrastructure/repositories/invitation.repository-fake.js";
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
@@ -54,7 +55,8 @@ describe("revokeInvitation", () => {
 
       yield* revokeInvitation(RevokeInvitationCommand.make({ invitationId, actorUserId }));
 
-      const updated = yield* repo.findOneById(invitationId);
+      const updated = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+      if (updated === null) throw new Error("expected invitation");
       deepStrictEqual(updated.revokedAt !== null, true);
 
       const events = yield* rec.byTag<InvitationRevoked>("InvitationRevoked");

--- a/packages/server/src/modules/organization/commands/revoke-invitation.handler.ts
+++ b/packages/server/src/modules/organization/commands/revoke-invitation.handler.ts
@@ -2,8 +2,10 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type RevokeInvitationCommand } from "@/modules/organization/commands/revoke-invitation.command.js";
+import { InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -13,7 +15,10 @@ export const revokeInvitation = Effect.fn("revokeInvitation")(function* (
   const repo = yield* InvitationRepository;
   const bus = yield* DomainEventBus;
   const now = yield* DateTime.now;
-  const invitation = yield* repo.findOneById(cmd.invitationId);
+  const invitation = yield* repo.findOne(InvitationSpecifications.withId(cmd.invitationId));
+  if (invitation === null) {
+    return yield* new InvitationNotFound({ invitationId: cmd.invitationId });
+  }
   const result = yield* Effect.fromResult(InvitationRootOps.revoke(invitation, { now }));
   yield* repo.updateOne(result.invitation);
   yield* bus.dispatch(result.events);

--- a/packages/server/src/modules/organization/commands/revoke-organization-role.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role.handler.test.ts
@@ -13,7 +13,9 @@ import { revokeOrganizationRole } from "@/modules/organization/commands/revoke-o
 import { DoesNotHaveOrganizationRole } from "@/modules/organization/domain/organization-roles/organization-role.errors.js";
 import { type OrganizationRoleRevoked } from "@/modules/organization/domain/organization-roles/organization-role.events.js";
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -52,8 +54,15 @@ describe("revokeOrganizationRole", () => {
         }),
       );
 
-      const roles = yield* repo.findOneByUserIdAndOrgId(targetId, orgId);
-      deepStrictEqual([...roles.roles], []);
+      // Revoking the only role leaves no rows, so the aggregate no longer
+      // resolves — findOne reports null (no rows = no roles).
+      const roles = yield* repo.findOne(
+        Spec.and(
+          OrganizationRolesSpecifications.forUser(targetId),
+          OrganizationRolesSpecifications.forOrganization(orgId),
+        ),
+      );
+      deepStrictEqual(roles, null);
 
       const events = yield* rec.byTag<OrganizationRoleRevoked>("OrganizationRoleRevoked");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/revoke-organization-role.handler.ts
+++ b/packages/server/src/modules/organization/commands/revoke-organization-role.handler.ts
@@ -3,6 +3,8 @@ import * as Effect from "effect/Effect";
 import { type RevokeOrganizationRoleCommand } from "@/modules/organization/commands/revoke-organization-role.command.js";
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
 import { OrganizationRolesRootOps } from "@/modules/organization/domain/organization-roles/organization-roles.root-ops.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -12,7 +14,13 @@ export const revokeOrganizationRole = Effect.fn("revokeOrganizationRole")(functi
   const repo = yield* OrganizationRolesRepository;
   const bus = yield* DomainEventBus;
 
-  const aggregate = yield* repo.findOneByUserIdAndOrgId(cmd.userId, cmd.organizationId);
+  const aggregate =
+    (yield* repo.findOne(
+      Spec.and(
+        OrganizationRolesSpecifications.forUser(cmd.userId),
+        OrganizationRolesSpecifications.forOrganization(cmd.organizationId),
+      ),
+    )) ?? OrganizationRolesRootOps.empty(cmd.userId, cmd.organizationId);
   const result = yield* Effect.fromResult(OrganizationRolesRootOps.revokeRole(aggregate, cmd.role));
 
   yield* repo.upsertOne(result.organizationRoles);

--- a/packages/server/src/modules/organization/commands/soft-delete-organization.handler.test.ts
+++ b/packages/server/src/modules/organization/commands/soft-delete-organization.handler.test.ts
@@ -13,6 +13,7 @@ import { softDeleteOrganization } from "@/modules/organization/commands/soft-del
 import { OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { type OrganizationSoftDeleted } from "@/modules/organization/domain/organization/organization.events.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
 import { MembershipRepositoryFake } from "@/modules/organization/infrastructure/repositories/membership.repository-fake.js";
 import { OrganizationRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization.repository-fake.js";
 import { OrganizationRolesRepositoryFake } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-fake.js";
@@ -42,7 +43,8 @@ describe("softDeleteOrganization", () => {
         CreateOrganizationCommand.make({ name: "Acme", actorUserId }),
       );
       yield* softDeleteOrganization(SoftDeleteOrganizationCommand.make({ organizationId: id }));
-      const stored = yield* repo.findOneByIdIncludingDeleted(id);
+      const stored = yield* repo.findOne(OrganizationSpecifications.withId(id));
+      if (stored === null) throw new Error("expected organization");
       deepStrictEqual(stored.deletedAt !== null, true);
       const events = yield* rec.byTag<OrganizationSoftDeleted>("OrganizationSoftDeleted");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/organization/commands/soft-delete-organization.handler.ts
+++ b/packages/server/src/modules/organization/commands/soft-delete-organization.handler.ts
@@ -2,8 +2,11 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type SoftDeleteOrganizationCommand } from "@/modules/organization/commands/soft-delete-organization.command.js";
+import { OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
 import { OrganizationRootOps } from "@/modules/organization/domain/organization/organization.root-ops.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -13,13 +16,21 @@ export const softDeleteOrganization = Effect.fn("softDeleteOrganization")(functi
   const repo = yield* OrganizationRepository;
   const bus = yield* DomainEventBus;
   const now = yield* DateTime.now;
-  // `findOneById` filters out tombstoned rows; if the org is already
+  // The active-only spec hides tombstoned rows; if the org is already
   // soft-deleted the use case returns the same `OrganizationNotFound`
   // a missing org would — same outward contract, simpler invariant
   // surface. The aggregate's `OrganizationAlreadyDeleted` covers the
   // race where two concurrent soft-deletes both observe the row as
   // active and then race the update.
-  const organization = yield* repo.findOneById(cmd.organizationId);
+  const organization = yield* repo.findOne(
+    Spec.and(
+      OrganizationSpecifications.withId(cmd.organizationId),
+      OrganizationSpecifications.notDeleted,
+    ),
+  );
+  if (organization === null) {
+    return yield* new OrganizationNotFound({ organizationId: cmd.organizationId });
+  }
   const result = yield* Effect.fromResult(OrganizationRootOps.softDelete(organization, { now }));
   yield* repo.updateOne(result.organization);
   yield* bus.dispatch(result.events);

--- a/packages/server/src/modules/organization/domain/invitation/invitation.repository.ts
+++ b/packages/server/src/modules/organization/domain/invitation/invitation.repository.ts
@@ -1,52 +1,29 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 
-import {
-  type InvitationNotFound,
-  type InvitationTokenNotFound,
-} from "@/modules/organization/domain/invitation/invitation.errors.js";
+import { type InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type InvitationId } from "@/platform/ids/invitation-id.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
-// `insert` is a fresh insert — the unique constraint on `token` will
-// reject collisions (the command generates a high-entropy token, so a
-// collision is a server defect that surfaces as a DatabaseError → die).
-//
-// `update` covers state transitions (accept/revoke/reissue) — the
-// aggregate produces the new state, the repo persists it. Surfaces
-// InvitationNotFound when the row is missing (likely a concurrent
-// delete; commands treat this as a 404).
-//
-// `findOneByToken` is the read path for the anonymous accept endpoint
-// (the caller doesn't know the invitation id, only the token).
-//
-// `findManyByOrganizationId` backs the pending-invitations list (the handler
-// filters/derives status). `findOneOpenByOrganizationIdAndEmail` backs the
-// invite-again-becomes-resend dedup: the `Open` qualifier (ADR-0005 permits a
-// qualifier in front of the `By<Key>` clause) says it returns only the OPEN
-// invitation — at most one open invite per (org, email) once dedup is in force —
-// i.e. the most recent open one (or null), so the command can reissue instead
-// of creating a duplicate.
+// Dumb persistence, collapsed to the minimal vocabulary: insert/update the
+// aggregate, and read it back by a Specification. Every variant and identity
+// lookup — by id, by token, the open invite for an (org, email) — is expressed
+// as a spec at the call site (see InvitationSpecifications) and compiled to a
+// WHERE fragment by the live repository. Absence is a plain `null`; mapping it
+// to a domain 404 (InvitationNotFound / InvitationTokenNotFound) is the
+// handler's job, since which not-found error applies depends on the use case.
 export type InvitationRepositoryShape = {
   readonly insertOne: (invitation: InvitationRoot) => Effect.Effect<void, PersistenceUnavailable>;
   readonly updateOne: (
     invitation: InvitationRoot,
   ) => Effect.Effect<void, InvitationNotFound | PersistenceUnavailable>;
-  readonly findOneById: (
-    id: InvitationId,
-  ) => Effect.Effect<InvitationRoot, InvitationNotFound | PersistenceUnavailable>;
-  readonly findOneByToken: (
-    token: string,
-  ) => Effect.Effect<InvitationRoot, InvitationTokenNotFound | PersistenceUnavailable>;
-  readonly findManyByOrganizationId: (
-    organizationId: OrganizationId,
-  ) => Effect.Effect<ReadonlyArray<InvitationRoot>, PersistenceUnavailable>;
-  readonly findOneOpenByOrganizationIdAndEmail: (
-    organizationId: OrganizationId,
-    inviteeEmail: string,
+  readonly findOne: (
+    spec: Specification<InvitationRoot>,
   ) => Effect.Effect<InvitationRoot | null, PersistenceUnavailable>;
+  readonly findMany: (
+    spec: Specification<InvitationRoot>,
+  ) => Effect.Effect<ReadonlyArray<InvitationRoot>, PersistenceUnavailable>;
 };
 
 export class InvitationRepository extends Context.Service<

--- a/packages/server/src/modules/organization/domain/invitation/invitation.root-ops.ts
+++ b/packages/server/src/modules/organization/domain/invitation/invitation.root-ops.ts
@@ -86,7 +86,7 @@ const accept = (
   if (InvitationSpecifications.isRevoked(invitation)) {
     return Result.fail(new InvitationRevokedError({ invitationId: invitation.id }));
   }
-  if (InvitationSpecifications.isExpiredAt(invitation, input.now)) {
+  if (InvitationSpecifications.isExpiredAt(input.now)(invitation)) {
     return Result.fail(new InvitationExpired({ invitationId: invitation.id }));
   }
   const updated = InvitationRoot.make({

--- a/packages/server/src/modules/organization/domain/invitation/invitation.specification.ts
+++ b/packages/server/src/modules/organization/domain/invitation/invitation.specification.ts
@@ -1,30 +1,59 @@
 import * as DateTime from "effect/DateTime";
 
+import {
+  type Predicate,
+  Spec,
+  type Specification,
+} from "@/platform/ddd/contracts/specification.js";
+import { type InvitationId } from "@/platform/ids/invitation-id.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
 import { type InvitationRoot } from "./invitation.root.js";
 
-const isAccepted = (invitation: InvitationRoot): boolean => invitation.acceptedAt !== null;
-const isRevoked = (invitation: InvitationRoot): boolean => invitation.revokedAt !== null;
-const isExpiredAt = (invitation: InvitationRoot, now: DateTime.Utc): boolean =>
-  DateTime.isLessThanOrEqualTo(invitation.expiresAt, now);
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The field-name strings live here and in the mapper's
+// column map; `Spec.eq`/`isNull` type them against InvitationRoot so a typo is
+// a compile error.
+const withId = (id: InvitationId): Specification<InvitationRoot> =>
+  Spec.eq<InvitationRoot, "id">("id", id);
+const withToken = (token: string): Specification<InvitationRoot> =>
+  Spec.eq<InvitationRoot, "token">("token", token);
+const forOrganization = (organizationId: OrganizationId): Specification<InvitationRoot> =>
+  Spec.eq<InvitationRoot, "organizationId">("organizationId", organizationId);
+const withInviteeEmail = (inviteeEmail: string): Specification<InvitationRoot> =>
+  Spec.eq<InvitationRoot, "inviteeEmail">("inviteeEmail", inviteeEmail);
 
-// "Open" = not yet accepted and not revoked — the set of invitations the
-// pending-list surfaces and that invite-again/resend re-issue. An open
-// invite is still further classified by `statusAt` as pending vs expired.
-const isOpen = (invitation: InvitationRoot): boolean =>
-  !isAccepted(invitation) && !isRevoked(invitation);
+const isAccepted = Spec.isNotNull<InvitationRoot>("acceptedAt");
+const isRevoked = Spec.isNotNull<InvitationRoot>("revokedAt");
+
+// "Open" = not yet accepted and not revoked — the set invite-again/resend
+// re-issue. Composed from the two terminal specs, so it filters in memory and
+// compiles to `NOT (accepted_at IS NOT NULL OR revoked_at IS NOT NULL)`.
+const isOpen = Spec.not(Spec.or(isAccepted, isRevoked));
+
+// Eval-only (a `Predicate`, not a `Specification`): DateTime comparison has no
+// Criteria node, and no repository filters invitations by expiry, so it never
+// needs SQL translation. It stays a guard used in the aggregate ops.
+const isExpiredAt =
+  (now: DateTime.Utc): Predicate<InvitationRoot> =>
+  (invitation) =>
+    DateTime.isLessThanOrEqualTo(invitation.expiresAt, now);
 
 export type InvitationStatus = "pending" | "expired";
 
-// Display status for an *open* invitation. Accepted/revoked invitations
-// are filtered out before this is called (they aren't part of the
-// pending list), so only the live-vs-lapsed distinction remains.
+// Display status for an *open* invitation. Accepted/revoked invitations are
+// filtered out before this is called, so only live-vs-lapsed remains.
 const statusAt = (invitation: InvitationRoot, now: DateTime.Utc): InvitationStatus =>
-  isExpiredAt(invitation, now) ? "expired" : "pending";
+  isExpiredAt(now)(invitation) ? "expired" : "pending";
 
 export const InvitationSpecifications = {
+  withId,
+  withToken,
+  forOrganization,
+  withInviteeEmail,
   isAccepted,
   isRevoked,
-  isExpiredAt,
   isOpen,
+  isExpiredAt,
   statusAt,
 } as const;

--- a/packages/server/src/modules/organization/domain/membership/membership.repository.ts
+++ b/packages/server/src/modules/organization/domain/membership/membership.repository.ts
@@ -4,6 +4,7 @@ import type * as Effect from "effect/Effect";
 import { type MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { type MembershipRoot } from "@/modules/organization/domain/membership/membership.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
@@ -15,19 +16,19 @@ import { type UserId } from "@/platform/ids/user-id.js";
 // `delete` returns `MembershipNotFound` when there's nothing to remove
 // — `RemoveMember`/`LeaveOrganization` rely on that to surface a 404 to
 // callers asking to remove a non-existent member.
+//
+// The composite (userId, organizationId) lookup is a spec at the call
+// site (see MembershipSpecifications). Absence is a plain `null`; mapping
+// it to `MembershipNotFound` is the caller's job.
 export type MembershipRepositoryShape = {
   readonly insertOne: (membership: MembershipRoot) => Effect.Effect<void, PersistenceUnavailable>;
   readonly deleteOne: (
     userId: UserId,
     organizationId: OrganizationId,
   ) => Effect.Effect<void, MembershipNotFound | PersistenceUnavailable>;
-  readonly findOneByUserIdAndOrgId: (
-    userId: UserId,
-    organizationId: OrganizationId,
-  ) => Effect.Effect<MembershipRoot, MembershipNotFound | PersistenceUnavailable>;
-  readonly findManyByOrganizationId: (
-    organizationId: OrganizationId,
-  ) => Effect.Effect<ReadonlyArray<MembershipRoot>, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<MembershipRoot>,
+  ) => Effect.Effect<MembershipRoot | null, PersistenceUnavailable>;
 };
 
 export class MembershipRepository extends Context.Service<

--- a/packages/server/src/modules/organization/domain/membership/membership.specification.test.ts
+++ b/packages/server/src/modules/organization/domain/membership/membership.specification.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { MembershipRootOps } from "./membership.root-ops.js";
+import { MembershipSpecifications } from "./membership.specification.js";
+
+const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");
+const organizationId = OrganizationId.make("33333333-3333-3333-3333-333333333333");
+const otherOrganizationId = OrganizationId.make("44444444-4444-4444-4444-444444444444");
+const now = DateTime.makeUnsafe(new Date("2026-01-01T00:00:00Z"));
+
+const seed = () => MembershipRootOps.create({ userId, organizationId, now }).membership;
+
+describe("MembershipSpecifications.forUser", () => {
+  it("matches only the given user and carries an Eq criteria", () => {
+    const membership = seed();
+    deepStrictEqual(MembershipSpecifications.forUser(userId)(membership), true);
+    deepStrictEqual(MembershipSpecifications.forUser(otherUserId)(membership), false);
+    deepStrictEqual(MembershipSpecifications.forUser(userId).criteria, {
+      _tag: "Eq",
+      field: "userId",
+      value: userId,
+    });
+  });
+});
+
+describe("MembershipSpecifications.forOrganization", () => {
+  it("matches only the given organization and carries an Eq criteria", () => {
+    const membership = seed();
+    deepStrictEqual(MembershipSpecifications.forOrganization(organizationId)(membership), true);
+    deepStrictEqual(
+      MembershipSpecifications.forOrganization(otherOrganizationId)(membership),
+      false,
+    );
+    deepStrictEqual(MembershipSpecifications.forOrganization(organizationId).criteria, {
+      _tag: "Eq",
+      field: "organizationId",
+      value: organizationId,
+    });
+  });
+});

--- a/packages/server/src/modules/organization/domain/membership/membership.specification.ts
+++ b/packages/server/src/modules/organization/domain/membership/membership.specification.ts
@@ -1,0 +1,15 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+import { type MembershipRoot } from "./membership.root.js";
+
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The composite identity is expressed by AND-composing the
+// two halves at the call site: `Spec.and(forUser(u), forOrganization(o))`.
+const forUser = (userId: UserId): Specification<MembershipRoot> =>
+  Spec.eq<MembershipRoot, "userId">("userId", userId);
+const forOrganization = (organizationId: OrganizationId): Specification<MembershipRoot> =>
+  Spec.eq<MembershipRoot, "organizationId">("organizationId", organizationId);
+
+export const MembershipSpecifications = { forUser, forOrganization } as const;

--- a/packages/server/src/modules/organization/domain/organization-roles/organization-roles.repository.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles/organization-roles.repository.ts
@@ -3,24 +3,22 @@ import type * as Effect from "effect/Effect";
 
 import { type OrganizationRolesRoot } from "@/modules/organization/domain/organization-roles/organization-roles.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
-// Dumb persistence port. The aggregate carries the invariants
-// (uniqueness, "revoke only what's held"); the repository only knows
-// how to save and fetch the resulting state.
-//
-// `findOneByUserIdAndOrgId` returns an empty `OrganizationRolesRoot` aggregate
-// if no rows are stored — the absence of any rows is a valid "no roles
-// yet" state, not a NotFound condition. Mirrors `RolesRepository`.
+// Dumb persistence, collapsed to upsert + spec-based read. The aggregate is
+// multi-row (one `organization_roles` row per assigned role) keyed on the
+// composite `(userId, organizationId)`. `findOne` compiles the spec to a WHERE,
+// fetches the matching rows, and reconstitutes ONE aggregate — or `null` when
+// no rows match. "No rows" is a valid "no roles yet" state, so the caller maps
+// `null` to `OrganizationRolesRootOps.empty(...)`: the empty aggregate is a
+// domain concern the repo can't synthesize from zero rows.
 export type OrganizationRolesRepositoryShape = {
   readonly upsertOne: (
     organizationRoles: OrganizationRolesRoot,
   ) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneByUserIdAndOrgId: (
-    userId: UserId,
-    organizationId: OrganizationId,
-  ) => Effect.Effect<OrganizationRolesRoot, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<OrganizationRolesRoot>,
+  ) => Effect.Effect<OrganizationRolesRoot | null, PersistenceUnavailable>;
 };
 
 export class OrganizationRolesRepository extends Context.Service<

--- a/packages/server/src/modules/organization/domain/organization-roles/organization-roles.root-ops.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles/organization-roles.root-ops.ts
@@ -32,7 +32,7 @@ const grantRole = (
   role: OrganizationRoleValueObject,
   issuedBy: UserId,
 ): Result.Result<Outcome, AlreadyHasOrganizationRole> => {
-  if (OrganizationRolesSpecifications.hasRole(aggregate, role)) {
+  if (OrganizationRolesSpecifications.hasRole(role)(aggregate)) {
     return Result.fail(
       new AlreadyHasOrganizationRole({
         userId: aggregate.userId,
@@ -64,7 +64,7 @@ const revokeRole = (
   aggregate: OrganizationRolesRoot,
   role: OrganizationRoleValueObject,
 ): Result.Result<Outcome, DoesNotHaveOrganizationRole> => {
-  if (!OrganizationRolesSpecifications.hasRole(aggregate, role)) {
+  if (!OrganizationRolesSpecifications.hasRole(role)(aggregate)) {
     return Result.fail(
       new DoesNotHaveOrganizationRole({
         userId: aggregate.userId,

--- a/packages/server/src/modules/organization/domain/organization-roles/organization-roles.specification.test.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles/organization-roles.specification.test.ts
@@ -2,9 +2,11 @@ import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Result from "effect/Result";
 
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
+import { type OrganizationRolesRoot } from "./organization-roles.root.js";
 import { OrganizationRolesRootOps } from "./organization-roles.root-ops.js";
 import { OrganizationRolesSpecifications } from "./organization-roles.specification.js";
 
@@ -12,12 +14,21 @@ const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
 
+// Boundary (criteria-to-sql): `hasRole` reaches into the `roles` child
+// collection, so it is a `Predicate`, not a translatable `Specification`, and
+// must never be usable as a repository filter. This assignment must NOT
+// compile — if `hasRole` ever gains a `.criteria`, the directive goes unused
+// and the build fails, catching the regression.
+// @ts-expect-error hasRole("admin") is a Predicate; it has no `.criteria`.
+const _hasRoleIsNotASpecification: Specification<OrganizationRolesRoot> =
+  OrganizationRolesSpecifications.hasRole("admin");
+void _hasRoleIsNotASpecification;
+
 describe("OrganizationRolesSpecifications.hasRole", () => {
   it("returns false on an empty aggregate", () => {
     deepStrictEqual(
-      OrganizationRolesSpecifications.hasRole(
+      OrganizationRolesSpecifications.hasRole("admin")(
         OrganizationRolesRootOps.empty(userId, orgId),
-        "admin",
       ),
       false,
     );
@@ -31,7 +42,7 @@ describe("OrganizationRolesSpecifications.hasRole", () => {
     );
     if (Result.isFailure(result)) throw new Error("expected Right");
     deepStrictEqual(
-      OrganizationRolesSpecifications.hasRole(result.success.organizationRoles, "admin"),
+      OrganizationRolesSpecifications.hasRole("admin")(result.success.organizationRoles),
       true,
     );
   });

--- a/packages/server/src/modules/organization/domain/organization-roles/organization-roles.specification.ts
+++ b/packages/server/src/modules/organization/domain/organization-roles/organization-roles.specification.ts
@@ -1,8 +1,30 @@
+import {
+  type Predicate,
+  Spec,
+  type Specification,
+} from "@/platform/ddd/contracts/specification.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { type OrganizationRoleValueObject } from "./organization-role.value-object.js";
 import { type OrganizationRolesRoot } from "./organization-roles.root.js";
 
-const hasRole = (aggregate: OrganizationRolesRoot, role: OrganizationRoleValueObject): boolean =>
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- comparison is provably constant while `OrganizationRoleValueObject` has a single literal; becomes a real comparison once a second role lands.
-  aggregate.roles.some((r) => r.role === role);
+// Translatable identity specs — the composite key `(userId, organizationId)`
+// lives on every row of the aggregate, so these compile to a WHERE that the
+// repository uses to fetch the row set it reconstitutes into one aggregate.
+const forUser = (userId: UserId): Specification<OrganizationRolesRoot> =>
+  Spec.eq<OrganizationRolesRoot, "userId">("userId", userId);
+const forOrganization = (organizationId: OrganizationId): Specification<OrganizationRolesRoot> =>
+  Spec.eq<OrganizationRolesRoot, "organizationId">("organizationId", organizationId);
 
-export const OrganizationRolesSpecifications = { hasRole } as const;
+// Eval-only: `hasRole` reaches into the `roles` child collection, which the
+// Criteria DSL cannot express (there is no "some child row" node). It is a
+// Predicate, never a Specification, so it guards aggregate ops but can never be
+// handed to a repository — the spec test locks that boundary at compile time.
+const hasRole =
+  (role: OrganizationRoleValueObject): Predicate<OrganizationRolesRoot> =>
+  (aggregate) =>
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- comparison is provably constant while `OrganizationRoleValueObject` has a single literal; becomes a real comparison once a second role lands.
+    aggregate.roles.some((r) => r.role === role);
+
+export const OrganizationRolesSpecifications = { forUser, forOrganization, hasRole } as const;

--- a/packages/server/src/modules/organization/domain/organization/organization.repository.ts
+++ b/packages/server/src/modules/organization/domain/organization/organization.repository.ts
@@ -4,13 +4,15 @@ import type * as Effect from "effect/Effect";
 import { type OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { type OrganizationRoot } from "@/modules/organization/domain/organization/organization.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
-// Single-aggregate persistence port. `findOneById` filters out soft-deleted
-// rows by default; `findOneByIdIncludingDeleted` is the explicit opt-in for
-// the restore code path (the resource resolver registered for the
-// `organization` resource uses this so policy checks can see deleted
-// orgs without callers having to maintain two `resource` keys).
+// Dumb persistence, collapsed to the minimal vocabulary: insert/update the
+// aggregate, and read it back by a Specification. Identity lookups and the
+// active-only filter are expressed as specs at the call site (see
+// OrganizationSpecifications: `withId`, `notDeleted`) — the restore path reads
+// the tombstone with `withId` alone, active-only flows compose it with
+// `notDeleted`. Absence is a plain `null`; mapping it to `OrganizationNotFound`
+// is the caller's job.
 //
 // `update` covers both write paths (rename + soft-delete + restore) —
 // the aggregate produces the new state and the repo just persists.
@@ -21,12 +23,9 @@ export type OrganizationRepositoryShape = {
   readonly updateOne: (
     organization: OrganizationRoot,
   ) => Effect.Effect<void, OrganizationNotFound | PersistenceUnavailable>;
-  readonly findOneById: (
-    id: OrganizationId,
-  ) => Effect.Effect<OrganizationRoot, OrganizationNotFound | PersistenceUnavailable>;
-  readonly findOneByIdIncludingDeleted: (
-    id: OrganizationId,
-  ) => Effect.Effect<OrganizationRoot, OrganizationNotFound | PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<OrganizationRoot>,
+  ) => Effect.Effect<OrganizationRoot | null, PersistenceUnavailable>;
 };
 
 export class OrganizationRepository extends Context.Service<

--- a/packages/server/src/modules/organization/domain/organization/organization.specification.test.ts
+++ b/packages/server/src/modules/organization/domain/organization/organization.specification.test.ts
@@ -12,12 +12,39 @@ const id = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const now = DateTime.makeUnsafe(new Date("2026-01-01T00:00:00Z"));
 const later = DateTime.makeUnsafe(new Date("2026-02-01T00:00:00Z"));
 
-describe("OrganizationSpecifications.isDeleted", () => {
+describe("OrganizationSpecifications.isDeleted / notDeleted", () => {
   it("returns false on a fresh org and true after softDelete", () => {
     const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
     deepStrictEqual(OrganizationSpecifications.isDeleted(organization), false);
+    deepStrictEqual(OrganizationSpecifications.notDeleted(organization), true);
     const result = OrganizationRootOps.softDelete(organization, { now: later });
     if (Result.isFailure(result)) throw new Error("expected Right");
     deepStrictEqual(OrganizationSpecifications.isDeleted(result.success.organization), true);
+    deepStrictEqual(OrganizationSpecifications.notDeleted(result.success.organization), false);
+  });
+
+  it("carry criteria complementary over deletedAt", () => {
+    deepStrictEqual(OrganizationSpecifications.isDeleted.criteria, {
+      _tag: "IsNotNull",
+      field: "deletedAt",
+    });
+    deepStrictEqual(OrganizationSpecifications.notDeleted.criteria, {
+      _tag: "IsNull",
+      field: "deletedAt",
+    });
+  });
+});
+
+describe("OrganizationSpecifications.withId", () => {
+  it("matches only the org with the given id and carries an Eq criteria", () => {
+    const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
+    const other = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+    deepStrictEqual(OrganizationSpecifications.withId(id)(organization), true);
+    deepStrictEqual(OrganizationSpecifications.withId(other)(organization), false);
+    deepStrictEqual(OrganizationSpecifications.withId(id).criteria, {
+      _tag: "Eq",
+      field: "id",
+      value: id,
+    });
   });
 });

--- a/packages/server/src/modules/organization/domain/organization/organization.specification.ts
+++ b/packages/server/src/modules/organization/domain/organization/organization.specification.ts
@@ -1,5 +1,16 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
 import { type OrganizationRoot } from "./organization.root.js";
 
-const isDeleted = (organization: OrganizationRoot): boolean => organization.deletedAt !== null;
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). `isDeleted` doubles as the soft-delete guard the root-ops
+// call as a predicate; `notDeleted` is its complement, composed into the
+// active-only read; `withId` is the identity lookup.
+const withId = (id: OrganizationId): Specification<OrganizationRoot> =>
+  Spec.eq<OrganizationRoot, "id">("id", id);
 
-export const OrganizationSpecifications = { isDeleted } as const;
+const isDeleted = Spec.isNotNull<OrganizationRoot>("deletedAt");
+const notDeleted = Spec.isNull<OrganizationRoot>("deletedAt");
+
+export const OrganizationSpecifications = { withId, isDeleted, notDeleted } as const;

--- a/packages/server/src/modules/organization/infrastructure/repositories/invitation.mapper.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/invitation.mapper.ts
@@ -4,8 +4,21 @@ import * as DateTime from "effect/DateTime";
 import { InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.InvitationRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of "organization".invitations. Only filterable scalar
+// fields need an entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+  token: "token",
+  organizationId: "organization_id",
+  inviteeEmail: "invitee_email",
+  acceptedAt: "accepted_at",
+  revokedAt: "revoked_at",
+} as const satisfies Partial<Record<keyof InvitationRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): InvitationRoot =>
   new InvitationRoot({

--- a/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-fake.test.ts
@@ -7,13 +7,11 @@ import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 
-import {
-  InvitationNotFound,
-  InvitationTokenNotFound,
-} from "@/modules/organization/domain/invitation/invitation.errors.js";
+import { InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -39,50 +37,46 @@ const seed = (): InvitationRoot =>
 const provide = Effect.provide(InvitationRepositoryFake);
 
 describe("InvitationRepositoryFake", () => {
-  it.effect("findOneById round-trips an inserted invitation", () =>
+  it.effect("findOne(withId) round-trips an inserted invitation", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
       yield* repo.insertOne(seed());
-      const found = yield* repo.findOneById(invitationId);
+      const found = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+      if (found === null) throw new Error("expected invitation");
       deepStrictEqual(found.id, invitationId);
       deepStrictEqual(found.token, "tok-abc");
     }).pipe(provide),
   );
 
-  it.effect("findOneByToken returns the matching invitation", () =>
+  it.effect("findOne(withToken) returns the matching invitation", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
       yield* repo.insertOne(seed());
-      const found = yield* repo.findOneByToken("tok-abc");
+      const found = yield* repo.findOne(InvitationSpecifications.withToken("tok-abc"));
+      if (found === null) throw new Error("expected invitation");
       deepStrictEqual(found.id, invitationId);
     }).pipe(provide),
   );
 
-  it.effect("findOneById fails InvitationNotFound when absent", () =>
+  it.effect("findOne returns null when no row matches (absence is not an error)", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      const exit = yield* Effect.exit(repo.findOneById(invitationId));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof InvitationNotFound, true);
-      }
+      const byId = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+      const byToken = yield* repo.findOne(InvitationSpecifications.withToken("missing"));
+      deepStrictEqual(byId, null);
+      deepStrictEqual(byToken, null);
     }).pipe(provide),
   );
 
-  it.effect("findOneByToken fails InvitationTokenNotFound when no row matches", () =>
+  it.effect("findOne(isOpen) narrows to open invitations", () =>
     Effect.gen(function* () {
       const repo = yield* InvitationRepository;
-      const exit = yield* Effect.exit(repo.findOneByToken("missing"));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof InvitationTokenNotFound, true);
-      }
+      yield* repo.insertOne(seed());
+      const revoked = InvitationRootOps.revoke(seed(), { now });
+      if (Result.isFailure(revoked)) throw new Error("expected Right");
+      yield* repo.updateOne(revoked.success.invitation);
+      const open = yield* repo.findOne(InvitationSpecifications.isOpen);
+      deepStrictEqual(open, null);
     }).pipe(provide),
   );
 
@@ -93,7 +87,8 @@ describe("InvitationRepositoryFake", () => {
       const accepted = InvitationRootOps.accept(seed(), { userId, now });
       if (Result.isFailure(accepted)) throw new Error("expected Right");
       yield* repo.updateOne(accepted.success.invitation);
-      const found = yield* repo.findOneById(invitationId);
+      const found = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+      if (found === null) throw new Error("expected invitation");
       deepStrictEqual(found.acceptedAt !== null, true);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-fake.ts
@@ -4,15 +4,11 @@ import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 
-import {
-  InvitationNotFound,
-  InvitationTokenNotFound,
-} from "@/modules/organization/domain/invitation/invitation.errors.js";
+import { InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
-import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type InvitationId } from "@/platform/ids/invitation-id.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 export const InvitationRepositoryFake = Layer.effect(
   InvitationRepository,
@@ -29,60 +25,24 @@ export const InvitationRepositoryFake = Layer.effect(
           : Effect.fail(new InvitationNotFound({ invitationId: invitation.id })),
       );
 
-    const findOneById = (id: InvitationId): Effect.Effect<InvitationRoot, InvitationNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        const found = HashMap.get(m, id);
-        return found._tag === "Some"
-          ? Effect.succeed(found.value)
-          : Effect.fail(new InvitationNotFound({ invitationId: id }));
-      });
-
-    const findOneByToken = (
-      token: string,
-    ): Effect.Effect<InvitationRoot, InvitationTokenNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        for (const inv of HashMap.values(m)) {
-          if (inv.token === token) return Effect.succeed(inv);
-        }
-        return Effect.fail(new InvitationTokenNotFound());
-      });
-
-    // Newest-first, matching the live repo's `ORDER BY created_at DESC`.
+    // Newest-first, matching the live repo's `ORDER BY created_at DESC`. The
+    // spec IS the in-memory predicate — same object the live repo compiles to
+    // SQL — so fake and live agree by construction.
     const byCreatedAtDesc = (a: InvitationRoot, b: InvitationRoot): number =>
       DateTime.toEpochMillis(b.createdAt) - DateTime.toEpochMillis(a.createdAt);
 
-    const findManyByOrganizationId = (
-      organizationId: OrganizationId,
-    ): Effect.Effect<ReadonlyArray<InvitationRoot>> =>
+    const matching = (spec: Specification<InvitationRoot>) =>
       Effect.map(Ref.get(store), (m) =>
-        Array.from(HashMap.values(m))
-          .filter((inv) => inv.organizationId === organizationId)
-          .sort(byCreatedAtDesc),
+        Array.from(HashMap.values(m)).filter(spec).sort(byCreatedAtDesc),
       );
 
-    const findOneOpenByOrganizationIdAndEmail = (
-      organizationId: OrganizationId,
-      inviteeEmail: string,
-    ): Effect.Effect<InvitationRoot | null> =>
-      Effect.map(Ref.get(store), (m) => {
-        const open = Array.from(HashMap.values(m))
-          .filter(
-            (inv) =>
-              inv.organizationId === organizationId &&
-              inv.inviteeEmail === inviteeEmail &&
-              InvitationSpecifications.isOpen(inv),
-          )
-          .sort(byCreatedAtDesc);
-        return open[0] ?? null;
-      });
+    const findOne = (spec: Specification<InvitationRoot>): Effect.Effect<InvitationRoot | null> =>
+      Effect.map(matching(spec), (rows) => rows[0] ?? null);
 
-    return InvitationRepository.of({
-      insertOne,
-      updateOne,
-      findOneById,
-      findOneByToken,
-      findManyByOrganizationId,
-      findOneOpenByOrganizationIdAndEmail,
-    });
+    const findMany = (
+      spec: Specification<InvitationRoot>,
+    ): Effect.Effect<ReadonlyArray<InvitationRoot>> => matching(spec);
+
+    return InvitationRepository.of({ insertOne, updateOne, findOne, findMany });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-live.integration.test.ts
@@ -10,14 +10,13 @@ import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import { beforeEach } from "vitest";
 
-import {
-  InvitationNotFound,
-  InvitationTokenNotFound,
-} from "@/modules/organization/domain/invitation/invitation.errors.js";
+import { InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import { InvitationRootOps } from "@/modules/organization/domain/invitation/invitation.root-ops.js";
+import { InvitationSpecifications } from "@/modules/organization/domain/invitation/invitation.specification.js";
 import { InvitationRepositoryLive } from "@/modules/organization/infrastructure/repositories/invitation.repository-live.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { InvitationId } from "@/platform/ids/invitation-id.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -53,6 +52,12 @@ const seed = (): InvitationRoot =>
     now,
   }).invitation;
 
+const openForAlice = Spec.and(
+  InvitationSpecifications.forOrganization(orgId),
+  InvitationSpecifications.withInviteeEmail("alice@example.com"),
+  InvitationSpecifications.isOpen,
+);
+
 const TestLayer = InvitationRepositoryLive.pipe(Layer.provideMerge(TestDatabaseLive));
 
 const suite = describe.sequential;
@@ -66,46 +71,27 @@ suite("InvitationRepositoryLive (integration)", () => {
     );
   });
 
-  describe("insert + findOneById + findOneByToken", () => {
+  describe("insert + findOne (by id, by token)", () => {
     it.effect("round-trips an inserted invitation by id and by token", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
         yield* repo.insertOne(seed());
-        const byId = yield* repo.findOneById(invitationId);
-        deepStrictEqual(byId.id, invitationId);
-        const byToken = yield* repo.findOneByToken("tok-abc");
-        deepStrictEqual(byToken.id, invitationId);
+        const byId = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+        deepStrictEqual(byId?.id, invitationId);
+        const byToken = yield* repo.findOne(InvitationSpecifications.withToken("tok-abc"));
+        deepStrictEqual(byToken?.id, invitationId);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findOneById fails InvitationNotFound for an unknown id", () =>
+    it.effect("findOne returns null for an unknown id or token (absence is not an error)", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
-        const exit = yield* Effect.exit(repo.findOneById(invitationId));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof InvitationNotFound, true);
-        }
-      }).pipe(Effect.provide(TestLayer)),
-    );
-
-    it.effect("findOneByToken fails InvitationTokenNotFound for an unknown token", () =>
-      Effect.gen(function* () {
-        yield* seedOrg;
-        const repo = yield* InvitationRepository;
-        const exit = yield* Effect.exit(repo.findOneByToken("missing"));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof InvitationTokenNotFound, true);
-        }
+        const byId = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+        const byToken = yield* repo.findOne(InvitationSpecifications.withToken("missing"));
+        deepStrictEqual(byId, null);
+        deepStrictEqual(byToken, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
@@ -119,7 +105,8 @@ suite("InvitationRepositoryLive (integration)", () => {
         const accepted = InvitationRootOps.accept(seed(), { userId, now });
         if (Result.isFailure(accepted)) throw new Error("expected Right");
         yield* repo.updateOne(accepted.success.invitation);
-        const found = yield* repo.findOneById(invitationId);
+        const found = yield* repo.findOne(InvitationSpecifications.withId(invitationId));
+        if (found === null) throw new Error("expected invitation");
         deepStrictEqual(found.acceptedAt !== null, true);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -139,7 +126,8 @@ suite("InvitationRepositoryLive (integration)", () => {
         yield* repo.updateOne(reissued.success.invitation);
 
         // The new token must resolve...
-        const byNew = yield* repo.findOneByToken("tok-rotated");
+        const byNew = yield* repo.findOne(InvitationSpecifications.withToken("tok-rotated"));
+        if (byNew === null) throw new Error("expected invitation");
         deepStrictEqual(byNew.id, invitationId);
         deepStrictEqual(
           DateTime.toEpochMillis(byNew.expiresAt),
@@ -147,14 +135,8 @@ suite("InvitationRepositoryLive (integration)", () => {
         );
 
         // ...and the old token must no longer resolve.
-        const exit = yield* Effect.exit(repo.findOneByToken("tok-abc"));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof InvitationTokenNotFound, true);
-        }
+        const byOld = yield* repo.findOne(InvitationSpecifications.withToken("tok-abc"));
+        deepStrictEqual(byOld, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 
@@ -174,10 +156,38 @@ suite("InvitationRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findManyByOrganizationId", () => {
+  describe("findOne / findMany by specification", () => {
     const secondId = InvitationId.make("44444444-4444-4444-4444-444444444445");
 
-    it.effect("returns all invitations for the org, newest first", () =>
+    it.effect("findOne compiles a composed spec (org + email + open) to SQL", () =>
+      Effect.gen(function* () {
+        yield* seedOrg;
+        const repo = yield* InvitationRepository;
+        yield* repo.insertOne(seed());
+        const found = yield* repo.findOne(openForAlice);
+        deepStrictEqual(found?.id, invitationId);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("the open variant is applied in SQL — a revoked invite is excluded", () =>
+      Effect.gen(function* () {
+        yield* seedOrg;
+        const repo = yield* InvitationRepository;
+        yield* repo.insertOne(seed());
+        const revoked = InvitationRootOps.revoke(seed(), { now });
+        if (Result.isFailure(revoked)) throw new Error("expected Right");
+        yield* repo.updateOne(revoked.success.invitation);
+
+        // open spec filters it out...
+        deepStrictEqual(yield* repo.findOne(openForAlice), null);
+        // ...but the row is still there when the spec doesn't demand open.
+        const all = yield* repo.findMany(InvitationSpecifications.forOrganization(orgId));
+        deepStrictEqual(all.length, 1);
+        deepStrictEqual(all[0]?.revokedAt !== null, true);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("findMany(forOrganization) returns every invitation, newest first", () =>
       Effect.gen(function* () {
         yield* seedOrg;
         const repo = yield* InvitationRepository;
@@ -191,55 +201,10 @@ suite("InvitationRepositoryLive (integration)", () => {
           now: DateTime.makeUnsafe(new Date("2026-01-02T00:00:00Z")),
         }).invitation;
         yield* repo.insertOne(later);
-        const all = yield* repo.findManyByOrganizationId(orgId);
+        const all = yield* repo.findMany(InvitationSpecifications.forOrganization(orgId));
         deepStrictEqual(all.length, 2);
-        // ORDER BY created_at DESC → bob (later) first.
         deepStrictEqual(all[0]?.id, secondId);
         deepStrictEqual(all[1]?.id, invitationId);
-      }).pipe(Effect.provide(TestLayer)),
-    );
-
-    it.effect("returns an empty array for an org with no invitations", () =>
-      Effect.gen(function* () {
-        yield* seedOrg;
-        const repo = yield* InvitationRepository;
-        const all = yield* repo.findManyByOrganizationId(orgId);
-        deepStrictEqual(all.length, 0);
-      }).pipe(Effect.provide(TestLayer)),
-    );
-  });
-
-  describe("findOneOpenByOrganizationIdAndEmail", () => {
-    it.effect("finds an open invitation by (org, email)", () =>
-      Effect.gen(function* () {
-        yield* seedOrg;
-        const repo = yield* InvitationRepository;
-        yield* repo.insertOne(seed());
-        const found = yield* repo.findOneOpenByOrganizationIdAndEmail(orgId, "alice@example.com");
-        deepStrictEqual(found?.id, invitationId);
-      }).pipe(Effect.provide(TestLayer)),
-    );
-
-    it.effect("returns null when the only invitation is revoked (not open)", () =>
-      Effect.gen(function* () {
-        yield* seedOrg;
-        const repo = yield* InvitationRepository;
-        yield* repo.insertOne(seed());
-        const revoked = InvitationRootOps.revoke(seed(), { now });
-        if (Result.isFailure(revoked)) throw new Error("expected Right");
-        yield* repo.updateOne(revoked.success.invitation);
-        const found = yield* repo.findOneOpenByOrganizationIdAndEmail(orgId, "alice@example.com");
-        deepStrictEqual(found, null);
-      }).pipe(Effect.provide(TestLayer)),
-    );
-
-    it.effect("returns null when no invitation matches the email", () =>
-      Effect.gen(function* () {
-        yield* seedOrg;
-        const repo = yield* InvitationRepository;
-        yield* repo.insertOne(seed());
-        const found = yield* repo.findOneOpenByOrganizationIdAndEmail(orgId, "nobody@example.com");
-        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/invitation.repository-live.ts
@@ -2,15 +2,12 @@ import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import {
-  InvitationNotFound,
-  InvitationTokenNotFound,
-} from "@/modules/organization/domain/invitation/invitation.errors.js";
+import { InvitationNotFound } from "@/modules/organization/domain/invitation/invitation.errors.js";
 import { InvitationRepository } from "@/modules/organization/domain/invitation/invitation.repository.js";
 import { type InvitationRoot } from "@/modules/organization/domain/invitation/invitation.root.js";
 import * as InvitationMapper from "@/modules/organization/infrastructure/repositories/invitation.mapper.js";
-import { type InvitationId } from "@/platform/ids/invitation-id.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 export const InvitationRepositoryLive = Layer.effect(
@@ -71,77 +68,41 @@ export const InvitationRepositoryLive = Layer.effect(
       );
     });
 
-    const findOneById = db.makeQuery((execute, id: InvitationId) =>
+    // The spec contributes only the WHERE; the repository owns FROM, the
+    // newest-first ordering, and the projection. `LIMIT 1` is safe because
+    // every spec used with findOne selects at most one row (identity keys, or
+    // the at-most-one open invite per org+email).
+    const findOne = db.makeQuery((execute, spec: Specification<InvitationRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.InvitationRowStd)`
-          SELECT * FROM "organization".invitations WHERE id = ${id}
+          SELECT * FROM "organization".invitations
+          WHERE ${criteriaToWhere(spec.criteria, InvitationMapper.columns)}
+          ORDER BY created_at DESC
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new InvitationNotFound({ invitationId: id })),
-        Effect.map(InvitationMapper.toDomain),
+        Effect.map((row) => (row === null ? null : InvitationMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.findOneById"),
+        Effect.withSpan("InvitationRepository.findOne"),
       ),
     );
 
-    const findOneByToken = db.makeQuery((execute, token: string) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.InvitationRowStd)`
-          SELECT * FROM "organization".invitations WHERE token = ${token}
-        `),
-      ).pipe(
-        orFail(() => new InvitationTokenNotFound()),
-        Effect.map(InvitationMapper.toDomain),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.findOneByToken"),
-      ),
-    );
-
-    const findManyByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
+    const findMany = db.makeQuery((execute, spec: Specification<InvitationRoot>) =>
       execute((client) =>
         client.any(sql.type(RowSchemas.InvitationRowStd)`
           SELECT * FROM "organization".invitations
-          WHERE organization_id = ${organizationId}
+          WHERE ${criteriaToWhere(spec.criteria, InvitationMapper.columns)}
           ORDER BY created_at DESC
         `),
       ).pipe(
         Effect.map((rows) => rows.map(InvitationMapper.toDomain)),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("InvitationRepository.findManyByOrganizationId"),
+        Effect.withSpan("InvitationRepository.findMany"),
       ),
     );
 
-    const findOneOpenByOrganizationIdAndEmail = db.makeQuery(
-      (execute, args: { organizationId: OrganizationId; inviteeEmail: string }) =>
-        execute((client) =>
-          client.maybeOne(sql.type(RowSchemas.InvitationRowStd)`
-            SELECT * FROM "organization".invitations
-            WHERE organization_id = ${args.organizationId}
-              AND invitee_email = ${args.inviteeEmail}
-              AND accepted_at IS NULL
-              AND revoked_at IS NULL
-            ORDER BY created_at DESC
-            LIMIT 1
-          `),
-        ).pipe(
-          Effect.map((row) => (row === null ? null : InvitationMapper.toDomain(row))),
-          Effect.catchTag("DatabaseError", Effect.die),
-          translatePersistenceUnavailable,
-          Effect.withSpan("InvitationRepository.findOneOpenByOrganizationIdAndEmail"),
-        ),
-    );
-
-    return InvitationRepository.of({
-      insertOne,
-      updateOne,
-      findOneById,
-      findOneByToken,
-      findManyByOrganizationId,
-      findOneOpenByOrganizationIdAndEmail: (organizationId, inviteeEmail) =>
-        findOneOpenByOrganizationIdAndEmail({ organizationId, inviteeEmail }),
-    });
+    return InvitationRepository.of({ insertOne, updateOne, findOne, findMany });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/membership.mapper.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/membership.mapper.ts
@@ -4,8 +4,17 @@ import * as DateTime from "effect/DateTime";
 import { MembershipRoot } from "@/modules/organization/domain/membership/membership.root.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.MembershipRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of "organization".memberships. Only filterable scalar
+// fields need an entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  userId: "user_id",
+  organizationId: "organization_id",
+} as const satisfies Partial<Record<keyof MembershipRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): MembershipRoot =>
   new MembershipRoot({

--- a/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-fake.test.ts
@@ -9,6 +9,8 @@ import * as Option from "effect/Option";
 import { MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { MembershipRootOps } from "@/modules/organization/domain/membership/membership.root-ops.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -20,13 +22,17 @@ const organizationId = OrganizationId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
 const now = DateTime.makeUnsafe(new Date("2026-01-01T00:00:00Z"));
 const provide = Effect.provide(MembershipRepositoryFake);
 
+const byPair = (u: UserId, o: OrganizationId) =>
+  Spec.and(MembershipSpecifications.forUser(u), MembershipSpecifications.forOrganization(o));
+
 describe("MembershipRepositoryFake", () => {
-  it.effect("findOneByUserIdAndOrgId round-trips an inserted membership", () =>
+  it.effect("findOne by pair spec round-trips an inserted membership", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = MembershipRootOps.create({ userId, organizationId, now });
       yield* repo.insertOne(membership);
-      const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
+      const found = yield* repo.findOne(byPair(userId, organizationId));
+      if (found === null) throw new Error("expected membership");
       deepStrictEqual(found.userId, userId);
       deepStrictEqual(found.organizationId, organizationId);
     }).pipe(provide),
@@ -38,33 +44,28 @@ describe("MembershipRepositoryFake", () => {
       const { membership } = MembershipRootOps.create({ userId, organizationId, now });
       yield* repo.insertOne(membership);
       yield* repo.insertOne(membership);
-      const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
+      const found = yield* repo.findOne(byPair(userId, organizationId));
+      if (found === null) throw new Error("expected membership");
       deepStrictEqual(found.userId, userId);
     }).pipe(provide),
   );
 
-  it.effect("findOneByUserIdAndOrgId fails MembershipNotFound when absent", () =>
+  it.effect("findOne returns null when absent", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
-      const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(userId, organizationId));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof MembershipNotFound, true);
-      }
+      const found = yield* repo.findOne(byPair(userId, organizationId));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 
-  it.effect("delete removes the row; subsequent find fails MembershipNotFound", () =>
+  it.effect("delete removes the row; subsequent find returns null", () =>
     Effect.gen(function* () {
       const repo = yield* MembershipRepository;
       const { membership } = MembershipRootOps.create({ userId, organizationId, now });
       yield* repo.insertOne(membership);
       yield* repo.deleteOne(userId, organizationId);
-      const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(userId, organizationId));
-      deepStrictEqual(Exit.isFailure(exit), true);
+      const found = yield* repo.findOne(byPair(userId, organizationId));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 
@@ -87,8 +88,8 @@ describe("MembershipRepositoryFake", () => {
       const repo = yield* MembershipRepository;
       const { membership } = MembershipRootOps.create({ userId, organizationId, now });
       yield* repo.insertOne(membership);
-      const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(otherUserId, organizationId));
-      deepStrictEqual(Exit.isFailure(exit), true);
+      const found = yield* repo.findOne(byPair(otherUserId, organizationId));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 });

--- a/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-fake.ts
@@ -6,6 +6,7 @@ import * as Ref from "effect/Ref";
 import { MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { type MembershipRoot } from "@/modules/organization/domain/membership/membership.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
@@ -38,29 +39,15 @@ export const MembershipRepositoryFake = Layer.effect(
         return Ref.update(store, HashMap.remove(k));
       });
 
-    const findOneByUserIdAndOrgId = (
-      userId: UserId,
-      organizationId: OrganizationId,
-    ): Effect.Effect<MembershipRoot, MembershipNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        const found = HashMap.get(m, key(userId, organizationId));
-        return found._tag === "Some"
-          ? Effect.succeed(found.value)
-          : Effect.fail(new MembershipNotFound({ userId, organizationId }));
-      });
-
-    const findManyByOrganizationId = (
-      organizationId: OrganizationId,
-    ): Effect.Effect<ReadonlyArray<MembershipRoot>> =>
-      Effect.map(Ref.get(store), (m) =>
-        Array.from(HashMap.values(m)).filter((mem) => mem.organizationId === organizationId),
-      );
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (spec: Specification<MembershipRoot>): Effect.Effect<MembershipRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
     return MembershipRepository.of({
       insertOne,
       deleteOne: deleteRow,
-      findOneByUserIdAndOrgId,
-      findManyByOrganizationId,
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-live.integration.test.ts
@@ -12,7 +12,9 @@ import { beforeEach } from "vitest";
 import { MembershipNotFound } from "@/modules/organization/domain/membership/membership.errors.js";
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { MembershipRootOps } from "@/modules/organization/domain/membership/membership.root-ops.js";
+import { MembershipSpecifications } from "@/modules/organization/domain/membership/membership.specification.js";
 import { MembershipRepositoryLive } from "@/modules/organization/infrastructure/repositories/membership.repository-live.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -21,6 +23,9 @@ const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const otherUserId = UserId.make("22222222-2222-2222-2222-222222222222");
 const organizationId = OrganizationId.make("33333333-3333-3333-3333-333333333333");
 const now = DateTime.makeUnsafe(new Date("2026-01-01T00:00:00Z"));
+
+const byPair = (u: UserId, o: OrganizationId) =>
+  Spec.and(MembershipSpecifications.forUser(u), MembershipSpecifications.forOrganization(o));
 
 // organization.memberships FKs to "user".users(id) and
 // organization.organizations(id) — seed both via raw SQL since neither
@@ -59,14 +64,15 @@ suite("MembershipRepositoryLive (integration)", () => {
     );
   });
 
-  describe("insert + findOneByUserIdAndOrgId", () => {
+  describe("insert + findOne", () => {
     it.effect("round-trips an inserted membership", () =>
       Effect.gen(function* () {
         yield* seedFks;
         const repo = yield* MembershipRepository;
         const { membership } = MembershipRootOps.create({ userId, organizationId, now });
         yield* repo.insertOne(membership);
-        const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
+        const found = yield* repo.findOne(byPair(userId, organizationId));
+        if (found === null) throw new Error("expected membership");
         deepStrictEqual(found.userId, userId);
         deepStrictEqual(found.organizationId, organizationId);
       }).pipe(Effect.provide(TestLayer)),
@@ -79,37 +85,32 @@ suite("MembershipRepositoryLive (integration)", () => {
         const { membership } = MembershipRootOps.create({ userId, organizationId, now });
         yield* repo.insertOne(membership);
         yield* repo.insertOne(membership);
-        const found = yield* repo.findOneByUserIdAndOrgId(userId, organizationId);
+        const found = yield* repo.findOne(byPair(userId, organizationId));
+        if (found === null) throw new Error("expected membership");
         deepStrictEqual(found.userId, userId);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findOneByUserIdAndOrgId fails MembershipNotFound for an unknown pair", () =>
+    it.effect("findOne returns null for an unknown pair", () =>
       Effect.gen(function* () {
         yield* seedFks;
         const repo = yield* MembershipRepository;
-        const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(otherUserId, organizationId));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof MembershipNotFound, true);
-        }
+        const found = yield* repo.findOne(byPair(otherUserId, organizationId));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
 
   describe("delete", () => {
-    it.effect("removes the row; subsequent find fails MembershipNotFound", () =>
+    it.effect("removes the row; subsequent find returns null", () =>
       Effect.gen(function* () {
         yield* seedFks;
         const repo = yield* MembershipRepository;
         const { membership } = MembershipRootOps.create({ userId, organizationId, now });
         yield* repo.insertOne(membership);
         yield* repo.deleteOne(userId, organizationId);
-        const exit = yield* Effect.exit(repo.findOneByUserIdAndOrgId(userId, organizationId));
-        deepStrictEqual(Exit.isFailure(exit), true);
+        const found = yield* repo.findOne(byPair(userId, organizationId));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 

--- a/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/membership.repository-live.ts
@@ -6,8 +6,10 @@ import { MembershipNotFound } from "@/modules/organization/domain/membership/mem
 import { MembershipRepository } from "@/modules/organization/domain/membership/membership.repository.js";
 import { type MembershipRoot } from "@/modules/organization/domain/membership/membership.root.js";
 import * as MembershipMapper from "@/modules/organization/infrastructure/repositories/membership.mapper.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 import { type UserId } from "@/platform/ids/user-id.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 export const MembershipRepositoryLive = Layer.effect(
@@ -65,53 +67,28 @@ export const MembershipRepositoryLive = Layer.effect(
         ),
     );
 
-    const findOneByUserIdAndOrgId = db.makeQuery(
-      (execute, args: { userId: UserId; organizationId: OrganizationId }) =>
-        execute((client) =>
-          client.maybeOne(sql.type(RowSchemas.MembershipRowStd)`
-            SELECT * FROM "organization".memberships
-            WHERE user_id = ${args.userId}
-              AND organization_id = ${args.organizationId}
-          `),
-        ).pipe(
-          Effect.flatMap((row) =>
-            row === null
-              ? Effect.fail(
-                  new MembershipNotFound({
-                    userId: args.userId,
-                    organizationId: args.organizationId,
-                  }),
-                )
-              : Effect.succeed(MembershipMapper.toDomain(row)),
-          ),
-          Effect.catchTag("DatabaseError", Effect.die),
-          translatePersistenceUnavailable,
-          Effect.withSpan("MembershipRepository.findOneByUserIdAndOrgId"),
-        ),
-    );
-
-    const findManyByOrganizationId = db.makeQuery(
-      (execute, args: { organizationId: OrganizationId }) =>
-        execute((client) =>
-          client.any(sql.type(RowSchemas.MembershipRowStd)`
-            SELECT * FROM "organization".memberships
-            WHERE organization_id = ${args.organizationId}
-            ORDER BY created_at ASC
-          `),
-        ).pipe(
-          Effect.map((rows) => rows.map(MembershipMapper.toDomain)),
-          Effect.catchTag("DatabaseError", Effect.die),
-          translatePersistenceUnavailable,
-          Effect.withSpan("MembershipRepository.findManyByOrganizationId"),
-        ),
+    // The spec contributes only the WHERE (the composite identity); the
+    // repository owns FROM and projection. `LIMIT 1` is safe because the
+    // composite key selects at most one row.
+    const findOne = db.makeQuery((execute, spec: Specification<MembershipRoot>) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.MembershipRowStd)`
+          SELECT * FROM "organization".memberships
+          WHERE ${criteriaToWhere(spec.criteria, MembershipMapper.columns)}
+          LIMIT 1
+        `),
+      ).pipe(
+        Effect.map((row) => (row === null ? null : MembershipMapper.toDomain(row))),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("MembershipRepository.findOne"),
+      ),
     );
 
     return MembershipRepository.of({
       insertOne,
       deleteOne: (userId, organizationId) => deleteRow({ userId, organizationId }),
-      findOneByUserIdAndOrgId: (userId, organizationId) =>
-        findOneByUserIdAndOrgId({ userId, organizationId }),
-      findManyByOrganizationId: (organizationId) => findManyByOrganizationId({ organizationId }),
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.mapper.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.mapper.ts
@@ -5,8 +5,11 @@ import {
   IssuedRoleValueObject,
   OrganizationRolesRoot,
 } from "@/modules/organization/domain/organization-roles/organization-roles.root.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
+
+type Row = RowSchemas.OrganizationRoleRow;
 
 // Closed set of recognized role names. Mirrors the `OrganizationRoleValueObject`
 // Schema literal in `domain/organization-roles/organization-role.value-object.ts` — adding a new role
@@ -15,20 +18,25 @@ const KNOWN_ROLES = new Set<string>(["admin"]);
 
 const narrow = (role: string): role is OrganizationRoleValueObject => KNOWN_ROLES.has(role);
 
-// Builds an `OrganizationRolesRoot` aggregate from raw
-// `organization.organization_roles` rows. The caller (the live
-// repository) groups rows by `(user_id, organization_id)` and hands
-// the slice for one pair here. Unknown role strings (never inserted by
-// application code) are filtered out rather than crashing the read —
-// defense in depth, same pattern as `role-mapper.ts`.
-export const toDomain = (
-  userId: UserId,
-  organizationId: OrganizationId,
-  rows: ReadonlyArray<RowSchemas.OrganizationRoleRow>,
-): OrganizationRolesRoot =>
-  OrganizationRolesRoot.make({
-    userId,
-    organizationId,
+// Field → column map for spec translation. Only the composite-key fields are
+// filterable; `roles` is a child collection with no scalar column, which is why
+// `hasRole` stays an eval-only Predicate and never reaches this map.
+export const columns = {
+  userId: "user_id",
+  organizationId: "organization_id",
+} as const satisfies Partial<Record<keyof OrganizationRolesRoot, string>> & ColumnMap;
+
+// Reconstitutes ONE aggregate from the rows the repository fetched for a single
+// (user, org) pair. Zero rows → `null`; the caller decides that "no rows" means
+// an empty aggregate. Identity is read from the rows themselves — every row of
+// the aggregate carries the composite key. Unknown role strings (never inserted
+// by application code) are filtered out rather than crashing the read.
+export const toDomain = (rows: ReadonlyArray<Row>): OrganizationRolesRoot | null => {
+  const first = rows[0];
+  if (first === undefined) return null;
+  return OrganizationRolesRoot.make({
+    userId: UserId.make(first.user_id),
+    organizationId: OrganizationId.make(first.organization_id),
     roles: rows
       .filter((r) => narrow(r.role))
       .map((r) =>
@@ -38,3 +46,4 @@ export const toDomain = (
         }),
       ),
   });
+};

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-fake.test.ts
@@ -5,6 +5,8 @@ import * as Result from "effect/Result";
 
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
 import { OrganizationRolesRootOps } from "@/modules/organization/domain/organization-roles/organization-roles.root-ops.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -14,18 +16,21 @@ const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
 
+const forPair = Spec.and(
+  OrganizationRolesSpecifications.forUser(userId),
+  OrganizationRolesSpecifications.forOrganization(orgId),
+);
+
 describe("OrganizationRolesRepositoryFake", () => {
-  it.effect("returns an empty aggregate for a previously-unseen (user, org) pair", () =>
+  it.effect("findOne returns null for a previously-unseen (user, org) pair", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRolesRepository;
-      const roles = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
-      deepStrictEqual(roles.userId, userId);
-      deepStrictEqual(roles.organizationId, orgId);
-      deepStrictEqual([...roles.roles], []);
+      const roles = yield* repo.findOne(forPair);
+      deepStrictEqual(roles, null);
     }).pipe(Effect.provide(OrganizationRolesRepositoryFake)),
   );
 
-  it.effect("round-trips a saved aggregate via findOneByUserIdAndOrgId", () =>
+  it.effect("round-trips a saved aggregate via findOne", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRolesRepository;
       const granted = OrganizationRolesRootOps.grantRole(
@@ -35,7 +40,8 @@ describe("OrganizationRolesRepositoryFake", () => {
       );
       if (Result.isFailure(granted)) throw new Error("expected Right");
       yield* repo.upsertOne(granted.success.organizationRoles);
-      const fetched = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
+      const fetched = yield* repo.findOne(forPair);
+      if (fetched === null) throw new Error("expected aggregate");
       deepStrictEqual(
         fetched.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
         [{ role: "admin", issuedBy }],

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-fake.ts
@@ -5,7 +5,7 @@ import * as Ref from "effect/Ref";
 
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
 import { type OrganizationRolesRoot } from "@/modules/organization/domain/organization-roles/organization-roles.root.js";
-import { OrganizationRolesRootOps } from "@/modules/organization/domain/organization-roles/organization-roles.root-ops.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
@@ -23,26 +23,29 @@ export const OrganizationRolesRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<string, OrganizationRolesRoot>());
 
+    // Mirror the live repo's row model: it persists as DELETE-then-INSERT, so
+    // an aggregate with no roles leaves zero rows — indistinguishable from an
+    // absent one. Storing an empty aggregate here would make findOne return it
+    // where the live repo returns null, so an empty upsert deletes the entry.
     const upsertOne = (organizationRoles: OrganizationRolesRoot): Effect.Effect<void> =>
       Ref.update(
         store,
-        HashMap.set(
-          key(organizationRoles.userId, organizationRoles.organizationId),
-          organizationRoles,
-        ),
+        organizationRoles.roles.length === 0
+          ? HashMap.remove(key(organizationRoles.userId, organizationRoles.organizationId))
+          : HashMap.set(
+              key(organizationRoles.userId, organizationRoles.organizationId),
+              organizationRoles,
+            ),
       );
 
-    const findOneByUserIdAndOrgId = (
-      userId: UserId,
-      organizationId: OrganizationId,
-    ): Effect.Effect<OrganizationRolesRoot> =>
-      Effect.map(Ref.get(store), (m) => {
-        const found = HashMap.get(m, key(userId, organizationId));
-        return found._tag === "Some"
-          ? found.value
-          : OrganizationRolesRootOps.empty(userId, organizationId);
-      });
+    // The spec is the in-memory predicate over the whole aggregate — the same
+    // object the live repo compiles to SQL. Absence is `null`; the caller maps
+    // it to an empty aggregate.
+    const findOne = (
+      spec: Specification<OrganizationRolesRoot>,
+    ): Effect.Effect<OrganizationRolesRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    return OrganizationRolesRepository.of({ upsertOne, findOneByUserIdAndOrgId });
+    return OrganizationRolesRepository.of({ upsertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-live.integration.test.ts
@@ -8,7 +8,9 @@ import { beforeEach } from "vitest";
 
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
 import { OrganizationRolesRootOps } from "@/modules/organization/domain/organization-roles/organization-roles.root-ops.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
 import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-live.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -16,6 +18,11 @@ import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 const orgId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
 const issuedBy = UserId.make("99999999-9999-9999-9999-999999999999");
+
+const forPair = Spec.and(
+  OrganizationRolesSpecifications.forUser(userId),
+  OrganizationRolesSpecifications.forOrganization(orgId),
+);
 
 // organization.organization_roles FKs to "user".users(id) (twice — for
 // user_id + issued_by) and organization.organizations(id). Each test
@@ -62,15 +69,13 @@ suite("OrganizationRolesRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findOneByUserIdAndOrgId", () => {
-    it.effect("returns an empty aggregate when no rows exist", () =>
+  describe("findOne", () => {
+    it.effect("returns null when no rows exist (the empty case is the caller's)", () =>
       Effect.gen(function* () {
         yield* seedFixtures;
         const repo = yield* OrganizationRolesRepository;
-        const roles = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
-        deepStrictEqual(roles.userId, userId);
-        deepStrictEqual(roles.organizationId, orgId);
-        deepStrictEqual([...roles.roles], []);
+        const roles = yield* repo.findOne(forPair);
+        deepStrictEqual(roles, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
@@ -87,7 +92,8 @@ suite("OrganizationRolesRepositoryLive (integration)", () => {
         );
         if (Result.isFailure(granted)) throw new Error("expected Right");
         yield* repo.upsertOne(granted.success.organizationRoles);
-        const fetched = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
+        const fetched = yield* repo.findOne(forPair);
+        if (fetched === null) throw new Error("expected aggregate");
         deepStrictEqual(
           fetched.roles.map((r) => ({ role: r.role, issuedBy: r.issuedBy })),
           [{ role: "admin", issuedBy }],
@@ -112,8 +118,10 @@ suite("OrganizationRolesRepositoryLive (integration)", () => {
         );
         if (Result.isFailure(revoked)) throw new Error("expected Right");
         yield* repo.upsertOne(revoked.success.organizationRoles);
-        const fetched = yield* repo.findOneByUserIdAndOrgId(userId, orgId);
-        deepStrictEqual([...fetched.roles], []);
+        // Revoking the last role deletes every row, so there is nothing to
+        // reconstitute — findOne reports null (no rows = no roles).
+        const fetched = yield* repo.findOne(forPair);
+        deepStrictEqual(fetched, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization-roles.repository-live.ts
@@ -6,8 +6,8 @@ import * as Option from "effect/Option";
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
 import { type OrganizationRolesRoot } from "@/modules/organization/domain/organization-roles/organization-roles.root.js";
 import * as OrganizationRolesMapper from "@/modules/organization/infrastructure/repositories/organization-roles.mapper.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 export const OrganizationRolesRepositoryLive = Layer.effect(
@@ -64,29 +64,25 @@ export const OrganizationRolesRepositoryLive = Layer.effect(
         Effect.withSpan("OrganizationRolesRepository.upsertOne"),
       );
 
-    const findOneByUserIdAndOrgId = db.makeQuery(
-      (execute, args: { userId: UserId; organizationId: OrganizationId }) =>
-        execute((client) =>
-          client.any(sql.type(RowSchemas.OrganizationRoleRowStd)`
-            SELECT organization_id, user_id, role, issued_by, created_at
-            FROM "organization".organization_roles
-            WHERE user_id = ${args.userId}
-              AND organization_id = ${args.organizationId}
-          `),
-        ).pipe(
-          Effect.map((rows) =>
-            OrganizationRolesMapper.toDomain(args.userId, args.organizationId, rows),
-          ),
-          Effect.catchTag("DatabaseError", Effect.die),
-          translatePersistenceUnavailable,
-          Effect.withSpan("OrganizationRolesRepository.findOneByUserIdAndOrgId"),
-        ),
+    // The spec pins the composite key, so every matched row belongs to one
+    // aggregate; the mapper groups them (or returns null for zero rows). The
+    // compiler contributes only the WHERE — this repo owns the projection and,
+    // for a multi-row aggregate, the reconstitution.
+    const findOne = db.makeQuery((execute, spec: Specification<OrganizationRolesRoot>) =>
+      execute((client) =>
+        client.any(sql.type(RowSchemas.OrganizationRoleRowStd)`
+          SELECT organization_id, user_id, role, issued_by, created_at
+          FROM "organization".organization_roles
+          WHERE ${criteriaToWhere(spec.criteria, OrganizationRolesMapper.columns)}
+        `),
+      ).pipe(
+        Effect.map((rows) => OrganizationRolesMapper.toDomain(rows)),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("OrganizationRolesRepository.findOne"),
+      ),
     );
 
-    return OrganizationRolesRepository.of({
-      upsertOne,
-      findOneByUserIdAndOrgId: (userId, organizationId) =>
-        findOneByUserIdAndOrgId({ userId, organizationId }),
-    });
+    return OrganizationRolesRepository.of({ upsertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization.mapper.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization.mapper.ts
@@ -3,8 +3,17 @@ import * as DateTime from "effect/DateTime";
 
 import { OrganizationRoot } from "@/modules/organization/domain/organization/organization.root.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.OrganizationRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of "organization".organizations. Only filterable scalar
+// fields need an entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+  deletedAt: "deleted_at",
+} as const satisfies Partial<Record<keyof OrganizationRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): OrganizationRoot =>
   new OrganizationRoot({

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-fake.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-fake.test.ts
@@ -10,9 +10,14 @@ import * as Result from "effect/Result";
 import { OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
 import { OrganizationRootOps } from "@/modules/organization/domain/organization/organization.root-ops.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 
 import { OrganizationRepositoryFake } from "./organization.repository-fake.js";
+
+const activeById = (id: OrganizationId) =>
+  Spec.and(OrganizationSpecifications.withId(id), OrganizationSpecifications.notDeleted);
 
 const id = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const now = DateTime.makeUnsafe(new Date("2026-01-01T00:00:00Z"));
@@ -20,18 +25,19 @@ const later = DateTime.makeUnsafe(new Date("2026-02-01T00:00:00Z"));
 const provide = Effect.provide(OrganizationRepositoryFake);
 
 describe("OrganizationRepositoryFake", () => {
-  it.effect("findOneById round-trips an inserted org", () =>
+  it.effect("findOne by active-id spec round-trips an inserted org", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
       yield* repo.insertOne(organization);
-      const found = yield* repo.findOneById(id);
+      const found = yield* repo.findOne(activeById(id));
+      if (found === null) throw new Error("expected organization");
       deepStrictEqual(found.id, id);
       deepStrictEqual(found.name, "Acme");
     }).pipe(provide),
   );
 
-  it.effect("findOneById hides soft-deleted rows", () =>
+  it.effect("the active-id spec hides soft-deleted rows", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
@@ -39,18 +45,12 @@ describe("OrganizationRepositoryFake", () => {
       const deletedEither = OrganizationRootOps.softDelete(organization, { now: later });
       if (Result.isFailure(deletedEither)) throw new Error("expected Right");
       yield* repo.updateOne(deletedEither.success.organization);
-      const exit = yield* Effect.exit(repo.findOneById(id));
-      deepStrictEqual(Exit.isFailure(exit), true);
-      if (Exit.isFailure(exit)) {
-        const error = Cause.hasFails(exit.cause)
-          ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-          : null;
-        deepStrictEqual(error instanceof OrganizationNotFound, true);
-      }
+      const found = yield* repo.findOne(activeById(id));
+      deepStrictEqual(found, null);
     }).pipe(provide),
   );
 
-  it.effect("findOneByIdIncludingDeleted returns soft-deleted rows", () =>
+  it.effect("the withId spec returns soft-deleted rows", () =>
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository;
       const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
@@ -58,7 +58,8 @@ describe("OrganizationRepositoryFake", () => {
       const deletedEither = OrganizationRootOps.softDelete(organization, { now: later });
       if (Result.isFailure(deletedEither)) throw new Error("expected Right");
       yield* repo.updateOne(deletedEither.success.organization);
-      const found = yield* repo.findOneByIdIncludingDeleted(id);
+      const found = yield* repo.findOne(OrganizationSpecifications.withId(id));
+      if (found === null) throw new Error("expected organization");
       deepStrictEqual(found.deletedAt !== null, true);
     }).pipe(provide),
   );

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-fake.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-fake.ts
@@ -6,6 +6,7 @@ import * as Ref from "effect/Ref";
 import { OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
 import { type OrganizationRoot } from "@/modules/organization/domain/organization/organization.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 export const OrganizationRepositoryFake = Layer.effect(
@@ -23,32 +24,17 @@ export const OrganizationRepositoryFake = Layer.effect(
           : Effect.fail(new OrganizationNotFound({ organizationId: organization.id })),
       );
 
-    const findOneById = (
-      id: OrganizationId,
-    ): Effect.Effect<OrganizationRoot, OrganizationNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        const found = HashMap.get(m, id);
-        if (found._tag === "None" || found.value.deletedAt !== null) {
-          return Effect.fail(new OrganizationNotFound({ organizationId: id }));
-        }
-        return Effect.succeed(found.value);
-      });
-
-    const findOneByIdIncludingDeleted = (
-      id: OrganizationId,
-    ): Effect.Effect<OrganizationRoot, OrganizationNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) => {
-        const found = HashMap.get(m, id);
-        return found._tag === "Some"
-          ? Effect.succeed(found.value)
-          : Effect.fail(new OrganizationNotFound({ organizationId: id }));
-      });
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (
+      spec: Specification<OrganizationRoot>,
+    ): Effect.Effect<OrganizationRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
     return OrganizationRepository.of({
       insertOne,
       updateOne,
-      findOneById,
-      findOneByIdIncludingDeleted,
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-live.integration.test.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-live.integration.test.ts
@@ -12,9 +12,14 @@ import { beforeEach } from "vitest";
 import { OrganizationNotFound } from "@/modules/organization/domain/organization/organization.errors.js";
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
 import { OrganizationRootOps } from "@/modules/organization/domain/organization/organization.root-ops.js";
+import { OrganizationSpecifications } from "@/modules/organization/domain/organization/organization.specification.js";
 import { OrganizationRepositoryLive } from "@/modules/organization/infrastructure/repositories/organization.repository-live.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
+
+const activeById = (id: OrganizationId) =>
+  Spec.and(OrganizationSpecifications.withId(id), OrganizationSpecifications.notDeleted);
 
 const id = OrganizationId.make("11111111-1111-1111-1111-111111111111");
 const now = DateTime.makeUnsafe(new Date("2026-01-01T00:00:00Z"));
@@ -31,36 +36,31 @@ suite("OrganizationRepositoryLive (integration)", () => {
     );
   });
 
-  describe("insert + findOneById", () => {
+  describe("insert + findOne", () => {
     it.effect("round-trips an inserted org", () =>
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
         const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
         yield* repo.insertOne(organization);
-        const found = yield* repo.findOneById(id);
+        const found = yield* repo.findOne(activeById(id));
+        if (found === null) throw new Error("expected organization");
         deepStrictEqual(found.id, id);
         deepStrictEqual(found.name, "Acme");
         deepStrictEqual(found.deletedAt, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("findOneById fails OrganizationNotFound for an unknown id", () =>
+    it.effect("findOne returns null for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
-        const exit = yield* Effect.exit(repo.findOneById(id));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof OrganizationNotFound, true);
-        }
+        const found = yield* repo.findOne(activeById(id));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
 
   describe("update (soft-delete tombstone)", () => {
-    it.effect("findOneById hides a soft-deleted row; findOneByIdIncludingDeleted returns it", () =>
+    it.effect("the active-id spec hides a soft-deleted row; withId returns it", () =>
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository;
         const { organization } = OrganizationRootOps.create({ id, name: "Acme", now });
@@ -69,10 +69,11 @@ suite("OrganizationRepositoryLive (integration)", () => {
         if (Result.isFailure(deletedEither)) throw new Error("expected Right");
         yield* repo.updateOne(deletedEither.success.organization);
 
-        const hiddenExit = yield* Effect.exit(repo.findOneById(id));
-        deepStrictEqual(Exit.isFailure(hiddenExit), true);
+        const hidden = yield* repo.findOne(activeById(id));
+        deepStrictEqual(hidden, null);
 
-        const visible = yield* repo.findOneByIdIncludingDeleted(id);
+        const visible = yield* repo.findOne(OrganizationSpecifications.withId(id));
+        if (visible === null) throw new Error("expected organization");
         deepStrictEqual(visible.deletedAt !== null, true);
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-live.ts
+++ b/packages/server/src/modules/organization/infrastructure/repositories/organization.repository-live.ts
@@ -6,7 +6,8 @@ import { OrganizationNotFound } from "@/modules/organization/domain/organization
 import { OrganizationRepository } from "@/modules/organization/domain/organization/organization.repository.js";
 import { type OrganizationRoot } from "@/modules/organization/domain/organization/organization.root.js";
 import * as OrganizationMapper from "@/modules/organization/infrastructure/repositories/organization.mapper.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 export const OrganizationRepositoryLive = Layer.effect(
@@ -55,48 +56,29 @@ export const OrganizationRepositoryLive = Layer.effect(
       );
     });
 
-    // findOneById hides soft-deleted rows so consumers (commands, the
-    // resource resolver registered for active-only flows) don't have to
-    // remember to filter on `deleted_at IS NULL` themselves.
-    const findOneById = db.makeQuery((execute, id: OrganizationId) =>
+    // The spec contributes only the WHERE (identity, and — for active-only
+    // reads — `deleted_at IS NULL`); the repository owns FROM and projection.
+    // `LIMIT 1` is safe because every spec used with findOne selects at most
+    // one row (identity keys).
+    const findOne = db.makeQuery((execute, spec: Specification<OrganizationRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.OrganizationRowStd)`
           SELECT * FROM "organization".organizations
-          WHERE id = ${id} AND deleted_at IS NULL
+          WHERE ${criteriaToWhere(spec.criteria, OrganizationMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new OrganizationNotFound({ organizationId: id })),
-        Effect.map(OrganizationMapper.toDomain),
+        Effect.map((row) => (row === null ? null : OrganizationMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRepository.findOneById"),
-      ),
-    );
-
-    // Explicit opt-in for the restore path and the super-admin
-    // "include deleted" listing. Keeping the variant separate at the
-    // port level documents that callers had to actively ask for
-    // tombstones — same shape as the `with-deleted` boolean would
-    // collapse to, but more discoverable.
-    const findOneByIdIncludingDeleted = db.makeQuery((execute, id: OrganizationId) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.OrganizationRowStd)`
-          SELECT * FROM "organization".organizations WHERE id = ${id}
-        `),
-      ).pipe(
-        orFail(() => new OrganizationNotFound({ organizationId: id })),
-        Effect.map(OrganizationMapper.toDomain),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("OrganizationRepository.findOneByIdIncludingDeleted"),
+        Effect.withSpan("OrganizationRepository.findOne"),
       ),
     );
 
     return OrganizationRepository.of({
       insertOne,
       updateOne,
-      findOneById,
-      findOneByIdIncludingDeleted,
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/organization/interface/http/soft-delete.endpoint.ts
+++ b/packages/server/src/modules/organization/interface/http/soft-delete.endpoint.ts
@@ -35,7 +35,7 @@ export const softDeleteEndpoint = (
       ),
     ),
     // `OrganizationAlreadyDeleted` is unreachable in practice: the
-    // command's `findOneById` filters tombstoned rows, so a double-delete
+    // command's active-only load filters tombstoned rows, so a double-delete
     // surfaces as `OrganizationNotFound` above. The aggregate-level
     // invariant remains as defense in depth; if it does fire, treat it
     // as a not-found at the wire (same outward effect).

--- a/packages/server/src/modules/organization/policies/organization.resource-resolver.ts
+++ b/packages/server/src/modules/organization/policies/organization.resource-resolver.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import { type Resolver } from "@/platform/auth/resource-resolver-registry.js";
 
 import { OrganizationRepository } from "../domain/organization/organization.repository.js";
+import { OrganizationSpecifications } from "../domain/organization/organization.specification.js";
 import { OrganizationRepositoryLive } from "../infrastructure/repositories/organization.repository-live.js";
 
 // Resolver loads soft-deleted rows too. The restore endpoint
@@ -29,9 +30,11 @@ export const OrganizationResolverEntryLive = Layer.effect(
   Effect.gen(function* () {
     const repo = yield* OrganizationRepository;
     return (id) =>
-      repo.findOneByIdIncludingDeleted(id).pipe(
-        Effect.catchTag("OrganizationNotFound", () =>
-          Effect.fail(new CustomHttpApiError.NotFound()),
+      repo.findOne(OrganizationSpecifications.withId(id)).pipe(
+        Effect.flatMap((organization) =>
+          organization === null
+            ? Effect.fail(new CustomHttpApiError.NotFound())
+            : Effect.succeed(organization),
         ),
         Effect.catchTag("PersistenceUnavailable", Effect.die),
       );

--- a/packages/server/src/modules/organization/policies/public/organization-role.service-live.ts
+++ b/packages/server/src/modules/organization/policies/public/organization-role.service-live.ts
@@ -2,7 +2,9 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 import { OrganizationRolesRepository } from "@/modules/organization/domain/organization-roles/organization-roles.repository.js";
+import { OrganizationRolesSpecifications } from "@/modules/organization/domain/organization-roles/organization-roles.specification.js";
 import { OrganizationRolesRepositoryLive } from "@/modules/organization/infrastructure/repositories/organization-roles.repository-live.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import {
   type OrganizationRoleName,
   OrganizationRoleService,
@@ -23,16 +25,25 @@ export const OrganizationRoleServiceLive = Layer.effect(
     const repo = yield* OrganizationRolesRepository;
     return OrganizationRoleService.of({
       findOrganizationPermissions: (userId, organizationId) =>
-        repo.findOneByUserIdAndOrgId(userId, organizationId).pipe(
-          Effect.map((aggregate) => ({
-            userId: aggregate.userId,
-            organizationId: aggregate.organizationId,
-            roles: aggregate.roles
-              .map((r) => r.role)
-              .filter((r): r is OrganizationRoleName => narrow(r)),
-          })),
-          Effect.withSpan("OrganizationRoleService.findOrganizationPermissions"),
-        ),
+        repo
+          .findOne(
+            Spec.and(
+              OrganizationRolesSpecifications.forUser(userId),
+              OrganizationRolesSpecifications.forOrganization(organizationId),
+            ),
+          )
+          .pipe(
+            // No rows → no roles (the empty-aggregate state); this service only
+            // needs the role names, so it reads them off the aggregate or [].
+            Effect.map((aggregate) => ({
+              userId,
+              organizationId,
+              roles: (aggregate?.roles ?? [])
+                .map((r) => r.role)
+                .filter((r): r is OrganizationRoleName => narrow(r)),
+            })),
+            Effect.withSpan("OrganizationRoleService.findOrganizationPermissions"),
+          ),
     });
   }),
 ).pipe(Layer.provide(OrganizationRolesRepositoryLive));

--- a/packages/server/src/modules/role/commands/grant-role.handler.test.ts
+++ b/packages/server/src/modules/role/commands/grant-role.handler.test.ts
@@ -11,6 +11,7 @@ import { grantRole } from "@/modules/role/commands/grant-role.handler.js";
 import { AlreadyHasRole, CannotPromoteSelf } from "@/modules/role/domain/roles/role.errors.js";
 import { type RoleGranted } from "@/modules/role/domain/roles/role.events.js";
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
+import { RolesSpecifications } from "@/modules/role/domain/roles/roles.specification.js";
 import { RolesRepositoryFake } from "@/modules/role/infrastructure/repositories/roles.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -31,7 +32,8 @@ describe("grantRole", () => {
         GrantRoleCommand.make({ userId: targetId, role: "super_admin", actorUserId: actorId }),
       );
 
-      const roles = yield* repo.findOneByUserId(targetId);
+      const roles = yield* repo.findOne(RolesSpecifications.forUser(targetId));
+      if (roles === null) throw new Error("expected aggregate");
       deepStrictEqual([...roles.roles], ["super_admin"]);
 
       const events = yield* rec.byTag<RoleGranted>("RoleGranted");

--- a/packages/server/src/modules/role/commands/grant-role.handler.ts
+++ b/packages/server/src/modules/role/commands/grant-role.handler.ts
@@ -4,6 +4,7 @@ import { type GrantRoleCommand } from "@/modules/role/commands/grant-role.comman
 import { CannotPromoteSelf } from "@/modules/role/domain/roles/role.errors.js";
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
 import { RolesRootOps } from "@/modules/role/domain/roles/roles.root-ops.js";
+import { RolesSpecifications } from "@/modules/role/domain/roles/roles.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -18,7 +19,9 @@ export const grantRole = Effect.fn("grantRole")(function* (cmd: GrantRoleCommand
   const repo = yield* RolesRepository;
   const bus = yield* DomainEventBus;
 
-  const aggregate = yield* repo.findOneByUserId(cmd.userId);
+  const aggregate =
+    (yield* repo.findOne(RolesSpecifications.forUser(cmd.userId))) ??
+    RolesRootOps.empty(cmd.userId);
   const result = yield* Effect.fromResult(RolesRootOps.grant(aggregate, cmd.role));
 
   yield* repo.upsertOne(result.roles);

--- a/packages/server/src/modules/role/commands/revoke-role.handler.test.ts
+++ b/packages/server/src/modules/role/commands/revoke-role.handler.test.ts
@@ -13,6 +13,7 @@ import { revokeRole } from "@/modules/role/commands/revoke-role.handler.js";
 import { DoesNotHaveRole } from "@/modules/role/domain/roles/role.errors.js";
 import { type RoleRevoked } from "@/modules/role/domain/roles/role.events.js";
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
+import { RolesSpecifications } from "@/modules/role/domain/roles/roles.specification.js";
 import { RolesRepositoryFake } from "@/modules/role/infrastructure/repositories/roles.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -34,8 +35,10 @@ describe("revokeRole", () => {
       );
       yield* revokeRole(RevokeRoleCommand.make({ userId: targetId, role: "super_admin" }));
 
-      const roles = yield* repo.findOneByUserId(targetId);
-      deepStrictEqual([...roles.roles], []);
+      // Revoking the only role leaves no rows, so the aggregate no longer
+      // resolves — findOne reports null (no rows = no roles).
+      const roles = yield* repo.findOne(RolesSpecifications.forUser(targetId));
+      deepStrictEqual(roles, null);
 
       const events = yield* rec.byTag<RoleRevoked>("RoleRevoked");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/role/commands/revoke-role.handler.ts
+++ b/packages/server/src/modules/role/commands/revoke-role.handler.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import { type RevokeRoleCommand } from "@/modules/role/commands/revoke-role.command.js";
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
 import { RolesRootOps } from "@/modules/role/domain/roles/roles.root-ops.js";
+import { RolesSpecifications } from "@/modules/role/domain/roles/roles.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
@@ -10,7 +11,9 @@ export const revokeRole = Effect.fn("revokeRole")(function* (cmd: RevokeRoleComm
   const repo = yield* RolesRepository;
   const bus = yield* DomainEventBus;
 
-  const aggregate = yield* repo.findOneByUserId(cmd.userId);
+  const aggregate =
+    (yield* repo.findOne(RolesSpecifications.forUser(cmd.userId))) ??
+    RolesRootOps.empty(cmd.userId);
   const result = yield* Effect.fromResult(RolesRootOps.revoke(aggregate, cmd.role));
 
   yield* repo.upsertOne(result.roles);

--- a/packages/server/src/modules/role/domain/roles/roles.repository.ts
+++ b/packages/server/src/modules/role/domain/roles/roles.repository.ts
@@ -3,17 +3,20 @@ import type * as Effect from "effect/Effect";
 
 import { type RolesRoot } from "@/modules/role/domain/roles/roles.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
-// Dumb persistence port. The aggregate carries the invariants; the
-// repository only knows how to save and fetch the resulting state.
-//
-// `findOneByUserId` returns an empty `RolesRoot` aggregate if no roles are
-// stored — the absence of any rows is a valid "no roles granted yet"
-// state, not a NotFound condition.
+// Dumb persistence, collapsed to upsert + spec-based read. The aggregate is
+// multi-row (one `platform.roles` row per granted role) keyed on `userId`.
+// `findOne` compiles the spec to a WHERE, fetches the matching rows, and
+// reconstitutes ONE aggregate — or `null` when no rows match. "No rows" is a
+// valid "no roles granted yet" state, so the caller maps `null` to
+// `RolesRootOps.empty(...)`: the empty aggregate is a domain concern the repo
+// can't synthesize from zero rows.
 export type RolesRepositoryShape = {
   readonly upsertOne: (roles: RolesRoot) => Effect.Effect<void, PersistenceUnavailable>;
-  readonly findOneByUserId: (userId: UserId) => Effect.Effect<RolesRoot, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<RolesRoot>,
+  ) => Effect.Effect<RolesRoot | null, PersistenceUnavailable>;
 };
 
 export class RolesRepository extends Context.Service<RolesRepository, RolesRepositoryShape>()(

--- a/packages/server/src/modules/role/domain/roles/roles.root-ops.ts
+++ b/packages/server/src/modules/role/domain/roles/roles.root-ops.ts
@@ -14,7 +14,7 @@ export type Outcome = {
 };
 
 // Factory for the "no roles yet" case — used by the command handler
-// when `findOneByUserId` returns nothing and we still want to apply a
+// when `findOne` returns nothing and we still want to apply a
 // grant rather than fail.
 const empty = (userId: UserId): RolesRoot => RolesRoot.make({ userId, roles: [] });
 
@@ -25,7 +25,7 @@ const grant = (
   aggregate: RolesRoot,
   role: RoleValueObject,
 ): Result.Result<Outcome, AlreadyHasRole> => {
-  if (RolesSpecifications.hasRole(aggregate, role)) {
+  if (RolesSpecifications.hasRole(role)(aggregate)) {
     return Result.fail(new AlreadyHasRole({ userId: aggregate.userId, role }));
   }
   return Result.succeed({
@@ -43,7 +43,7 @@ const revoke = (
   aggregate: RolesRoot,
   role: RoleValueObject,
 ): Result.Result<Outcome, DoesNotHaveRole> => {
-  if (!RolesSpecifications.hasRole(aggregate, role)) {
+  if (!RolesSpecifications.hasRole(role)(aggregate)) {
     return Result.fail(new DoesNotHaveRole({ userId: aggregate.userId, role }));
   }
   return Result.succeed({

--- a/packages/server/src/modules/role/domain/roles/roles.specification.test.ts
+++ b/packages/server/src/modules/role/domain/roles/roles.specification.test.ts
@@ -2,21 +2,33 @@ import { describe, it } from "@effect/vitest";
 import { deepStrictEqual } from "assert";
 import * as Result from "effect/Result";
 
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
+import { type RolesRoot } from "./roles.root.js";
 import { RolesRootOps } from "./roles.root-ops.js";
 import { RolesSpecifications } from "./roles.specification.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 
+// Boundary (criteria-to-sql): `hasRole` reaches into the `roles` child
+// collection, so it is a `Predicate`, not a translatable `Specification`, and
+// must never be usable as a repository filter. This assignment must NOT
+// compile — if `hasRole` ever gains a `.criteria`, the directive goes unused
+// and the build fails, catching the regression.
+// @ts-expect-error hasRole("super_admin") is a Predicate; it has no `.criteria`.
+const _hasRoleIsNotASpecification: Specification<RolesRoot> =
+  RolesSpecifications.hasRole("super_admin");
+void _hasRoleIsNotASpecification;
+
 describe("RolesSpecifications.hasRole", () => {
   it("returns false on an empty aggregate", () => {
-    deepStrictEqual(RolesSpecifications.hasRole(RolesRootOps.empty(userId), "super_admin"), false);
+    deepStrictEqual(RolesSpecifications.hasRole("super_admin")(RolesRootOps.empty(userId)), false);
   });
 
   it("returns true after the role is granted", () => {
     const result = RolesRootOps.grant(RolesRootOps.empty(userId), "super_admin");
     if (Result.isFailure(result)) throw new Error("expected Right");
-    deepStrictEqual(RolesSpecifications.hasRole(result.success.roles, "super_admin"), true);
+    deepStrictEqual(RolesSpecifications.hasRole("super_admin")(result.success.roles), true);
   });
 });

--- a/packages/server/src/modules/role/domain/roles/roles.specification.ts
+++ b/packages/server/src/modules/role/domain/roles/roles.specification.ts
@@ -1,7 +1,26 @@
+import {
+  type Predicate,
+  Spec,
+  type Specification,
+} from "@/platform/ddd/contracts/specification.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
 import { type RoleValueObject } from "./role.value-object.js";
 import { type RolesRoot } from "./roles.root.js";
 
-const hasRole = (aggregate: RolesRoot, role: RoleValueObject): boolean =>
-  aggregate.roles.includes(role);
+// Translatable identity spec — `userId` lives on every row of the aggregate, so
+// this compiles to a WHERE that the repository uses to fetch the row set it
+// reconstitutes into one aggregate.
+const forUser = (userId: UserId): Specification<RolesRoot> =>
+  Spec.eq<RolesRoot, "userId">("userId", userId);
 
-export const RolesSpecifications = { hasRole } as const;
+// Eval-only: `hasRole` reaches into the `roles` child collection, which the
+// Criteria DSL cannot express (there is no "some child row" node). It is a
+// Predicate, never a Specification, so it guards aggregate ops but can never be
+// handed to a repository — the spec test locks that boundary at compile time.
+const hasRole =
+  (role: RoleValueObject): Predicate<RolesRoot> =>
+  (aggregate) =>
+    aggregate.roles.includes(role);
+
+export const RolesSpecifications = { forUser, hasRole } as const;

--- a/packages/server/src/modules/role/infrastructure/repositories/role.mapper.ts
+++ b/packages/server/src/modules/role/infrastructure/repositories/role.mapper.ts
@@ -2,24 +2,34 @@ import { type RowSchemas } from "@org/database/index";
 
 import { type RoleValueObject } from "@/modules/role/domain/roles/role.value-object.js";
 import { RolesRoot } from "@/modules/role/domain/roles/roles.root.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
+
+type Row = RowSchemas.PlatformRoleRow;
 
 // Closed set of recognized role names. Mirrors the `RoleValueObject` Schema literal
-// in `domain/role.ts` — adding a new role requires updating both.
+// in `domain/roles/role.value-object.ts` — adding a new role requires updating both.
 const KNOWN_ROLES = new Set<string>(["super_admin"]);
 
 const narrow = (role: string): role is RoleValueObject => KNOWN_ROLES.has(role);
 
-// Builds a `RolesRoot` aggregate from raw `platform.roles` rows. The caller
-// (the live repository) groups rows by user_id and hands the slice for
-// one user here. Unknown role strings (never inserted by application
-// code) are filtered out rather than crashing the read — defense in
-// depth.
-export const toDomain = (
-  userId: UserId,
-  rows: ReadonlyArray<RowSchemas.PlatformRoleRow>,
-): RolesRoot =>
-  RolesRoot.make({
-    userId,
+// Field → column map for spec translation. Only `userId` is filterable; `roles`
+// is a child collection with no scalar column, which is why `hasRole` stays an
+// eval-only Predicate and never reaches this map.
+export const columns = {
+  userId: "user_id",
+} as const satisfies Partial<Record<keyof RolesRoot, string>> & ColumnMap;
+
+// Reconstitutes ONE aggregate from the rows the repository fetched for a single
+// user. Zero rows → `null`; the caller decides that "no rows" means an empty
+// aggregate. Identity is read from the rows themselves — every row carries
+// `user_id`. Unknown role strings (never inserted by application code) are
+// filtered out rather than crashing the read.
+export const toDomain = (rows: ReadonlyArray<Row>): RolesRoot | null => {
+  const first = rows[0];
+  if (first === undefined) return null;
+  return RolesRoot.make({
+    userId: UserId.make(first.user_id),
     roles: rows.map((r) => r.role).filter(narrow),
   });
+};

--- a/packages/server/src/modules/role/infrastructure/repositories/roles.repository-fake.test.ts
+++ b/packages/server/src/modules/role/infrastructure/repositories/roles.repository-fake.test.ts
@@ -5,29 +5,32 @@ import * as Result from "effect/Result";
 
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
 import { RolesRootOps } from "@/modules/role/domain/roles/roles.root-ops.js";
+import { RolesSpecifications } from "@/modules/role/domain/roles/roles.specification.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
 import { RolesRepositoryFake } from "./roles.repository-fake.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
 
+const forUser = RolesSpecifications.forUser(userId);
+
 describe("RolesRepositoryFake", () => {
-  it.effect("returns an empty aggregate for a previously-unseen user", () =>
+  it.effect("findOne returns null for a previously-unseen user", () =>
     Effect.gen(function* () {
       const repo = yield* RolesRepository;
-      const roles = yield* repo.findOneByUserId(userId);
-      deepStrictEqual(roles.userId, userId);
-      deepStrictEqual([...roles.roles], []);
+      const roles = yield* repo.findOne(forUser);
+      deepStrictEqual(roles, null);
     }).pipe(Effect.provide(RolesRepositoryFake)),
   );
 
-  it.effect("round-trips a saved aggregate via findOneByUserId", () =>
+  it.effect("round-trips a saved aggregate via findOne", () =>
     Effect.gen(function* () {
       const repo = yield* RolesRepository;
       const granted = RolesRootOps.grant(RolesRootOps.empty(userId), "super_admin");
       if (Result.isFailure(granted)) throw new Error("expected Right");
       yield* repo.upsertOne(granted.success.roles);
-      const fetched = yield* repo.findOneByUserId(userId);
+      const fetched = yield* repo.findOne(forUser);
+      if (fetched === null) throw new Error("expected aggregate");
       deepStrictEqual([...fetched.roles], ["super_admin"]);
     }).pipe(Effect.provide(RolesRepositoryFake)),
   );

--- a/packages/server/src/modules/role/infrastructure/repositories/roles.repository-fake.ts
+++ b/packages/server/src/modules/role/infrastructure/repositories/roles.repository-fake.ts
@@ -5,7 +5,7 @@ import * as Ref from "effect/Ref";
 
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
 import { type RolesRoot } from "@/modules/role/domain/roles/roles.root.js";
-import { RolesRootOps } from "@/modules/role/domain/roles/roles.root-ops.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
 // In-memory `RolesRepository` for use-case unit tests. Composes with
@@ -16,15 +16,22 @@ export const RolesRepositoryFake = Layer.effect(
   Effect.gen(function* () {
     const store = yield* Ref.make(HashMap.empty<UserId, RolesRoot>());
 
+    // Mirror the live repo's row model: it persists as DELETE-then-INSERT, so
+    // an aggregate with no roles leaves zero rows — indistinguishable from an
+    // absent one. Storing an empty aggregate here would make findOne return it
+    // where the live repo returns null, so an empty upsert deletes the entry.
     const upsertOne = (roles: RolesRoot): Effect.Effect<void> =>
-      Ref.update(store, HashMap.set(roles.userId, roles));
+      Ref.update(
+        store,
+        roles.roles.length === 0 ? HashMap.remove(roles.userId) : HashMap.set(roles.userId, roles),
+      );
 
-    const findOneByUserId = (userId: UserId): Effect.Effect<RolesRoot> =>
-      Effect.map(Ref.get(store), (m) => {
-        const found = HashMap.get(m, userId);
-        return found._tag === "Some" ? found.value : RolesRootOps.empty(userId);
-      });
+    // The spec is the in-memory predicate over the whole aggregate — the same
+    // object the live repo compiles to SQL. Absence is `null`; the caller maps
+    // it to an empty aggregate.
+    const findOne = (spec: Specification<RolesRoot>): Effect.Effect<RolesRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    return RolesRepository.of({ upsertOne, findOneByUserId });
+    return RolesRepository.of({ upsertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/role/infrastructure/repositories/roles.repository-live.integration.test.ts
+++ b/packages/server/src/modules/role/infrastructure/repositories/roles.repository-live.integration.test.ts
@@ -8,11 +8,14 @@ import { beforeEach } from "vitest";
 
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
 import { RolesRootOps } from "@/modules/role/domain/roles/roles.root-ops.js";
+import { RolesSpecifications } from "@/modules/role/domain/roles/roles.specification.js";
 import { RolesRepositoryLive } from "@/modules/role/infrastructure/repositories/roles.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
 const userId = UserId.make("11111111-1111-1111-1111-111111111111");
+
+const forUser = RolesSpecifications.forUser(userId);
 
 // platform.roles FKs to user.users(id) — every test seeds the FK row
 // via raw SQL since the role module's barrel doesn't (and shouldn't)
@@ -40,27 +43,27 @@ suite("RolesRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findOneByUserId", () => {
-    it.effect("returns an empty aggregate when no rows exist", () =>
+  describe("findOne", () => {
+    it.effect("returns null when no rows exist (the empty case is the caller's)", () =>
       Effect.gen(function* () {
         yield* seedUser;
         const repo = yield* RolesRepository;
-        const roles = yield* repo.findOneByUserId(userId);
-        deepStrictEqual(roles.userId, userId);
-        deepStrictEqual([...roles.roles], []);
+        const roles = yield* repo.findOne(forUser);
+        deepStrictEqual(roles, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
 
   describe("save", () => {
-    it.effect("persists granted roles and round-trips via findOneByUserId", () =>
+    it.effect("persists granted roles and round-trips via findOne", () =>
       Effect.gen(function* () {
         yield* seedUser;
         const repo = yield* RolesRepository;
         const granted = RolesRootOps.grant(RolesRootOps.empty(userId), "super_admin");
         if (Result.isFailure(granted)) throw new Error("expected Right");
         yield* repo.upsertOne(granted.success.roles);
-        const fetched = yield* repo.findOneByUserId(userId);
+        const fetched = yield* repo.findOne(forUser);
+        if (fetched === null) throw new Error("expected aggregate");
         deepStrictEqual([...fetched.roles], ["super_admin"]);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -75,8 +78,10 @@ suite("RolesRepositoryLive (integration)", () => {
         const revoked = RolesRootOps.revoke(granted.success.roles, "super_admin");
         if (Result.isFailure(revoked)) throw new Error("expected Right");
         yield* repo.upsertOne(revoked.success.roles);
-        const fetched = yield* repo.findOneByUserId(userId);
-        deepStrictEqual([...fetched.roles], []);
+        // Revoking the last role deletes every row, so there is nothing to
+        // reconstitute — findOne reports null (no rows = no roles).
+        const fetched = yield* repo.findOne(forUser);
+        deepStrictEqual(fetched, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/role/infrastructure/repositories/roles.repository-live.ts
+++ b/packages/server/src/modules/role/infrastructure/repositories/roles.repository-live.ts
@@ -6,7 +6,8 @@ import * as Option from "effect/Option";
 import { RolesRepository } from "@/modules/role/domain/roles/roles.repository.js";
 import { type RolesRoot } from "@/modules/role/domain/roles/roles.root.js";
 import * as RoleMapper from "@/modules/role/infrastructure/repositories/role.mapper.js";
-import { type UserId } from "@/platform/ids/user-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 export const RolesRepositoryLive = Layer.effect(
@@ -58,19 +59,25 @@ export const RolesRepositoryLive = Layer.effect(
         Effect.withSpan("RolesRepository.upsertOne"),
       );
 
-    const findOneByUserId = db.makeQuery((execute, userId: UserId) =>
+    // The spec pins the user id, so every matched row belongs to one aggregate;
+    // the mapper groups them (or returns null for zero rows). The compiler
+    // contributes only the WHERE — this repo owns the projection and, for a
+    // multi-row aggregate, the reconstitution.
+    const findOne = db.makeQuery((execute, spec: Specification<RolesRoot>) =>
       execute((client) =>
         client.any(sql.type(RowSchemas.PlatformRoleRowStd)`
-          SELECT user_id, role, granted_at FROM platform.roles WHERE user_id = ${userId}
+          SELECT user_id, role, granted_at
+          FROM platform.roles
+          WHERE ${criteriaToWhere(spec.criteria, RoleMapper.columns)}
         `),
       ).pipe(
-        Effect.map((rows) => RoleMapper.toDomain(userId, rows)),
+        Effect.map((rows) => RoleMapper.toDomain(rows)),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("RolesRepository.findOneByUserId"),
+        Effect.withSpan("RolesRepository.findOne"),
       ),
     );
 
-    return RolesRepository.of({ upsertOne, findOneByUserId });
+    return RolesRepository.of({ upsertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/todos/commands/complete-todo.handler.test.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo.handler.test.ts
@@ -10,7 +10,9 @@ import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/repositories/todos.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -39,7 +41,10 @@ describe("completeTodo", () => {
       );
       deepStrictEqual(completed.completed, true);
       deepStrictEqual(completed.title, "Buy milk");
-      const stored = yield* (yield* TodosRepository).findOneById(orgId, todoId);
+      const stored = yield* (yield* TodosRepository).findOne(
+        Spec.and(TodoSpecifications.withId(todoId), TodoSpecifications.forOrganization(orgId)),
+      );
+      if (stored === null) throw new Error("expected stored todo");
       deepStrictEqual(stored.completed, true);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/complete-todo.handler.ts
+++ b/packages/server/src/modules/todos/commands/complete-todo.handler.ts
@@ -2,12 +2,23 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type CompleteTodoCommand } from "@/modules/todos/commands/complete-todo.command.js";
+import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 
 export const completeTodo = Effect.fn("completeTodo")(function* (cmd: CompleteTodoCommand) {
   const repo = yield* TodosRepository;
-  const existing = yield* repo.findOneById(cmd.organizationId, cmd.todoId);
+  const existing = yield* repo.findOne(
+    Spec.and(
+      TodoSpecifications.withId(cmd.todoId),
+      TodoSpecifications.forOrganization(cmd.organizationId),
+    ),
+  );
+  if (existing === null) {
+    return yield* new TodoNotFound({ todoId: cmd.todoId });
+  }
   const now = yield* DateTime.now;
   const completed = TodoRootOps.complete(existing, now);
   yield* repo.updateOne(completed);

--- a/packages/server/src/modules/todos/commands/create-todo.handler.test.ts
+++ b/packages/server/src/modules/todos/commands/create-todo.handler.test.ts
@@ -3,7 +3,9 @@ import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
 
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/repositories/todos.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -23,7 +25,10 @@ describe("createTodo", () => {
       deepStrictEqual(todo.title, "Buy milk");
       deepStrictEqual(todo.completed, false);
       deepStrictEqual(todo.organizationId, orgId);
-      const stored = yield* repo.findOneById(orgId, todo.id);
+      const stored = yield* repo.findOne(
+        Spec.and(TodoSpecifications.withId(todo.id), TodoSpecifications.forOrganization(orgId)),
+      );
+      if (stored === null) throw new Error("expected stored todo");
       deepStrictEqual(stored.title, "Buy milk");
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/delete-todo.handler.test.ts
+++ b/packages/server/src/modules/todos/commands/delete-todo.handler.test.ts
@@ -10,7 +10,9 @@ import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/repositories/todos.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -33,8 +35,10 @@ describe("deleteTodo", () => {
       yield* deleteTodo(
         DeleteTodoCommand.make({ todoId: aliceId, organizationId: orgId, userId: aliceUserId }),
       );
-      const exit = yield* Effect.exit(repo.findOneById(orgId, aliceId));
-      deepStrictEqual(Exit.isFailure(exit), true);
+      const found = yield* repo.findOne(
+        Spec.and(TodoSpecifications.withId(aliceId), TodoSpecifications.forOrganization(orgId)),
+      );
+      deepStrictEqual(found, null);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );
 
@@ -78,7 +82,10 @@ describe("deleteTodo", () => {
         deepStrictEqual(error instanceof TodoNotFound, true);
       }
       // The original (correct-org) row is untouched.
-      const stillThere = yield* repo.findOneById(orgId, aliceId);
+      const stillThere = yield* repo.findOne(
+        Spec.and(TodoSpecifications.withId(aliceId), TodoSpecifications.forOrganization(orgId)),
+      );
+      if (stillThere === null) throw new Error("expected stored todo");
       deepStrictEqual(stillThere.id, aliceId);
     }).pipe(Effect.provide(TodosRepositoryFake)),
   );

--- a/packages/server/src/modules/todos/commands/update-todo.handler.test.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.handler.test.ts
@@ -10,7 +10,9 @@ import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
 import { TodosRepositoryFake } from "@/modules/todos/infrastructure/repositories/todos.repository-fake.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -46,7 +48,10 @@ describe("updateTodo", () => {
       deepStrictEqual(updated.completed, true);
 
       const repo = yield* TodosRepository;
-      const stored = yield* repo.findOneById(orgId, aliceId);
+      const stored = yield* repo.findOne(
+        Spec.and(TodoSpecifications.withId(aliceId), TodoSpecifications.forOrganization(orgId)),
+      );
+      if (stored === null) throw new Error("expected stored todo");
       deepStrictEqual(stored.title, "Buy oat milk");
       deepStrictEqual(stored.completed, true);
     }).pipe(Effect.provide(TodosRepositoryFake)),

--- a/packages/server/src/modules/todos/commands/update-todo.handler.ts
+++ b/packages/server/src/modules/todos/commands/update-todo.handler.ts
@@ -2,12 +2,23 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 
 import { type UpdateTodoCommand } from "@/modules/todos/commands/update-todo.command.js";
+import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 
 export const updateTodo = Effect.fn("updateTodo")(function* (cmd: UpdateTodoCommand) {
   const repo = yield* TodosRepository;
-  const existing = yield* repo.findOneById(cmd.organizationId, cmd.todoId);
+  const existing = yield* repo.findOne(
+    Spec.and(
+      TodoSpecifications.withId(cmd.todoId),
+      TodoSpecifications.forOrganization(cmd.organizationId),
+    ),
+  );
+  if (existing === null) {
+    return yield* new TodoNotFound({ todoId: cmd.todoId });
+  }
   const now = yield* DateTime.now;
   const updated = TodoRootOps.update(existing, {
     title: cmd.title,

--- a/packages/server/src/modules/todos/domain/todo/todos.repository.ts
+++ b/packages/server/src/modules/todos/domain/todo/todos.repository.ts
@@ -5,13 +5,17 @@ import { type TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { type TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { type TodoRoot } from "@/modules/todos/domain/todo/todo.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
-// Every read/mutate is org-scoped (Phase 5). `findOneById` and `remove`
-// take the `organizationId` explicitly so a caller can't reach a todo
-// outside the org in the request path — a row in another org reads as
-// `TodoNotFound`, not a leak. `insert`/`update` carry the org on the
-// `TodoRoot` itself; `update`'s SQL filters on it too.
+// Dumb persistence, collapsed to the minimal vocabulary: insert/update/delete
+// the aggregate, and read it back by a Specification. Every read is org-scoped
+// (Phase 5): a caller pins the org in the spec — `Spec.and(withId(id),
+// forOrganization(orgId))` (see TodoSpecifications) — so a row in another org
+// reads as absent (`null`), not a leak. `deleteOne` still takes the org
+// explicitly; `insert`/`update` carry it on the `TodoRoot` and `update`'s SQL
+// filters on it too. Absence is a plain `null`; mapping it to a domain 404
+// (TodoNotFound) is the caller's job.
 export type TodosRepositoryShape = {
   readonly insertOne: (todo: TodoRoot) => Effect.Effect<void, PersistenceUnavailable>;
   readonly updateOne: (
@@ -21,10 +25,9 @@ export type TodosRepositoryShape = {
     organizationId: OrganizationId,
     id: TodoId,
   ) => Effect.Effect<void, TodoNotFound | PersistenceUnavailable>;
-  readonly findOneById: (
-    organizationId: OrganizationId,
-    id: TodoId,
-  ) => Effect.Effect<TodoRoot, TodoNotFound | PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<TodoRoot>,
+  ) => Effect.Effect<TodoRoot | null, PersistenceUnavailable>;
 };
 
 export class TodosRepository extends Context.Service<TodosRepository, TodosRepositoryShape>()(

--- a/packages/server/src/modules/todos/domain/todo/todos.specification.test.ts
+++ b/packages/server/src/modules/todos/domain/todo/todos.specification.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+
+import { TodoId } from "./todo.id.js";
+import { TodoRootOps } from "./todo.root-ops.js";
+import { TodoSpecifications } from "./todos.specification.js";
+
+const aliceId = TodoId.make("11111111-1111-1111-1111-111111111111");
+const bobId = TodoId.make("22222222-2222-2222-2222-222222222222");
+const orgId = OrganizationId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const otherOrgId = OrganizationId.make("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
+
+const buyMilk = TodoRootOps.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now });
+
+describe("TodoSpecifications.withId", () => {
+  it("matches the todo with the given id and no other", () => {
+    deepStrictEqual(TodoSpecifications.withId(aliceId)(buyMilk), true);
+    deepStrictEqual(TodoSpecifications.withId(bobId)(buyMilk), false);
+  });
+
+  it("carries an Eq criteria over the id column", () => {
+    deepStrictEqual(TodoSpecifications.withId(aliceId).criteria, {
+      _tag: "Eq",
+      field: "id",
+      value: aliceId,
+    });
+  });
+});
+
+describe("TodoSpecifications.forOrganization", () => {
+  it("matches the todo owned by the given org and no other", () => {
+    deepStrictEqual(TodoSpecifications.forOrganization(orgId)(buyMilk), true);
+    deepStrictEqual(TodoSpecifications.forOrganization(otherOrgId)(buyMilk), false);
+  });
+
+  it("carries an Eq criteria over the organization_id column", () => {
+    deepStrictEqual(TodoSpecifications.forOrganization(orgId).criteria, {
+      _tag: "Eq",
+      field: "organizationId",
+      value: orgId,
+    });
+  });
+});

--- a/packages/server/src/modules/todos/domain/todo/todos.specification.ts
+++ b/packages/server/src/modules/todos/domain/todo/todos.specification.ts
@@ -1,0 +1,17 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
+import { type TodoId } from "./todo.id.js";
+import { type TodoRoot } from "./todo.root.js";
+
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The field-name strings live here and in the mapper's
+// column map; `Spec.eq` types them against TodoRoot so a typo is a compile
+// error. Every read is org-scoped, so an id lookup pins the org too:
+// `Spec.and(withId(id), forOrganization(orgId))`.
+const withId = (id: TodoId): Specification<TodoRoot> => Spec.eq<TodoRoot, "id">("id", id);
+
+const forOrganization = (organizationId: OrganizationId): Specification<TodoRoot> =>
+  Spec.eq<TodoRoot, "organizationId">("organizationId", organizationId);
+
+export const TodoSpecifications = { withId, forOrganization } as const;

--- a/packages/server/src/modules/todos/infrastructure/repositories/todo.mapper.ts
+++ b/packages/server/src/modules/todos/infrastructure/repositories/todo.mapper.ts
@@ -4,8 +4,17 @@ import * as DateTime from "effect/DateTime";
 import { TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodoRoot } from "@/modules/todos/domain/todo/todo.root.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.TodoRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of todos.todos. Only filterable scalar fields need an
+// entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+  organizationId: "organization_id",
+} as const satisfies Partial<Record<keyof TodoRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): TodoRoot =>
   new TodoRoot({

--- a/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-fake.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-fake.test.ts
@@ -10,6 +10,8 @@ import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 
 import { TodosRepositoryFake } from "./todos.repository-fake.js";
@@ -23,6 +25,9 @@ const later = DateTime.makeUnsafe(new Date("2025-02-01T00:00:00Z"));
 
 const buyMilk = TodoRootOps.create({ id: aliceId, organizationId: orgId, title: "Buy milk", now });
 
+const byOrgAndId = (organizationId: OrganizationId, id: TodoId) =>
+  Spec.and(TodoSpecifications.withId(id), TodoSpecifications.forOrganization(organizationId));
+
 const provide = Effect.provide(TodosRepositoryFake);
 
 describe("TodosRepositoryFake", () => {
@@ -31,7 +36,8 @@ describe("TodosRepositoryFake", () => {
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
         yield* repo.insertOne(buyMilk);
-        const found = yield* repo.findOneById(orgId, buyMilk.id);
+        const found = yield* repo.findOne(byOrgAndId(orgId, buyMilk.id));
+        if (found === null) throw new Error("expected stored todo");
         deepStrictEqual(found.id, buyMilk.id);
         deepStrictEqual(found.organizationId, orgId);
         deepStrictEqual(found.title, buyMilk.title);
@@ -40,33 +46,21 @@ describe("TodosRepositoryFake", () => {
     );
   });
 
-  describe("findOneById", () => {
-    it.effect("fails TodoNotFound for an unknown id", () =>
+  describe("findOne", () => {
+    it.effect("returns null for an unknown id", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.findOneById(orgId, bobId));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof TodoNotFound, true);
-        }
+        const found = yield* repo.findOne(byOrgAndId(orgId, bobId));
+        deepStrictEqual(found, null);
       }).pipe(provide),
     );
 
-    it.effect("fails TodoNotFound when the id exists but in another org (isolation)", () =>
+    it.effect("returns null when the id exists but in another org (isolation)", () =>
       Effect.gen(function* () {
         const repo = yield* TodosRepository;
         yield* repo.insertOne(buyMilk);
-        const exit = yield* Effect.exit(repo.findOneById(otherOrgId, buyMilk.id));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof TodoNotFound, true);
-        }
+        const found = yield* repo.findOne(byOrgAndId(otherOrgId, buyMilk.id));
+        deepStrictEqual(found, null);
       }).pipe(provide),
     );
   });
@@ -82,7 +76,8 @@ describe("TodosRepositoryFake", () => {
           now: later,
         });
         yield* repo.updateOne(completed);
-        const found = yield* repo.findOneById(orgId, buyMilk.id);
+        const found = yield* repo.findOne(byOrgAndId(orgId, buyMilk.id));
+        if (found === null) throw new Error("expected stored todo");
         deepStrictEqual(found.completed, true);
         deepStrictEqual(found.updatedAt, later);
       }).pipe(provide),
@@ -109,8 +104,8 @@ describe("TodosRepositoryFake", () => {
         const repo = yield* TodosRepository;
         yield* repo.insertOne(buyMilk);
         yield* repo.deleteOne(orgId, buyMilk.id);
-        const exit = yield* Effect.exit(repo.findOneById(orgId, buyMilk.id));
-        deepStrictEqual(Exit.isFailure(exit), true);
+        const found = yield* repo.findOne(byOrgAndId(orgId, buyMilk.id));
+        deepStrictEqual(found, null);
       }).pipe(provide),
     );
 
@@ -135,7 +130,8 @@ describe("TodosRepositoryFake", () => {
         const exit = yield* Effect.exit(repo.deleteOne(otherOrgId, buyMilk.id));
         deepStrictEqual(Exit.isFailure(exit), true);
         // Row still present under its real org.
-        const found = yield* repo.findOneById(orgId, buyMilk.id);
+        const found = yield* repo.findOne(byOrgAndId(orgId, buyMilk.id));
+        if (found === null) throw new Error("expected stored todo");
         deepStrictEqual(found.id, buyMilk.id);
       }).pipe(provide),
     );

--- a/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-fake.ts
+++ b/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-fake.ts
@@ -1,13 +1,13 @@
 import * as Effect from "effect/Effect";
 import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
 import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { type TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { type TodoRoot } from "@/modules/todos/domain/todo/todo.root.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 // Keyed by TodoId; org scoping is enforced by guarding on the stored
@@ -41,20 +41,13 @@ export const TodosRepositoryFake = Layer.effect(
           : Effect.fail(new TodoNotFound({ todoId: id }));
       });
 
-    const findOneById = (
-      organizationId: OrganizationId,
-      id: TodoId,
-    ): Effect.Effect<TodoRoot, TodoNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new TodoNotFound({ todoId: id })),
-          onSome: (todo) =>
-            todo.organizationId === organizationId
-              ? Effect.succeed(todo)
-              : Effect.fail(new TodoNotFound({ todoId: id })),
-        }),
-      );
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction. Org scoping is
+    // just another term in the spec (`forOrganization`), so a wrong-org read
+    // finds nothing and returns null, mirroring the live `WHERE`.
+    const findOne = (spec: Specification<TodoRoot>): Effect.Effect<TodoRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    return TodosRepository.of({ insertOne, updateOne, deleteOne, findOneById });
+    return TodosRepository.of({ insertOne, updateOne, deleteOne, findOne });
   }),
 );

--- a/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-live.integration.test.ts
+++ b/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-live.integration.test.ts
@@ -13,7 +13,9 @@ import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodoRootOps } from "@/modules/todos/domain/todo/todo.root-ops.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/repositories/todos.repository-live.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
 
@@ -25,6 +27,9 @@ const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
 const later = DateTime.makeUnsafe(new Date("2025-02-01T00:00:00Z"));
 
 const buyMilk = TodoRootOps.create({ id: aliceId, organizationId: orgA, title: "Buy milk", now });
+
+const byOrgAndId = (organizationId: OrganizationId, id: TodoId) =>
+  Spec.and(TodoSpecifications.withId(id), TodoSpecifications.forOrganization(organizationId));
 
 // todos.todos.organization_id FKs to organization.organizations(id);
 // seed both orgs via raw SQL since the todos repo can't (and shouldn't)
@@ -58,12 +63,13 @@ suite("TodosRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists the todo with its org and decodes it back via findOneById", () =>
+    it.effect("persists the todo with its org and decodes it back via findOne", () =>
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
         yield* repo.insertOne(buyMilk);
-        const found = yield* repo.findOneById(orgA, buyMilk.id);
+        const found = yield* repo.findOne(byOrgAndId(orgA, buyMilk.id));
+        if (found === null) throw new Error("expected stored todo");
         deepStrictEqual(found.id, buyMilk.id);
         deepStrictEqual(found.organizationId, orgA);
         deepStrictEqual(found.title, buyMilk.title);
@@ -72,35 +78,23 @@ suite("TodosRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findOneById", () => {
-    it.effect("fails TodoNotFound for an unknown id", () =>
+  describe("findOne", () => {
+    it.effect("returns null for an unknown id", () =>
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
-        const exit = yield* Effect.exit(repo.findOneById(orgA, bobId));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof TodoNotFound, true);
-        }
+        const found = yield* repo.findOne(byOrgAndId(orgA, bobId));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("fails TodoNotFound when the todo belongs to another org (tenant isolation)", () =>
+    it.effect("returns null when the todo belongs to another org (tenant isolation)", () =>
       Effect.gen(function* () {
         yield* seedOrgs;
         const repo = yield* TodosRepository;
         yield* repo.insertOne(buyMilk);
-        const exit = yield* Effect.exit(repo.findOneById(orgB, buyMilk.id));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof TodoNotFound, true);
-        }
+        const found = yield* repo.findOne(byOrgAndId(orgB, buyMilk.id));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
@@ -117,7 +111,8 @@ suite("TodosRepositoryLive (integration)", () => {
           now: later,
         });
         yield* repo.updateOne(completed);
-        const found = yield* repo.findOneById(orgA, buyMilk.id);
+        const found = yield* repo.findOne(byOrgAndId(orgA, buyMilk.id));
+        if (found === null) throw new Error("expected stored todo");
         deepStrictEqual(found.title, "Buy oat milk");
         deepStrictEqual(found.completed, true);
         deepStrictEqual(
@@ -150,8 +145,8 @@ suite("TodosRepositoryLive (integration)", () => {
         const repo = yield* TodosRepository;
         yield* repo.insertOne(buyMilk);
         yield* repo.deleteOne(orgA, buyMilk.id);
-        const exit = yield* Effect.exit(repo.findOneById(orgA, buyMilk.id));
-        deepStrictEqual(Exit.isFailure(exit), true);
+        const found = yield* repo.findOne(byOrgAndId(orgA, buyMilk.id));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 
@@ -168,7 +163,8 @@ suite("TodosRepositoryLive (integration)", () => {
             : null;
           deepStrictEqual(error instanceof TodoNotFound, true);
         }
-        const found = yield* repo.findOneById(orgA, buyMilk.id);
+        const found = yield* repo.findOne(byOrgAndId(orgA, buyMilk.id));
+        if (found === null) throw new Error("expected stored todo");
         deepStrictEqual(found.id, buyMilk.id);
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -204,8 +200,8 @@ suite("TodosRepositoryLive (integration)", () => {
           ),
         );
         deepStrictEqual(Exit.isFailure(exit), true);
-        const after = yield* Effect.exit(repo.findOneById(orgA, buyMilk.id));
-        deepStrictEqual(Exit.isFailure(after), true);
+        const after = yield* repo.findOne(byOrgAndId(orgA, buyMilk.id));
+        deepStrictEqual(after, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-live.ts
+++ b/packages/server/src/modules/todos/infrastructure/repositories/todos.repository-live.ts
@@ -6,7 +6,9 @@ import { TodoNotFound } from "@/modules/todos/domain/todo/todo.errors.js";
 import { type TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { type TodoRoot } from "@/modules/todos/domain/todo/todo.root.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as TodoMapper from "./todo.mapper.js";
@@ -76,27 +78,29 @@ export const TodosRepositoryLive = Layer.effect(
       ),
     );
 
-    const findOneById = db.makeQuery(
-      (execute, args: { organizationId: OrganizationId; id: TodoId }) =>
-        execute((client) =>
-          client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
-            SELECT * FROM todos.todos
-            WHERE id = ${args.id} AND organization_id = ${args.organizationId}
-          `),
-        ).pipe(
-          orFail(() => new TodoNotFound({ todoId: args.id })),
-          Effect.map(TodoMapper.toDomain),
-          Effect.catchTag("DatabaseError", Effect.die),
-          translatePersistenceUnavailable,
-          Effect.withSpan("TodosRepository.findOneById"),
-        ),
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne pins
+    // the (id, organization_id) primary key, selecting at most one row.
+    const findOne = db.makeQuery((execute, spec: Specification<TodoRoot>) =>
+      execute((client) =>
+        client.maybeOne(sql.type(RowSchemas.TodoRowStd)`
+          SELECT * FROM todos.todos
+          WHERE ${criteriaToWhere(spec.criteria, TodoMapper.columns)}
+          LIMIT 1
+        `),
+      ).pipe(
+        Effect.map((row) => (row === null ? null : TodoMapper.toDomain(row))),
+        Effect.catchTag("DatabaseError", Effect.die),
+        translatePersistenceUnavailable,
+        Effect.withSpan("TodosRepository.findOne"),
+      ),
     );
 
     return TodosRepository.of({
       insertOne,
       updateOne,
       deleteOne: (organizationId, id) => remove({ organizationId, id }),
-      findOneById: (organizationId, id) => findOneById({ organizationId, id }),
+      findOne,
     });
   }),
 );

--- a/packages/server/src/modules/todos/policies/todo.resource-resolvers.ts
+++ b/packages/server/src/modules/todos/policies/todo.resource-resolvers.ts
@@ -5,8 +5,10 @@ import * as Layer from "effect/Layer";
 
 import { type TodoId } from "@/modules/todos/domain/todo/todo.id.js";
 import { TodosRepository } from "@/modules/todos/domain/todo/todos.repository.js";
+import { TodoSpecifications } from "@/modules/todos/domain/todo/todos.specification.js";
 import { TodosRepositoryLive } from "@/modules/todos/infrastructure/repositories/todos.repository-live.js";
 import { type Resolver } from "@/platform/auth/resource-resolver-registry.js";
+import { Spec } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 // Todos expose two policy resources, split by what is actually being
@@ -55,8 +57,8 @@ export class TodoResolverEntry extends Context.Service<TodoResolverEntry, Resolv
   "TodoResolverEntry",
 ) {}
 
-// Loads the todo scoped to its org. `TodoNotFound` (missing OR
-// cross-tenant) → `NotFound`, which the endpoint maps to
+// Loads the todo scoped to its org. Absence (missing OR cross-tenant, since
+// the spec pins the org) → `NotFound`, which the endpoint maps to
 // `TodoNotFoundError`. `PersistenceUnavailable` dies inside the resolver
 // — the endpoint's `recoverPersistenceUnavailable` converts it to 503,
 // same shape as the organization resolver.
@@ -65,10 +67,20 @@ export const TodoResolverEntryLive = Layer.effect(
   Effect.gen(function* () {
     const repo = yield* TodosRepository;
     return ({ organizationId, todoId }) =>
-      repo.findOneById(organizationId, todoId).pipe(
-        Effect.map((todo) => ({ organizationId: todo.organizationId })),
-        Effect.catchTag("TodoNotFound", () => Effect.fail(new CustomHttpApiError.NotFound())),
-        Effect.catchTag("PersistenceUnavailable", Effect.die),
-      );
+      repo
+        .findOne(
+          Spec.and(
+            TodoSpecifications.withId(todoId),
+            TodoSpecifications.forOrganization(organizationId),
+          ),
+        )
+        .pipe(
+          Effect.flatMap((todo) =>
+            todo === null
+              ? Effect.fail(new CustomHttpApiError.NotFound())
+              : Effect.succeed({ organizationId: todo.organizationId }),
+          ),
+          Effect.catchTag("PersistenceUnavailable", Effect.die),
+        );
   }),
 ).pipe(Layer.provide(TodosRepositoryLive));

--- a/packages/server/src/modules/user/commands/create-user.handler.test.ts
+++ b/packages/server/src/modules/user/commands/create-user.handler.test.ts
@@ -9,6 +9,7 @@ import * as Option from "effect/Option";
 import { UserAlreadyExists } from "@/modules/user/domain/user/user.errors.js";
 import { type UserCreated } from "@/modules/user/domain/user/user.events.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
+import { UserSpecifications } from "@/modules/user/domain/user/user.specification.js";
 import { UserRepositoryFake } from "@/modules/user/infrastructure/repositories/user.repository-fake.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
 import { RecordedEvents, RecordingEventBus } from "@/test-utils/recording-event-bus.js";
@@ -30,7 +31,8 @@ describe("createUser", () => {
     Effect.gen(function* () {
       const repo = yield* UserRepository;
       const id = yield* createUser(CreateUserCommand.make(baseCmd));
-      const stored = yield* repo.findOneById(id);
+      const stored = yield* repo.findOne(UserSpecifications.withId(id));
+      if (stored === null) throw new Error("expected stored user");
       deepStrictEqual(stored.email, "alice@example.com");
     }).pipe(Effect.provide(TestLayer)),
   );
@@ -52,7 +54,8 @@ describe("createUser", () => {
     Effect.gen(function* () {
       const repo = yield* UserRepository;
       const id = yield* createUser(CreateUserCommand.make({ email: "jit@example.com" }));
-      const stored = yield* repo.findOneById(id);
+      const stored = yield* repo.findOne(UserSpecifications.withId(id));
+      if (stored === null) throw new Error("expected stored user");
       deepStrictEqual(stored.email, "jit@example.com");
       deepStrictEqual(stored.address, null);
     }).pipe(Effect.provide(TestLayer)),

--- a/packages/server/src/modules/user/commands/delete-user.handler.test.ts
+++ b/packages/server/src/modules/user/commands/delete-user.handler.test.ts
@@ -9,6 +9,7 @@ import * as Option from "effect/Option";
 import { UserNotFound } from "@/modules/user/domain/user/user.errors.js";
 import { type UserDeleted } from "@/modules/user/domain/user/user.events.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
+import { UserSpecifications } from "@/modules/user/domain/user/user.specification.js";
 import { AddressValueObject } from "@/modules/user/domain/user/value-objects/address.value-object.js";
 import { UserRepositoryFake } from "@/modules/user/infrastructure/repositories/user.repository-fake.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -44,8 +45,8 @@ describe("deleteUser", () => {
 
       yield* deleteUser(DeleteUserCommand.make({ userId: id }));
 
-      const exit = yield* Effect.exit(repo.findOneById(id));
-      deepStrictEqual(Exit.isFailure(exit), true);
+      const found = yield* repo.findOne(UserSpecifications.withId(id));
+      deepStrictEqual(found, null);
 
       const events = yield* rec.byTag<UserDeleted>("UserDeleted");
       deepStrictEqual(events.length, 1);

--- a/packages/server/src/modules/user/commands/delete-user.handler.ts
+++ b/packages/server/src/modules/user/commands/delete-user.handler.ts
@@ -1,15 +1,20 @@
 import * as Effect from "effect/Effect";
 
 import { type DeleteUserCommand } from "@/modules/user/commands/delete-user.command.js";
+import { UserNotFound } from "@/modules/user/domain/user/user.errors.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
 import { UserRootOps } from "@/modules/user/domain/user/user.root-ops.js";
+import { UserSpecifications } from "@/modules/user/domain/user/user.specification.js";
 import { DomainEventBus } from "@/platform/ddd/ports/domain-event-bus.js";
 import { withUnitOfWork } from "@/platform/ddd/ports/with-unit-of-work.js";
 
 export const deleteUser = Effect.fn("deleteUser")(function* (cmd: DeleteUserCommand) {
   const repo = yield* UserRepository;
   const bus = yield* DomainEventBus;
-  const user = yield* repo.findOneById(cmd.userId);
+  const user = yield* repo.findOne(UserSpecifications.withId(cmd.userId));
+  if (user === null) {
+    return yield* new UserNotFound({ userId: cmd.userId });
+  }
   const { events } = UserRootOps.markDeleted(user);
   yield* repo.deleteOne(user.id);
   yield* bus.dispatch(events);

--- a/packages/server/src/modules/user/domain/user/user.repository.ts
+++ b/packages/server/src/modules/user/domain/user/user.repository.ts
@@ -1,6 +1,5 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
-import type * as Option from "effect/Option";
 
 import {
   type UserAlreadyExists,
@@ -8,15 +7,19 @@ import {
 } from "@/modules/user/domain/user/user.errors.js";
 import { type UserRoot } from "@/modules/user/domain/user/user.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
-// Every method's error channel includes `PersistenceUnavailable` so the
-// transient-store signal can flow from the live repo through to the
-// endpoint, which maps it to a 503. The shared-kernel port name keeps
-// the domain free of any specific storage technology — the live
-// implementation translates `@org/database`'s `DatabaseUnavailable` into
-// this abstract port-level error at the boundary. Fakes never produce
-// this at runtime but match the channel for type compatibility.
+// Dumb persistence, collapsed to the minimal vocabulary: insert/update/delete
+// the aggregate, and read it back by a Specification. Identity and natural-key
+// lookups — by id, by email — are expressed as a spec at the call site (see
+// UserSpecifications) and compiled to a WHERE fragment by the live repository.
+// Absence is a plain `null`; mapping it to a domain 404 (UserNotFound) is the
+// caller's job. Every method's error channel includes `PersistenceUnavailable`
+// so the transient-store signal can flow from the live repo through to the
+// endpoint, which maps it to a 503; the live implementation translates
+// `@org/database`'s `DatabaseUnavailable` into this abstract port-level error
+// at the boundary. Fakes never produce it at runtime but match the channel.
 export type UserRepositoryShape = {
   readonly insertOne: (
     user: UserRoot,
@@ -25,12 +28,9 @@ export type UserRepositoryShape = {
     user: UserRoot,
   ) => Effect.Effect<void, UserNotFound | PersistenceUnavailable>;
   readonly deleteOne: (id: UserId) => Effect.Effect<void, UserNotFound | PersistenceUnavailable>;
-  readonly findOneById: (
-    id: UserId,
-  ) => Effect.Effect<UserRoot, UserNotFound | PersistenceUnavailable>;
-  readonly findOneByEmail: (
-    email: string,
-  ) => Effect.Effect<Option.Option<UserRoot>, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<UserRoot>,
+  ) => Effect.Effect<UserRoot | null, PersistenceUnavailable>;
 };
 
 export class UserRepository extends Context.Service<UserRepository, UserRepositoryShape>()(

--- a/packages/server/src/modules/user/domain/user/user.specification.test.ts
+++ b/packages/server/src/modules/user/domain/user/user.specification.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { UserId } from "@/platform/ids/user-id.js";
+
+import { UserRootOps } from "./user.root-ops.js";
+import { UserSpecifications } from "./user.specification.js";
+
+const aliceId = UserId.make("11111111-1111-1111-1111-111111111111");
+const bobId = UserId.make("22222222-2222-2222-2222-222222222222");
+const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
+
+const alice = UserRootOps.create({
+  id: aliceId,
+  email: "alice@example.com",
+  address: null,
+  now,
+}).user;
+
+describe("UserSpecifications.withId", () => {
+  it("matches the user with the given id and no other", () => {
+    deepStrictEqual(UserSpecifications.withId(aliceId)(alice), true);
+    deepStrictEqual(UserSpecifications.withId(bobId)(alice), false);
+  });
+
+  it("carries an Eq criteria over the id column", () => {
+    deepStrictEqual(UserSpecifications.withId(aliceId).criteria, {
+      _tag: "Eq",
+      field: "id",
+      value: aliceId,
+    });
+  });
+});
+
+describe("UserSpecifications.withEmail", () => {
+  it("matches the user with the given email and no other", () => {
+    deepStrictEqual(UserSpecifications.withEmail("alice@example.com")(alice), true);
+    deepStrictEqual(UserSpecifications.withEmail("nobody@example.com")(alice), false);
+  });
+
+  it("carries an Eq criteria over the email column", () => {
+    deepStrictEqual(UserSpecifications.withEmail("alice@example.com").criteria, {
+      _tag: "Eq",
+      field: "email",
+      value: "alice@example.com",
+    });
+  });
+});

--- a/packages/server/src/modules/user/domain/user/user.specification.ts
+++ b/packages/server/src/modules/user/domain/user/user.specification.ts
@@ -1,0 +1,15 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type UserId } from "@/platform/ids/user-id.js";
+
+import { type UserRoot } from "./user.root.js";
+
+// Translatable specs (carry a Criteria → usable as repository filters and as
+// in-memory guards). The field-name strings live here and in the mapper's
+// column map; `Spec.eq` types them against UserRoot so a typo is a compile
+// error.
+const withId = (id: UserId): Specification<UserRoot> => Spec.eq<UserRoot, "id">("id", id);
+
+const withEmail = (email: string): Specification<UserRoot> =>
+  Spec.eq<UserRoot, "email">("email", email);
+
+export const UserSpecifications = { withId, withEmail } as const;

--- a/packages/server/src/modules/user/infrastructure/repositories/user.mapper.ts
+++ b/packages/server/src/modules/user/infrastructure/repositories/user.mapper.ts
@@ -4,8 +4,17 @@ import * as DateTime from "effect/DateTime";
 import { UserRoot } from "@/modules/user/domain/user/user.root.js";
 import { AddressValueObject } from "@/modules/user/domain/user/value-objects/address.value-object.js";
 import { UserId } from "@/platform/ids/user-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.UserRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of "user".users. Only filterable scalar fields need an
+// entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+  email: "email",
+} as const satisfies Partial<Record<keyof UserRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): UserRoot =>
   new UserRoot({

--- a/packages/server/src/modules/user/infrastructure/repositories/user.repository-fake.test.ts
+++ b/packages/server/src/modules/user/infrastructure/repositories/user.repository-fake.test.ts
@@ -9,6 +9,7 @@ import * as Option from "effect/Option";
 import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user/user.errors.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
 import { UserRootOps } from "@/modules/user/domain/user/user.root-ops.js";
+import { UserSpecifications } from "@/modules/user/domain/user/user.specification.js";
 import { AddressValueObject } from "@/modules/user/domain/user/value-objects/address.value-object.js";
 import { UserId } from "@/platform/ids/user-id.js";
 
@@ -35,7 +36,8 @@ describe("UserRepositoryFake", () => {
       Effect.gen(function* () {
         const repo = yield* UserRepository;
         yield* repo.insertOne(alice);
-        const found = yield* repo.findOneById(alice.id);
+        const found = yield* repo.findOne(UserSpecifications.withId(alice.id));
+        if (found === null) throw new Error("expected stored user");
         deepStrictEqual(found.id, alice.id);
         deepStrictEqual(found.email, alice.email);
       }).pipe(provide),
@@ -64,40 +66,30 @@ describe("UserRepositoryFake", () => {
     );
   });
 
-  describe("findOneById", () => {
-    it.effect("fails UserNotFound for an unknown id", () =>
+  describe("findOne", () => {
+    it.effect("returns null for an unknown id (absence is not an error)", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.findOneById(aliceId));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof UserNotFound, true);
-        }
+        const found = yield* repo.findOne(UserSpecifications.withId(aliceId));
+        deepStrictEqual(found, null);
       }).pipe(provide),
     );
-  });
 
-  describe("findOneByEmail", () => {
-    it.effect("returns Some(user) when the email matches", () =>
+    it.effect("returns the user when the email matches", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
         yield* repo.insertOne(alice);
-        const result = yield* repo.findOneByEmail("alice@example.com");
-        deepStrictEqual(Option.isSome(result), true);
-        if (Option.isSome(result)) {
-          deepStrictEqual(result.value.id, alice.id);
-        }
+        const found = yield* repo.findOne(UserSpecifications.withEmail("alice@example.com"));
+        if (found === null) throw new Error("expected stored user");
+        deepStrictEqual(found.id, alice.id);
       }).pipe(provide),
     );
 
-    it.effect("returns None when no user has the email", () =>
+    it.effect("returns null when no user has the email", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const result = yield* repo.findOneByEmail("nobody@example.com");
-        deepStrictEqual(Option.isNone(result), true);
+        const found = yield* repo.findOne(UserSpecifications.withEmail("nobody@example.com"));
+        deepStrictEqual(found, null);
       }).pipe(provide),
     );
   });
@@ -112,7 +104,8 @@ describe("UserRepositoryFake", () => {
           now: later,
         });
         yield* repo.updateOne(updated);
-        const found = yield* repo.findOneById(alice.id);
+        const found = yield* repo.findOne(UserSpecifications.withId(alice.id));
+        if (found === null) throw new Error("expected stored user");
         deepStrictEqual(found.address?.country, "Canada");
         deepStrictEqual(found.updatedAt, later);
       }).pipe(provide),
@@ -139,8 +132,8 @@ describe("UserRepositoryFake", () => {
         const repo = yield* UserRepository;
         yield* repo.insertOne(alice);
         yield* repo.deleteOne(alice.id);
-        const exit = yield* Effect.exit(repo.findOneById(alice.id));
-        deepStrictEqual(Exit.isFailure(exit), true);
+        const found = yield* repo.findOne(UserSpecifications.withId(alice.id));
+        deepStrictEqual(found, null);
       }).pipe(provide),
     );
 
@@ -164,15 +157,15 @@ describe("UserRepositoryFake", () => {
       Effect.gen(function* () {
         const repo1 = yield* UserRepository;
         yield* repo1.insertOne(alice);
-        const exists = yield* repo1.findOneByEmail(alice.email);
-        deepStrictEqual(Option.isSome(exists), true);
+        const exists = yield* repo1.findOne(UserSpecifications.withEmail(alice.email));
+        deepStrictEqual(exists !== null, true);
       }).pipe(provide, (first) =>
         Effect.andThen(
           first,
           Effect.gen(function* () {
             const repo2 = yield* UserRepository;
-            const empty = yield* repo2.findOneByEmail(alice.email);
-            deepStrictEqual(Option.isNone(empty), true);
+            const empty = yield* repo2.findOne(UserSpecifications.withEmail(alice.email));
+            deepStrictEqual(empty, null);
           }).pipe(provide),
         ),
       ),

--- a/packages/server/src/modules/user/infrastructure/repositories/user.repository-fake.ts
+++ b/packages/server/src/modules/user/infrastructure/repositories/user.repository-fake.ts
@@ -7,6 +7,7 @@ import * as Ref from "effect/Ref";
 import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user/user.errors.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
 import { type UserRoot } from "@/modules/user/domain/user/user.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type UserId } from "@/platform/ids/user-id.js";
 
 const findUserByEmail = (
@@ -45,17 +46,11 @@ export const UserRepositoryFake = Layer.effect(
           : Effect.fail(new UserNotFound({ userId: id })),
       );
 
-    const findOneById = (id: UserId): Effect.Effect<UserRoot, UserNotFound> =>
-      Effect.flatMap(Ref.get(store), (m) =>
-        Option.match(HashMap.get(m, id), {
-          onNone: () => Effect.fail(new UserNotFound({ userId: id })),
-          onSome: Effect.succeed,
-        }),
-      );
+    // The spec IS the in-memory predicate — the same object the live repo
+    // compiles to SQL — so fake and live agree by construction.
+    const findOne = (spec: Specification<UserRoot>): Effect.Effect<UserRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    const findOneByEmail = (email: string): Effect.Effect<Option.Option<UserRoot>> =>
-      Effect.map(Ref.get(store), (m) => findUserByEmail(m, email));
-
-    return UserRepository.of({ insertOne, updateOne, deleteOne, findOneById, findOneByEmail });
+    return UserRepository.of({ insertOne, updateOne, deleteOne, findOne });
   }),
 );

--- a/packages/server/src/modules/user/infrastructure/repositories/user.repository-live.integration.test.ts
+++ b/packages/server/src/modules/user/infrastructure/repositories/user.repository-live.integration.test.ts
@@ -12,6 +12,7 @@ import { beforeEach } from "vitest";
 import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user/user.errors.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
 import { UserRootOps } from "@/modules/user/domain/user/user.root-ops.js";
+import { UserSpecifications } from "@/modules/user/domain/user/user.specification.js";
 import { AddressValueObject } from "@/modules/user/domain/user/value-objects/address.value-object.js";
 import { UserRepositoryLive } from "@/modules/user/infrastructure/repositories/user.repository-live.js";
 import { UserId } from "@/platform/ids/user-id.js";
@@ -42,11 +43,12 @@ suite("UserRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists the user and decodes it back via findOneById", () =>
+    it.effect("persists the user and decodes it back via findOne(withId)", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
         yield* repo.insertOne(alice);
-        const found = yield* repo.findOneById(alice.id);
+        const found = yield* repo.findOne(UserSpecifications.withId(alice.id));
+        if (found === null) throw new Error("expected stored user");
         deepStrictEqual(found.id, alice.id);
         deepStrictEqual(found.email, alice.email);
         if (found.address === null) throw new Error("expected a stored address");
@@ -79,40 +81,30 @@ suite("UserRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findOneById", () => {
-    it.effect("fails UserNotFound for an unknown id", () =>
+  describe("findOne", () => {
+    it.effect("returns null for an unknown id (absence is not an error)", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const exit = yield* Effect.exit(repo.findOneById(aliceId));
-        deepStrictEqual(Exit.isFailure(exit), true);
-        if (Exit.isFailure(exit)) {
-          const error = Cause.hasFails(exit.cause)
-            ? Cause.findErrorOption(exit.cause).pipe(Option.getOrThrow)
-            : null;
-          deepStrictEqual(error instanceof UserNotFound, true);
-        }
+        const found = yield* repo.findOne(UserSpecifications.withId(aliceId));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
-  });
 
-  describe("findOneByEmail", () => {
-    it.effect("returns Some(user) when the email matches", () =>
+    it.effect("returns the user when the email matches", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
         yield* repo.insertOne(alice);
-        const result = yield* repo.findOneByEmail("alice@example.com");
-        deepStrictEqual(Option.isSome(result), true);
-        if (Option.isSome(result)) {
-          deepStrictEqual(result.value.id, alice.id);
-        }
+        const found = yield* repo.findOne(UserSpecifications.withEmail("alice@example.com"));
+        if (found === null) throw new Error("expected stored user");
+        deepStrictEqual(found.id, alice.id);
       }).pipe(Effect.provide(TestLayer)),
     );
 
-    it.effect("returns None when no user has the email", () =>
+    it.effect("returns null when no user has the email", () =>
       Effect.gen(function* () {
         const repo = yield* UserRepository;
-        const result = yield* repo.findOneByEmail("nobody@example.com");
-        deepStrictEqual(Option.isNone(result), true);
+        const found = yield* repo.findOne(UserSpecifications.withEmail("nobody@example.com"));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });
@@ -127,7 +119,8 @@ suite("UserRepositoryLive (integration)", () => {
           now: later,
         });
         yield* repo.updateOne(updated);
-        const found = yield* repo.findOneById(alice.id);
+        const found = yield* repo.findOne(UserSpecifications.withId(alice.id));
+        if (found === null) throw new Error("expected stored user");
         deepStrictEqual(found.address?.country, "Canada");
         deepStrictEqual(
           DateTime.toDate(found.updatedAt).toISOString(),
@@ -157,8 +150,8 @@ suite("UserRepositoryLive (integration)", () => {
         const repo = yield* UserRepository;
         yield* repo.insertOne(alice);
         yield* repo.deleteOne(alice.id);
-        const exit = yield* Effect.exit(repo.findOneById(alice.id));
-        deepStrictEqual(Exit.isFailure(exit), true);
+        const found = yield* repo.findOne(UserSpecifications.withId(alice.id));
+        deepStrictEqual(found, null);
       }).pipe(Effect.provide(TestLayer)),
     );
 
@@ -185,8 +178,8 @@ suite("UserRepositoryLive (integration)", () => {
         yield* db.transaction((tx) =>
           repo.insertOne(alice).pipe(Database.TransactionContext.provide(tx)),
         );
-        const found = yield* repo.findOneByEmail(alice.email);
-        deepStrictEqual(Option.isSome(found), true);
+        const found = yield* repo.findOne(UserSpecifications.withEmail(alice.email));
+        deepStrictEqual(found !== null, true);
       }).pipe(Effect.provide(TestLayer)),
     );
 
@@ -209,8 +202,8 @@ suite("UserRepositoryLive (integration)", () => {
             : null;
           deepStrictEqual(error instanceof UserNotFound, true);
         }
-        const after = yield* repo.findOneByEmail(alice.email);
-        deepStrictEqual(Option.isNone(after), true);
+        const after = yield* repo.findOne(UserSpecifications.withEmail(alice.email));
+        deepStrictEqual(after, null);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/user/infrastructure/repositories/user.repository-live.ts
+++ b/packages/server/src/modules/user/infrastructure/repositories/user.repository-live.ts
@@ -1,12 +1,13 @@
 import { Database, orFail, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import { UserAlreadyExists, UserNotFound } from "@/modules/user/domain/user/user.errors.js";
 import { UserRepository } from "@/modules/user/domain/user/user.repository.js";
 import { type UserRoot } from "@/modules/user/domain/user/user.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type UserId } from "@/platform/ids/user-id.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as UserMapper from "./user.mapper.js";
@@ -79,33 +80,24 @@ export const UserRepositoryLive = Layer.effect(
       ),
     );
 
-    const findOneById = db.makeQuery((execute, id: UserId) =>
+    // The spec contributes only the WHERE; the repository owns FROM and the
+    // projection. `LIMIT 1` is safe because every spec used with findOne
+    // selects at most one row (the id primary key, the unique email).
+    const findOne = db.makeQuery((execute, spec: Specification<UserRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.UserRowStd)`
-          SELECT * FROM "user".users WHERE id = ${id}
+          SELECT * FROM "user".users
+          WHERE ${criteriaToWhere(spec.criteria, UserMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        orFail(() => new UserNotFound({ userId: id })),
-        Effect.map(UserMapper.toDomain),
+        Effect.map((row) => (row === null ? null : UserMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.findOneById"),
+        Effect.withSpan("UserRepository.findOne"),
       ),
     );
 
-    const findOneByEmail = db.makeQuery((execute, email: string) =>
-      execute((client) =>
-        client.maybeOne(sql.type(RowSchemas.UserRowStd)`
-          SELECT * FROM "user".users WHERE email = ${email}
-        `),
-      ).pipe(
-        Effect.map((row) => (row === null ? Option.none() : Option.some(UserMapper.toDomain(row)))),
-        Effect.catchTag("DatabaseError", Effect.die),
-        translatePersistenceUnavailable,
-        Effect.withSpan("UserRepository.findOneByEmail"),
-      ),
-    );
-
-    return UserRepository.of({ insertOne, updateOne, deleteOne, findOneById, findOneByEmail });
+    return UserRepository.of({ insertOne, updateOne, deleteOne, findOne });
   }),
 );

--- a/packages/server/src/modules/user/policies/user.resource-resolver.ts
+++ b/packages/server/src/modules/user/policies/user.resource-resolver.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import { type Resolver } from "@/platform/auth/resource-resolver-registry.js";
 
 import { UserRepository } from "../domain/user/user.repository.js";
+import { UserSpecifications } from "../domain/user/user.specification.js";
 import { UserRepositoryLive } from "../infrastructure/repositories/user.repository-live.js";
 
 // PersistenceUnavailable is treated as an unrecoverable failure here
@@ -20,8 +21,10 @@ export const UserResolverEntryLive = Layer.effect(
   Effect.gen(function* () {
     const repo = yield* UserRepository;
     return (id) =>
-      repo.findOneById(id).pipe(
-        Effect.catchTag("UserNotFound", () => Effect.fail(new CustomHttpApiError.NotFound())),
+      repo.findOne(UserSpecifications.withId(id)).pipe(
+        Effect.flatMap((user) =>
+          user === null ? Effect.fail(new CustomHttpApiError.NotFound()) : Effect.succeed(user),
+        ),
         Effect.catchTag("PersistenceUnavailable", Effect.die),
       );
   }),

--- a/packages/server/src/modules/wallet/commands/create-wallet.handler.test.ts
+++ b/packages/server/src/modules/wallet/commands/create-wallet.handler.test.ts
@@ -3,11 +3,11 @@ import { deepStrictEqual } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import { CreateWalletCommand } from "@/modules/wallet/commands/create-wallet.command.js";
 import { createWallet } from "@/modules/wallet/commands/create-wallet.handler.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet/wallet.repository.js";
+import { WalletSpecifications } from "@/modules/wallet/domain/wallet/wallet.specification.js";
 import { WalletRepositoryFake } from "@/modules/wallet/infrastructure/repositories/wallet.repository-fake.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { IdentityUnitOfWork } from "@/test-utils/identity-unit-of-work.js";
@@ -25,11 +25,11 @@ describe("createWallet", () => {
 
       yield* createWallet(CreateWalletCommand.make({ organizationId }));
 
-      const stored = yield* repo.findOneByOrganizationId(organizationId);
-      deepStrictEqual(Option.isSome(stored), true);
-      if (Option.isSome(stored)) {
-        deepStrictEqual(stored.value.balance, 0);
-        deepStrictEqual(stored.value.organizationId, organizationId);
+      const stored = yield* repo.findOne(WalletSpecifications.forOrganization(organizationId));
+      deepStrictEqual(stored !== null, true);
+      if (stored !== null) {
+        deepStrictEqual(stored.balance, 0);
+        deepStrictEqual(stored.organizationId, organizationId);
       }
 
       const tags = (yield* rec.all).map((e) => e._tag);

--- a/packages/server/src/modules/wallet/domain/wallet/wallet.repository.ts
+++ b/packages/server/src/modules/wallet/domain/wallet/wallet.repository.ts
@@ -1,19 +1,24 @@
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
-import type * as Option from "effect/Option";
 
 import { type WalletAlreadyExistsForOrganization } from "@/modules/wallet/domain/wallet/wallet.errors.js";
 import { type WalletRoot } from "@/modules/wallet/domain/wallet/wallet.root.js";
 import { type PersistenceUnavailable } from "@/platform/ddd/contracts/persistence-unavailable.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 
+// Dumb persistence, collapsed to the minimal vocabulary: insert the aggregate,
+// and read it back by a Specification. The org's wallet is looked up as a spec
+// at the call site (see WalletSpecifications.forOrganization) and compiled to a
+// WHERE fragment by the live repository. Absence is a plain `null`. `insertOne`
+// keeps its `WalletAlreadyExistsForOrganization` channel: the unique index on
+// organization_id is the idempotency guard the create handler swallows.
 export type WalletRepositoryShape = {
   readonly insertOne: (
     wallet: WalletRoot,
   ) => Effect.Effect<void, WalletAlreadyExistsForOrganization | PersistenceUnavailable>;
-  readonly findOneByOrganizationId: (
-    organizationId: OrganizationId,
-  ) => Effect.Effect<Option.Option<WalletRoot>, PersistenceUnavailable>;
+  readonly findOne: (
+    spec: Specification<WalletRoot>,
+  ) => Effect.Effect<WalletRoot | null, PersistenceUnavailable>;
 };
 
 export class WalletRepository extends Context.Service<WalletRepository, WalletRepositoryShape>()(

--- a/packages/server/src/modules/wallet/domain/wallet/wallet.specification.test.ts
+++ b/packages/server/src/modules/wallet/domain/wallet/wallet.specification.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+import * as DateTime from "effect/DateTime";
+
+import { WalletId } from "@/modules/wallet/domain/wallet/wallet.id.js";
+import { OrganizationId } from "@/platform/ids/organization-id.js";
+
+import { WalletRootOps } from "./wallet.root-ops.js";
+import { WalletSpecifications } from "./wallet.specification.js";
+
+const acmeId = OrganizationId.make("11111111-1111-1111-1111-111111111111");
+const betaId = OrganizationId.make("22222222-2222-2222-2222-222222222222");
+const walletId = WalletId.make("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+const now = DateTime.makeUnsafe(new Date("2025-01-01T00:00:00Z"));
+
+const acmeWallet = WalletRootOps.create({ id: walletId, organizationId: acmeId, now }).wallet;
+
+describe("WalletSpecifications.forOrganization", () => {
+  it("matches the wallet belonging to the given organization and no other", () => {
+    deepStrictEqual(WalletSpecifications.forOrganization(acmeId)(acmeWallet), true);
+    deepStrictEqual(WalletSpecifications.forOrganization(betaId)(acmeWallet), false);
+  });
+
+  it("carries an Eq criteria over the organizationId field", () => {
+    deepStrictEqual(WalletSpecifications.forOrganization(acmeId).criteria, {
+      _tag: "Eq",
+      field: "organizationId",
+      value: acmeId,
+    });
+  });
+});

--- a/packages/server/src/modules/wallet/domain/wallet/wallet.specification.ts
+++ b/packages/server/src/modules/wallet/domain/wallet/wallet.specification.ts
@@ -1,0 +1,13 @@
+import { Spec, type Specification } from "@/platform/ddd/contracts/specification.js";
+import { type OrganizationId } from "@/platform/ids/organization-id.js";
+
+import { type WalletRoot } from "./wallet.root.js";
+
+// Translatable spec (carries a Criteria → usable as a repository filter and as
+// an in-memory guard). The field-name string lives here and in the mapper's
+// column map; `Spec.eq` types it against WalletRoot so a typo is a compile
+// error.
+const forOrganization = (organizationId: OrganizationId): Specification<WalletRoot> =>
+  Spec.eq<WalletRoot, "organizationId">("organizationId", organizationId);
+
+export const WalletSpecifications = { forOrganization } as const;

--- a/packages/server/src/modules/wallet/infrastructure/repositories/wallet.mapper.ts
+++ b/packages/server/src/modules/wallet/infrastructure/repositories/wallet.mapper.ts
@@ -4,8 +4,17 @@ import * as DateTime from "effect/DateTime";
 import { WalletId } from "@/modules/wallet/domain/wallet/wallet.id.js";
 import { WalletRoot } from "@/modules/wallet/domain/wallet/wallet.root.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
+import { type ColumnMap } from "@/platform/persistence/criteria-to-sql.js";
 
 type Row = RowSchemas.WalletRow;
+
+// Resolves the specification field names the live repository filters on to
+// physical columns of wallet.wallets. Only filterable scalar fields need an
+// entry; `satisfies` keeps the keys honest against the root.
+export const columns = {
+  id: "id",
+  organizationId: "organization_id",
+} as const satisfies Partial<Record<keyof WalletRoot, string>> & ColumnMap;
 
 export const toDomain = (row: Row): WalletRoot =>
   new WalletRoot({

--- a/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-fake.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-fake.test.ts
@@ -10,6 +10,7 @@ import { WalletAlreadyExistsForOrganization } from "@/modules/wallet/domain/wall
 import { WalletId } from "@/modules/wallet/domain/wallet/wallet.id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet/wallet.repository.js";
 import { WalletRootOps } from "@/modules/wallet/domain/wallet/wallet.root-ops.js";
+import { WalletSpecifications } from "@/modules/wallet/domain/wallet/wallet.specification.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 
 import { WalletRepositoryFake } from "./wallet.repository-fake.js";
@@ -29,13 +30,11 @@ describe("WalletRepositoryFake", () => {
         const repo = yield* WalletRepository;
         const { wallet } = WalletRootOps.create({ id: walletA, organizationId: acmeId, now });
         yield* repo.insertOne(wallet);
-        const found = yield* repo.findOneByOrganizationId(acmeId);
-        ok(Option.isSome(found));
-        if (Option.isSome(found)) {
-          deepStrictEqual(found.value.id, walletA);
-          deepStrictEqual(found.value.organizationId, acmeId);
-          deepStrictEqual(found.value.balance, 0);
-        }
+        const found = yield* repo.findOne(WalletSpecifications.forOrganization(acmeId));
+        if (found === null) throw new Error("expected stored wallet");
+        deepStrictEqual(found.id, walletA);
+        deepStrictEqual(found.organizationId, acmeId);
+        deepStrictEqual(found.balance, 0);
       }).pipe(provide),
     );
 
@@ -82,22 +81,22 @@ describe("WalletRepositoryFake", () => {
         });
         yield* repo.insertOne(acmeWallet);
         yield* repo.insertOne(betaWallet);
-        const acmeFound = yield* repo.findOneByOrganizationId(acmeId);
-        const betaFound = yield* repo.findOneByOrganizationId(betaId);
-        ok(Option.isSome(acmeFound));
-        ok(Option.isSome(betaFound));
-        if (Option.isSome(acmeFound)) deepStrictEqual(acmeFound.value.id, walletA);
-        if (Option.isSome(betaFound)) deepStrictEqual(betaFound.value.id, walletB);
+        const acmeFound = yield* repo.findOne(WalletSpecifications.forOrganization(acmeId));
+        const betaFound = yield* repo.findOne(WalletSpecifications.forOrganization(betaId));
+        if (acmeFound === null) throw new Error("expected acme wallet");
+        if (betaFound === null) throw new Error("expected beta wallet");
+        deepStrictEqual(acmeFound.id, walletA);
+        deepStrictEqual(betaFound.id, walletB);
       }).pipe(provide),
     );
   });
 
-  describe("findOneByOrganizationId", () => {
-    it.effect("returns None when no wallet exists for the org", () =>
+  describe("findOne", () => {
+    it.effect("returns null when no wallet exists for the org", () =>
       Effect.gen(function* () {
         const repo = yield* WalletRepository;
-        const result = yield* repo.findOneByOrganizationId(acmeId);
-        ok(Option.isNone(result));
+        const result = yield* repo.findOne(WalletSpecifications.forOrganization(acmeId));
+        ok(result === null);
       }).pipe(provide),
     );
   });
@@ -108,15 +107,15 @@ describe("WalletRepositoryFake", () => {
         const repo1 = yield* WalletRepository;
         const { wallet } = WalletRootOps.create({ id: walletA, organizationId: acmeId, now });
         yield* repo1.insertOne(wallet);
-        const exists = yield* repo1.findOneByOrganizationId(acmeId);
-        ok(Option.isSome(exists));
+        const exists = yield* repo1.findOne(WalletSpecifications.forOrganization(acmeId));
+        ok(exists !== null);
       }).pipe(provide, (first) =>
         Effect.andThen(
           first,
           Effect.gen(function* () {
             const repo2 = yield* WalletRepository;
-            const empty = yield* repo2.findOneByOrganizationId(acmeId);
-            ok(Option.isNone(empty));
+            const empty = yield* repo2.findOne(WalletSpecifications.forOrganization(acmeId));
+            ok(empty === null);
           }).pipe(provide),
         ),
       ),

--- a/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-fake.ts
+++ b/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-fake.ts
@@ -8,6 +8,7 @@ import { WalletAlreadyExistsForOrganization } from "@/modules/wallet/domain/wall
 import { type WalletId } from "@/modules/wallet/domain/wallet/wallet.id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet/wallet.repository.js";
 import { type WalletRoot } from "@/modules/wallet/domain/wallet/wallet.root.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
 import { type OrganizationId } from "@/platform/ids/organization-id.js";
 
 const findByOrganizationIdIn = (
@@ -36,11 +37,9 @@ export const WalletRepositoryFake = Layer.effect(
           : Ref.update(store, HashMap.set(wallet.id, wallet)),
       );
 
-    const findOneByOrganizationId = (
-      organizationId: OrganizationId,
-    ): Effect.Effect<Option.Option<WalletRoot>> =>
-      Effect.map(Ref.get(store), (m) => findByOrganizationIdIn(m, organizationId));
+    const findOne = (spec: Specification<WalletRoot>): Effect.Effect<WalletRoot | null> =>
+      Effect.map(Ref.get(store), (m) => Array.from(HashMap.values(m)).find(spec) ?? null);
 
-    return WalletRepository.of({ insertOne, findOneByOrganizationId });
+    return WalletRepository.of({ insertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-live.integration.test.ts
+++ b/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-live.integration.test.ts
@@ -13,6 +13,7 @@ import { WalletAlreadyExistsForOrganization } from "@/modules/wallet/domain/wall
 import { WalletId } from "@/modules/wallet/domain/wallet/wallet.id.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet/wallet.repository.js";
 import { WalletRootOps } from "@/modules/wallet/domain/wallet/wallet.root-ops.js";
+import { WalletSpecifications } from "@/modules/wallet/domain/wallet/wallet.specification.js";
 import { WalletRepositoryLive } from "@/modules/wallet/infrastructure/repositories/wallet.repository-live.js";
 import { OrganizationId } from "@/platform/ids/organization-id.js";
 import { TestDatabaseLive, truncate } from "@/test-utils/test-database.js";
@@ -59,17 +60,17 @@ suite("WalletRepositoryLive (integration)", () => {
   });
 
   describe("insert", () => {
-    it.effect("persists the wallet and decodes it back via findOneByOrganizationId", () =>
+    it.effect("persists the wallet and decodes it back via findOne", () =>
       Effect.gen(function* () {
         yield* seedOrgRow(organizationId);
         const repo = yield* WalletRepository;
         yield* repo.insertOne(acmeWallet);
-        const found = yield* repo.findOneByOrganizationId(organizationId);
-        deepStrictEqual(Option.isSome(found), true);
-        if (Option.isSome(found)) {
-          deepStrictEqual(found.value.id, acmeWallet.id);
-          deepStrictEqual(found.value.organizationId, organizationId);
-          deepStrictEqual(found.value.balance, 0);
+        const found = yield* repo.findOne(WalletSpecifications.forOrganization(organizationId));
+        deepStrictEqual(found !== null, true);
+        if (found !== null) {
+          deepStrictEqual(found.id, acmeWallet.id);
+          deepStrictEqual(found.organizationId, organizationId);
+          deepStrictEqual(found.balance, 0);
         }
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -98,12 +99,12 @@ suite("WalletRepositoryLive (integration)", () => {
     );
   });
 
-  describe("findOneByOrganizationId", () => {
-    it.effect("returns None when no wallet exists for the org", () =>
+  describe("findOne", () => {
+    it.effect("returns null when no wallet exists for the org", () =>
       Effect.gen(function* () {
         const repo = yield* WalletRepository;
-        const result = yield* repo.findOneByOrganizationId(otherOrgId);
-        deepStrictEqual(Option.isNone(result), true);
+        const result = yield* repo.findOne(WalletSpecifications.forOrganization(otherOrgId));
+        deepStrictEqual(result === null, true);
       }).pipe(Effect.provide(TestLayer)),
     );
   });

--- a/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-live.ts
+++ b/packages/server/src/modules/wallet/infrastructure/repositories/wallet.repository-live.ts
@@ -1,12 +1,12 @@
 import { Database, RowSchemas, sql } from "@org/database/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import { WalletAlreadyExistsForOrganization } from "@/modules/wallet/domain/wallet/wallet.errors.js";
 import { WalletRepository } from "@/modules/wallet/domain/wallet/wallet.repository.js";
 import { type WalletRoot } from "@/modules/wallet/domain/wallet/wallet.root.js";
-import { type OrganizationId } from "@/platform/ids/organization-id.js";
+import { type Specification } from "@/platform/ddd/contracts/specification.js";
+import { criteriaToWhere } from "@/platform/persistence/criteria-to-sql.js";
 import { translatePersistenceUnavailable } from "@/platform/translate-persistence-unavailable.js";
 
 import * as WalletMapper from "./wallet.mapper.js";
@@ -45,21 +45,24 @@ export const WalletRepositoryLive = Layer.effect(
       );
     });
 
-    const findOneByOrganizationId = db.makeQuery((execute, organizationId: OrganizationId) =>
+    // The spec contributes only the WHERE; the repository owns FROM, projection,
+    // and the `LIMIT 1` (every spec used with findOne selects at most one row —
+    // the unique organization_id index guarantees at most one wallet per org).
+    const findOne = db.makeQuery((execute, spec: Specification<WalletRoot>) =>
       execute((client) =>
         client.maybeOne(sql.type(RowSchemas.WalletRowStd)`
-          SELECT * FROM wallet.wallets WHERE organization_id = ${organizationId}
+          SELECT * FROM wallet.wallets
+          WHERE ${criteriaToWhere(spec.criteria, WalletMapper.columns)}
+          LIMIT 1
         `),
       ).pipe(
-        Effect.map((row) =>
-          row === null ? Option.none() : Option.some(WalletMapper.toDomain(row)),
-        ),
+        Effect.map((row) => (row === null ? null : WalletMapper.toDomain(row))),
         Effect.catchTag("DatabaseError", Effect.die),
         translatePersistenceUnavailable,
-        Effect.withSpan("WalletRepository.findOneByOrganizationId"),
+        Effect.withSpan("WalletRepository.findOne"),
       ),
     );
 
-    return WalletRepository.of({ insertOne, findOneByOrganizationId });
+    return WalletRepository.of({ insertOne, findOne });
   }),
 );

--- a/packages/server/src/modules/wallet/interface/events/organization.event-adapter.integration.test.ts
+++ b/packages/server/src/modules/wallet/interface/events/organization.event-adapter.integration.test.ts
@@ -5,7 +5,6 @@ import { deepStrictEqual, ok } from "assert";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 import { beforeEach } from "vitest";
 
@@ -95,7 +94,7 @@ const FailingWalletRepository = Layer.succeed(
   WalletRepository,
   WalletRepository.of({
     insertOne: () => Effect.die("simulated wallet command failure"),
-    findOneByOrganizationId: () => Effect.succeed(Option.none()),
+    findOne: () => Effect.succeed(null),
   }),
 );
 

--- a/packages/server/src/platform/ddd/contracts/specification.test.ts
+++ b/packages/server/src/platform/ddd/contracts/specification.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual } from "assert";
+
+import { Spec } from "./specification.js";
+
+type Row = { id: string; acceptedAt: string | null; revokedAt: string | null };
+
+const open = (o: Partial<Row> = {}): Row => ({
+  id: "1",
+  acceptedAt: null,
+  revokedAt: null,
+  ...o,
+});
+
+describe("Spec builders — predicate + criteria in one object", () => {
+  it("eq matches by field and records an Eq criterion", () => {
+    const withId = Spec.eq<Row, "id">("id", "abc");
+    deepStrictEqual(withId(open({ id: "abc" })), true);
+    deepStrictEqual(withId(open({ id: "xyz" })), false);
+    deepStrictEqual(withId.criteria, { _tag: "Eq", field: "id", value: "abc" });
+  });
+
+  it("isNull / isNotNull match nullability", () => {
+    const accepted = Spec.isNotNull<Row>("acceptedAt");
+    deepStrictEqual(accepted(open({ acceptedAt: "2026-01-01" })), true);
+    deepStrictEqual(accepted(open()), false);
+    deepStrictEqual(accepted.criteria, { _tag: "IsNotNull", field: "acceptedAt" });
+  });
+
+  it("and / or / not compose both the predicate and the AST", () => {
+    const isAccepted = Spec.isNotNull<Row>("acceptedAt");
+    const isRevoked = Spec.isNotNull<Row>("revokedAt");
+    const isOpen = Spec.not(Spec.or(isAccepted, isRevoked));
+
+    deepStrictEqual(isOpen(open()), true);
+    deepStrictEqual(isOpen(open({ acceptedAt: "2026-01-01" })), false);
+    deepStrictEqual(isOpen(open({ revokedAt: "2026-01-01" })), false);
+
+    deepStrictEqual(isOpen.criteria, {
+      _tag: "Not",
+      node: {
+        _tag: "Or",
+        nodes: [
+          { _tag: "IsNotNull", field: "acceptedAt" },
+          { _tag: "IsNotNull", field: "revokedAt" },
+        ],
+      },
+    });
+  });
+});

--- a/packages/server/src/platform/ddd/contracts/specification.ts
+++ b/packages/server/src/platform/ddd/contracts/specification.ts
@@ -1,0 +1,64 @@
+// Criteria — a small, closed AST of predicates over an aggregate's ROOT-LEVEL
+// scalar fields. It deliberately has no "some child row matches …" node: a spec
+// can express `accepted_at IS NULL`, never `roles contains admin`. That keeps
+// translation to a WHERE fragment sound (there is one root row to filter) and
+// makes join-shaped filters *unconstructable* — a predicate that reaches into a
+// child collection (e.g. OrganizationRolesSpecifications.hasRole) can only be a
+// plain `Predicate`, never a `Specification`, so it can never be handed to a
+// repository. Multi-table filtered loads are the repository's job (a two-phase
+// id query it owns) or the read side, not this DSL. See criteria-to-sql.
+export type Criteria =
+  | { readonly _tag: "And"; readonly nodes: ReadonlyArray<Criteria> }
+  | { readonly _tag: "Or"; readonly nodes: ReadonlyArray<Criteria> }
+  | { readonly _tag: "Not"; readonly node: Criteria }
+  | { readonly _tag: "IsNull"; readonly field: string }
+  | { readonly _tag: "IsNotNull"; readonly field: string }
+  | { readonly _tag: "Eq"; readonly field: string; readonly value: string | number | boolean };
+
+// An eval-only predicate over a fully materialized aggregate: domain guards,
+// the fake repository, post-load filtering. It carries no Criteria and so is
+// never translatable to SQL.
+export type Predicate<T> = (candidate: T) => boolean;
+
+// A Specification is a Predicate that ALSO carries a translatable Criteria, so
+// the same object filters in memory (fake, guards) and compiles to SQL (live
+// repository). Every builder below produces one; there is no other way to make
+// a Criteria, which is what bounds the DSL to root-level scalars.
+export type Specification<T> = Predicate<T> & {
+  readonly criteria: Criteria;
+};
+
+const make = <T>(predicate: Predicate<T>, criteria: Criteria): Specification<T> =>
+  Object.assign(predicate, { criteria });
+
+const readField = (candidate: unknown, field: string): unknown =>
+  (candidate as Record<string, unknown>)[field];
+
+const isNull = <T>(field: keyof T & string): Specification<T> =>
+  make<T>((candidate) => readField(candidate, field) === null, { _tag: "IsNull", field });
+
+const isNotNull = <T>(field: keyof T & string): Specification<T> =>
+  make<T>((candidate) => readField(candidate, field) !== null, { _tag: "IsNotNull", field });
+
+const eq = <T, K extends keyof T & string>(
+  field: K,
+  value: Extract<T[K], string | number | boolean>,
+): Specification<T> =>
+  make<T>((candidate) => readField(candidate, field) === value, { _tag: "Eq", field, value });
+
+const and = <T>(...specs: ReadonlyArray<Specification<T>>): Specification<T> =>
+  make<T>((candidate) => specs.every((spec) => spec(candidate)), {
+    _tag: "And",
+    nodes: specs.map((spec) => spec.criteria),
+  });
+
+const or = <T>(...specs: ReadonlyArray<Specification<T>>): Specification<T> =>
+  make<T>((candidate) => specs.some((spec) => spec(candidate)), {
+    _tag: "Or",
+    nodes: specs.map((spec) => spec.criteria),
+  });
+
+const not = <T>(spec: Specification<T>): Specification<T> =>
+  make<T>((candidate) => !spec(candidate), { _tag: "Not", node: spec.criteria });
+
+export const Spec = { isNull, isNotNull, eq, and, or, not } as const;

--- a/packages/server/src/platform/persistence/criteria-to-sql.test.ts
+++ b/packages/server/src/platform/persistence/criteria-to-sql.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "@effect/vitest";
+import { deepStrictEqual, throws } from "assert";
+
+import { Spec } from "@/platform/ddd/contracts/specification.js";
+
+import { type ColumnMap, criteriaToWhere } from "./criteria-to-sql.js";
+
+type Row = { id: string; acceptedAt: string | null; revokedAt: string | null };
+
+const columns: ColumnMap = {
+  id: "id",
+  acceptedAt: "accepted_at",
+  revokedAt: "revoked_at",
+};
+
+describe("criteriaToWhere", () => {
+  it("compiles composed null checks to a parameter-free WHERE fragment", () => {
+    const isOpen = Spec.not(
+      Spec.or(Spec.isNotNull<Row>("acceptedAt"), Spec.isNotNull<Row>("revokedAt")),
+    );
+    const frag = criteriaToWhere(isOpen.criteria, columns);
+    deepStrictEqual(frag.sql, '(NOT ("accepted_at" IS NOT NULL OR "revoked_at" IS NOT NULL))');
+    deepStrictEqual(frag.values, []);
+  });
+
+  it("parameterizes Eq values (no interpolation into SQL text)", () => {
+    const frag = criteriaToWhere(Spec.eq<Row, "id">("id", "abc").criteria, columns);
+    deepStrictEqual(frag.sql, '"id" = $slonik_1');
+    deepStrictEqual(frag.values, ["abc"]);
+  });
+
+  it("combines key eq + variant into one AND fragment", () => {
+    const spec = Spec.and(Spec.eq<Row, "id">("id", "abc"), Spec.isNull<Row>("acceptedAt"));
+    const frag = criteriaToWhere(spec.criteria, columns);
+    deepStrictEqual(frag.sql, '("id" = $slonik_1 AND "accepted_at" IS NULL)');
+    deepStrictEqual(frag.values, ["abc"]);
+  });
+
+  it("dies on an unmapped field (programmer error, not a query)", () => {
+    const spec = Spec.eq<Row, "id">("id", "abc");
+    throws(() => criteriaToWhere(spec.criteria, { acceptedAt: "accepted_at" }));
+  });
+});

--- a/packages/server/src/platform/persistence/criteria-to-sql.ts
+++ b/packages/server/src/platform/persistence/criteria-to-sql.ts
@@ -1,0 +1,45 @@
+import { sql } from "@org/database/index";
+
+import { type Criteria } from "@/platform/ddd/contracts/specification.js";
+
+type WhereFragment = ReturnType<typeof sql.fragment>;
+
+// Maps a spec's logical field names to physical columns. Values may be
+// qualified (e.g. "m.role") so the fragment slots into a repository query that
+// owns its own FROM/JOINs — the compiler emits ONLY the WHERE, never the table
+// or projection. The map lives with each repository's mapper.
+export type ColumnMap = Readonly<Record<string, string>>;
+
+// Compiles a Criteria (root-level scalar predicate) into a slonik WHERE
+// fragment. The repository interpolates the result into a query it wrote:
+//   SELECT <projection> FROM <tables/joins> WHERE ${criteriaToWhere(...)}
+// A field with no column mapping is a programmer error (die), not a query.
+export const criteriaToWhere = (criteria: Criteria, columns: ColumnMap): WhereFragment => {
+  const column = (field: string) => {
+    const mapped = columns[field];
+    if (mapped === undefined) {
+      throw new Error(`criteriaToWhere: no column mapping for field "${field}"`);
+    }
+    return sql.identifier([mapped]);
+  };
+
+  const compile = (node: Criteria): WhereFragment => {
+    if (node._tag === "And") {
+      return node.nodes.length === 0
+        ? sql.fragment`TRUE`
+        : sql.fragment`(${sql.join(node.nodes.map(compile), sql.fragment` AND `)})`;
+    }
+    if (node._tag === "Or") {
+      return node.nodes.length === 0
+        ? sql.fragment`FALSE`
+        : sql.fragment`(${sql.join(node.nodes.map(compile), sql.fragment` OR `)})`;
+    }
+    if (node._tag === "Not") return sql.fragment`(NOT ${compile(node.node)})`;
+    if (node._tag === "IsNull") return sql.fragment`${column(node.field)} IS NULL`;
+    if (node._tag === "IsNotNull") return sql.fragment`${column(node.field)} IS NOT NULL`;
+    // Eq — the exhaustive final branch.
+    return sql.fragment`${column(node.field)} = ${node.value}`;
+  };
+
+  return compile(criteria);
+};

--- a/scripts/eslint-rules/dumb-repository-ports.mjs
+++ b/scripts/eslint-rules/dumb-repository-ports.mjs
@@ -1,14 +1,19 @@
 /* eslint-disable */
 /**
- * @fileoverview Repository ports are dumb persistence with a cardinality-explicit
- * vocabulary (ADR-0005). The `*RepositoryShape` type may only declare methods of
- * the form <verb><One|Many>, where verb is insert/update/delete/upsert, plus
- * findOne / findMany (each optionally suffixed with a `By<Key>` lookup). Every
- * operation names its size — one row or many — so callers read intent off the
- * method name. Domain verbs (grant, revoke, promote, activate, cancel, …) are
- * aggregate behaviour, not persistence. Because the Live and Fake implementations
- * must structurally satisfy the port, constraining the port's method names
- * transitively keeps the implementations dumb too.
+ * @fileoverview Repository ports are dumb persistence with a minimal vocabulary
+ * (ADR-0005). The `*RepositoryShape` type may only declare: the write verbs
+ * `<insert|update|delete|upsert><One|Many>`, and the two reads `findOne` /
+ * `findMany`. Reads take a `Specification` and nothing else — there are no
+ * keyed or variant finders (`findOneById`, `findManyByOrganizationId`,
+ * `findOneOpenBy…`, `findAll…`). Every lookup and every variant — by id, by a
+ * natural key, "open", "active", "not deleted" — is a domain Specification the
+ * caller composes and passes to `findOne`/`findMany`, so the rule lives in one
+ * place, the fake filters and the live query with the same object, and the port
+ * cannot drift into read-method bloat. Domain verbs (grant, revoke, promote,
+ * activate, cancel, …) are aggregate behaviour, not persistence. Because the
+ * Live and Fake implementations must structurally satisfy the port,
+ * constraining the port's method names transitively keeps the implementations
+ * dumb too.
  *
  * Scoped (via eslint.config.mjs) to:
  *   packages/server/src/modules/<m>/domain/ports/repositories/*.repository.ts
@@ -18,22 +23,16 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-// A method name is allowed when it is one of:
-//   <verb><One|Many>                    — insertOne, updateMany, deleteOne, upsertOne, …
-//   find<One|Many>[<Qualifier>]By<Key>  — findOneById, findManyByOrganizationId,
-//                                          findOneOpenByOrganizationIdAndEmail, …
-//   find<One|Many>                      — findOne, findMany (bare)
-//   findAll[<Qualifier>]                — findAll, findAllActive (whole collection,
-//                                          no key argument; qualifier is a built-in filter)
-// On a keyed find the optional qualifier (e.g. "Open") is only permitted in front
-// of the `By<Key>` clause, so it always rides along with a lookup — a bare
-// find-and-mutate name like `findOneAndDelete` (no `By`) is still rejected. A
-// keyless filtered collection is `findAll<Qualifier>`, not `findMany<Qualifier>`.
-const ALLOWED_METHOD =
-  /^(?:(?:insert|update|delete|upsert)(?:One|Many)|findAll(?:[A-Z][A-Za-z0-9]*)?|find(?:One|Many)(?:(?:[A-Z][A-Za-z0-9]*)?By[A-Z][A-Za-z0-9]*)?)$/;
+// A method name is allowed when it is exactly one of:
+//   <verb><One|Many>  — insertOne, updateMany, deleteOne, upsertOne, …
+//   findOne / findMany — the ONLY reads; each takes a Specification.
+// A keyed or variant finder (findOneById, findManyByOrganizationId,
+// findOneOpenBy…, findAll…) is rejected: express the lookup/variant as a
+// Specification passed to findOne/findMany, not as a bespoke persistence method.
+const ALLOWED_METHOD = /^(?:(?:insert|update|delete|upsert)(?:One|Many)|find(?:One|Many))$/;
 
 function describeAllowed() {
-  return "insertOne/insertMany, updateOne/updateMany, deleteOne/deleteMany, upsertOne/upsertMany, findOne/findMany (optionally find{One,Many}[<Qualifier>]By<Key>, e.g. findOneById / findManyByOrganizationId / findOneOpenByOrganizationIdAndEmail), findAll / findAll<Qualifier> (e.g. findAllActive)";
+  return "insertOne/insertMany, updateOne/updateMany, deleteOne/deleteMany, upsertOne/upsertMany, and findOne/findMany (each taking a Specification). Express a lookup or variant (by id, by email, open/active/not-deleted) as a Specification passed to findOne/findMany — not as a keyed/qualified find method.";
 }
 
 function keyName(member) {
@@ -73,9 +72,10 @@ export default {
         context.report({
           node: member.key,
           message:
-            `Repository port method "${name}" is not in the cardinality-explicit vocabulary — repositories are dumb persistence (ADR-0005). ` +
-            `Either it reads like a domain verb (put that behaviour on the aggregate and have the use case persist the result), ` +
-            `or it omits the One/Many size (rename to e.g. ${name.startsWith("find") ? "findOne…/findMany…" : "…One/…Many"}). ` +
+            `Repository port method "${name}" is not in the dumb-persistence vocabulary (ADR-0005). ` +
+            (name.startsWith("find")
+              ? `A read is only findOne/findMany taking a Specification — turn this lookup/variant into a Specification the caller composes (e.g. repo.findOne(XSpecifications.withId(id))). `
+              : `It reads like a domain verb — put that behaviour on the aggregate and have the use case persist the result. `) +
             `Allowed: ${describeAllowed()}.`,
         });
       }


### PR DESCRIPTION
## What & why

Repositories previously grew a keyed/variant finder per lookup (`findOneById`, `findManyByOrganizationId`, `findOneOpenByOrganizationIdAndEmail`, …). Each new variant meant a new port method **and** a bespoke `WHERE`, and the same predicate expressed in the fake (in memory) drifted from the live (as SQL).

This collapses every repository's read surface to **`findOne(spec)` / `findMany(spec)`** over a domain **Specification** — a callable predicate that also carries a translatable `Criteria` AST. The *same object* filters the fake in memory, guards aggregate ops, and compiles to a SQL `WHERE` for the live repo, so a lookup/variant is defined once and can't drift.

`ADR-0005` is rewritten to this decision; the `dumb-repository-ports` lint rule is tightened to allow only CRUD writes + bare `findOne`/`findMany`.

## The shape

- **`platform/ddd/contracts/specification.ts`** — `Spec` builders (`eq`, `isNull`, `isNotNull`, `and`, `or`, `not`); `Specification<T>` = a callable `Predicate<T>` carrying a `Criteria` AST; `Predicate<T>` = eval-only (guards / fake / post-load).
- **`platform/persistence/criteria-to-sql.ts`** — `criteriaToWhere(criteria, columns)` compiles a `Criteria` to a slonik `WHERE` fragment. Each mapper carries a `columns` field→column map. **The spec contributes only the `WHERE`; the repository owns FROM/JOIN/projection and reconstitution.**
- **Boundary (type-enforced):** `Criteria` has only root-scalar nodes, so a predicate over a child collection (e.g. `hasRole`) can't be built as a `Criteria` — it stays a `Predicate` and cannot be passed to `findOne` (spec tests lock this with `@ts-expect-error`). Dynamic-join filters remain bespoke repo queries or read-side queries.
- **Absence is `null`** (`findOne`) / `[]` (`findMany`); the handler maps `null` → the appropriate domain `NotFound`.

## Single-row vs multi-row

- Single-row: `findOne` = `maybeOne(… LIMIT 1)`.
- Multi-row (`role`, `organization-roles`): `findOne` = `any(…)` then `toDomain(rows): Root | null`. An empty aggregate = zero rows = `null`, so the caller does `… ?? XRootOps.empty(...)`, and the **fake mirrors the row model** (an empty upsert deletes the stored entry).

## Scope

All 14 aggregate repositories across every module (user, auth ×4, billing ×2, todos, wallet, organization ×3, role). New per-aggregate `*.specification.ts` (+ parity tests) and the shared kit above.

## Verification

`tsc -b`, `check:effect`, unit suite (**396 pass**), server lint (tightened rule), `lint:deps` (no violations), and **all repository + query integration tests** pass against Postgres. The HTTP endpoint / event-adapter integration suites fail only on the pre-existing placeholder-env `DATABASE_URL` config-boot error (`useServerTestRuntime`), unrelated to this change — CI, with real config, exercises them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
