### PR TITLE
fix(acceptance): key BFF readiness off its own ready line

### DIFF
--- a/packages/acceptance/playwright.config.ts
+++ b/packages/acceptance/playwright.config.ts
@@ -121,6 +121,13 @@ export default defineConfig({
       name: "bff",
       command: "pnpm -F @org/server exec tsx src/server.ts",
       url: `${BFF_PROBE_URL}/auth/me`,
+      // The listening socket opens before the `request` handler is attached
+      // (effect builds `NodeHttpServer.layer` first, `HttpRouter.serve` last),
+      // and a request accepted in that window is never answered. Playwright's
+      // URL probe has no per-request timeout and retries serially, so one probe
+      // landing there stalls readiness until `timeout`. "Listening on" is logged
+      // after the handler is attached; `url` stays as the port-in-use guard.
+      wait: { stdout: /Listening on/ },
       cwd: "../../",
       env: {
         ...process.env,


### PR DESCRIPTION
## The flake

The E2E workflow fails intermittently ([example run](https://github.com/dataquail/functional-domain-driven-hexagon/actions/runs/33414957496/job/99563282670)) with:

```
[bff] [16:37:23.695] INFO (#2): Listening on http://0.0.0.0:3001
Error: Timed out waiting 60000ms from config.webServer.
```

The BFF was up 3s in and then answered nothing for 57s — no `Sent HTTP response` line, and no `[web]` output at all. It isn't a slow boot; nothing ever asked the server anything.

## Cause

Two things compose into a permanent hang:

1. **The listening socket opens before the request handler exists.** `server.ts` provides `NodeHttpServer.layer` at the bottom of the graph, so it builds first, and `NodeHttpServer.make` calls `server.listen()` during its own layer construction. The node `request` handler is attached later, by `HttpRouter.serve`, once env, database, tracer, buses, module dispatchers and policy registries have all built.
2. **A request accepted in that window is never answered.** Node parses it and emits `request` with zero listeners; attaching a handler afterwards does not redeliver it. The connection just sits there.
3. **Playwright's probe has no per-request timeout and retries serially** (`httpStatusCode` passes no `socketTimeout`; `waitFor` awaits each probe). One probe caught in the window stops the readiness loop entirely until the entry's `timeout` expires — and since webServer entries start sequentially, `web` never gets spawned.

Probe schedule (0, 100, 350, 850, 1850, 2850, 3850ms…) versus a window that opens ~2s in and closes ~2.9s in is a coin flip, which is the intermittency: 4 failures in the last ~40 runs, always this step.

## Evidence

- Passing run [33400290212](https://github.com/dataquail/functional-domain-driven-hexagon/actions/runs/33400290212): `Listening on` at `14:04:11.008`, probe `GET /auth/me 401` at `14:04:11.372`. Same shape, probe just landed after the window.
- Reproduced with this repo's own idiom (`HttpRouter.serve` over a deliberately slow layer): probes sent at 100–2925ms all connected and were **never answered**; the first answered probe was sent 20ms after `Listening on`.
- Reproduced the exact CI signature at the harness level with a fake server that listens, then attaches its handler 5s later: `url` probe only → `Error: Timed out waiting 8000ms from config.webServer.`; with this change → `1 passed`.

## The change

```ts
wait: { stdout: /Listening on/ },
```

`Listening on` is logged after the handler is attached (`withLogAddress` builds the serve layer first), so it is a race-free readiness signal. `url` stays as the port-already-in-use guard and as a fallback — Playwright races both signals, so a stuck probe can no longer block.

`pnpm lint` and the acceptance typecheck pass.

## Not addressed here

- **`web` needs no equivalent**: `next start` attaches its handler before listening, so it has no window.
- **The window itself still exists in the BFF** — a client or health check connecting during boot gets a hang rather than a refusal. Closing it means not opening the socket until the graph is built, which this effect API doesn't expose; the workable version (forcing the heavy layers to build below `NodeHttpServer.layer`) duplicates the dependency list and would rot silently. Left for a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)