### PR TITLE
chore(deps): upgrade effect-server-utils to 0.1.0-beta.2

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.1081.0",
-    "@effect-server-utils/authz": "0.1.0-beta.1",
-    "@effect-server-utils/cqrs": "0.1.0-beta.1",
+    "@effect-server-utils/authz": "0.1.0-beta.2",
+    "@effect-server-utils/cqrs": "0.1.0-beta.2",
     "@effect/platform-node": "4.0.0-beta.94",
     "@org/contracts": "workspace:^",
     "@org/database": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,11 +372,11 @@ importers:
         specifier: ^3.1081.0
         version: 3.1081.0
       '@effect-server-utils/authz':
-        specifier: 0.1.0-beta.1
-        version: 0.1.0-beta.1(effect@4.0.0-beta.94)
+        specifier: 0.1.0-beta.2
+        version: 0.1.0-beta.2(effect@4.0.0-beta.94)
       '@effect-server-utils/cqrs':
-        specifier: 0.1.0-beta.1
-        version: 0.1.0-beta.1(effect@4.0.0-beta.94)
+        specifier: 0.1.0-beta.2
+        version: 0.1.0-beta.2(effect@4.0.0-beta.94)
       '@effect/platform-node':
         specifier: 4.0.0-beta.94
         version: 4.0.0-beta.94(effect@4.0.0-beta.94)(ioredis@5.11.1)
@@ -787,13 +787,13 @@ packages:
     resolution: {integrity: sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==}
     engines: {node: '>=14.17.0'}
 
-  '@effect-server-utils/authz@0.1.0-beta.1':
-    resolution: {integrity: sha512-GohG6f4nLcZh9nGK2q7p0Vk90M/FSvrvGQc9sJNMKP9Tyl1Iupsi4LPlkU5b3GfXszLXPmc7SkZNAQaKTlqzdQ==}
+  '@effect-server-utils/authz@0.1.0-beta.2':
+    resolution: {integrity: sha512-XeH12DQEFE5qb/r8csTwp4lEGwid9i3bhg8pxceXAmwnWdya+iQ4Li108efDhgI65pQuFpDAP1DTGWYNm8miMA==}
     peerDependencies:
       effect: 4.0.0-beta.94
 
-  '@effect-server-utils/cqrs@0.1.0-beta.1':
-    resolution: {integrity: sha512-rGg2e9yNsLWVcINxFHzfd59h1QvrXO2wJi0uptUqhn0XJSbB+L2A+s3n3ZiP+b3FeYDIBxzLT6+x1WG425gb6g==}
+  '@effect-server-utils/cqrs@0.1.0-beta.2':
+    resolution: {integrity: sha512-DON10PFNAlEfJiY12EjtzKAbEmxlYWi2QL2NvxkcuqW431FKzVM7S2NyjfCdy3iLsRueQCFjTxTz23oX2tXiBA==}
     peerDependencies:
       effect: 4.0.0-beta.94
 
@@ -7482,11 +7482,11 @@ snapshots:
 
   '@discoveryjs/json-ext@1.1.0': {}
 
-  '@effect-server-utils/authz@0.1.0-beta.1(effect@4.0.0-beta.94)':
+  '@effect-server-utils/authz@0.1.0-beta.2(effect@4.0.0-beta.94)':
     dependencies:
       effect: 4.0.0-beta.94
 
-  '@effect-server-utils/cqrs@0.1.0-beta.1(effect@4.0.0-beta.94)':
+  '@effect-server-utils/cqrs@0.1.0-beta.2(effect@4.0.0-beta.94)':
     dependencies:
       effect: 4.0.0-beta.94
 
@@ -10720,7 +10720,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -10753,7 +10753,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10805,7 +10805,7 @@ snapshots:
       - eslint
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
Upgrades both libraries from `0.1.0-beta.1` to `0.1.0-beta.2`.

## What beta.2 changed

It removed the legacy proxy directories flagged in the #124 review — **15 in cqrs, 5 in authz**, one per top-level `src/` module. Each held a lone `package.json` pointing `main`/`module`/`types` at the corresponding `dist` file, which is how a pre-`exports` resolver locates a subpath. Because both packages ship an `exports` map, and an exports map is authoritative for every current resolver, those directories were unreachable on any toolchain capable of consuming an `effect@4` beta.

The installed package root is now just what it should be:

```
@effect-server-utils/cqrs/          @effect-server-utils/authz/
├── dist/                          ├── dist/
├── src/                           ├── src/
├── LICENSE                        ├── LICENSE
├── README.md                      ├── README.md
└── package.json                   └── package.json
```

File counts drop by exactly the proxy counts: cqrs 166 → 151, authz 51 → 46. Unpacked size is essentially unchanged (~420 KB → ~418 KB) since the files were tiny — the win is a package root that no longer advertises 20 unreachable entry points.

## Nothing else moved

I diffed the two releases rather than trusting the version bump. The `exports` maps, all three `dist` trees (`cjs`/`dts`/`esm`), and `src/` all compare **equal** to beta.1, and `dist/**` plus `src/**` are byte-identical excluding sourcemaps. So this carries no code change.

The two properties that made beta.1 correct are intact:

- Root `package.json` still omits `type` while `dist/esm/package.json` declares `{"type":"module"}` — the CJS/ESM split is untouched, and `dist/cjs/package.json` is still correctly absent.
- `./internal` is still absent from `exports`, so the library keeps enforcing its own privacy through resolution failure. `src/internal/*` never had proxy directories, so nothing leaked there either.

## What I checked, because it now fails silently

With the proxy directories gone, **all** resolution rests on the `exports` map. Two things would break quietly rather than loudly, so both were verified explicitly:

- **The `AuthzConfig` augmentation still merges** into the shipped `dist/dts/config.d.ts`. If it stopped, there'd be no error — every `Caller` would just degrade to `never` and checks would type as nonsense. Confirmed with a planted type error resolving to the real `CurrentUser` shape and to this app's `Action` union.
- **Every subpath import still resolves**: `cqrs/event`, `cqrs/testing`, `cqrs/persistence-unavailable`, and the two authz registry seams. Confirmed through dependency-cruiser's resolver as well as `tsc`, since a rule that can't resolve an import silently stops enforcing (ADR-0008).

## Testing

`check`, `build`, `lint`, `lint:rules` (10/10 fire), `lint:deps`, `check:effect`, `test` — all green. 571 unit tests / 135 files. Server + jobs integration suites against local Postgres: 228 + 3 passing.

Diff is two files: `packages/server/package.json` and the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)