### PR TITLE
fix(lint): probe every architectural rule, and un-vacuum no-deep-relative-imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -266,7 +266,6 @@
         "react/self-closing-comp": "error",
         "react/no-unstable-nested-components": "error",
         "local/enforce-react-namespace": "error",
-        "local/no-deep-relative-imports": "error",
         "react/rules-of-hooks": "error",
         "react/exhaustive-deps": "warn",
         "react/only-export-components": [
@@ -421,7 +420,7 @@
       "plugins": ["react"]
     },
     {
-      "files": ["packages/server/**/*.{ts,tsx,js,jsx}"],
+      "files": ["packages/server/**/*.{ts,tsx,js,jsx}", "packages/web/**/*.{ts,tsx,js,jsx}"],
       "rules": {
         "local/no-deep-relative-imports": "error"
       }

--- a/scripts/lint-rule-probes.mjs
+++ b/scripts/lint-rule-probes.mjs
@@ -15,59 +15,64 @@ import path from "node:path";
 
 const repoRoot = process.cwd();
 
+// Probe filenames must not start with an underscore. The folder-structure
+// plugin mangles a leading `_` when substituting `{node-name}`, so an
+// `enforceExistence` rule fires on such a file whether or not its sibling
+// exists — a parity probe named that way passes vacuously, which is the exact
+// failure mode this script exists to catch.
 /** @type {Array<{rule: string, file: string, source: string}>} */
 const PROBES = [
   {
     rule: "project-structure/server-modules",
-    file: "packages/server/src/modules/todos/__probe-stray.ts",
+    file: "packages/server/src/modules/todos/zzprobe-stray.ts",
     source: "export const probe = 1;\n",
   },
   {
     rule: "project-structure/web-features",
-    file: "packages/web/features/__probe-untiered.tsx",
+    file: "packages/web/features/zzprobe-untiered.tsx",
     source: "export const Probe = () => null;\n",
   },
   {
     rule: "local/bus-factories-at-composition-roots",
-    file: "packages/server/src/modules/todos/commands/__probe-bus.handler.ts",
+    file: "packages/server/src/modules/todos/commands/zzprobe-bus.handler.ts",
     source:
       'import { makeCommandBus } from "@effect-server-utils/cqrs";\n\nexport const probe = makeCommandBus;\n',
   },
   {
     rule: "local/prefer-named-exports",
-    file: "packages/server/src/__probe-default.ts",
+    file: "packages/server/src/zzprobe-default.ts",
     source: "const probe = 1;\nexport default probe;\n",
   },
   {
     rule: "local/no-array-push-spread",
-    file: "packages/server/src/__probe-push.ts",
+    file: "packages/server/src/zzprobe-push.ts",
     source:
       "const items: Array<number> = [];\nconst target: Array<number> = [];\ntarget.push(...items);\n\nexport const probe = target;\n",
   },
   {
     rule: "local/lucide-icon-suffix",
-    file: "packages/components/primitives/__probe-lucide.ts",
+    file: "packages/components/primitives/zzprobe-lucide.ts",
     source: 'import { Clock } from "lucide-react";\n\nexport const probe = Clock;\n',
   },
   {
     rule: "local/no-inline-styling",
-    file: "packages/web/features/__probe/probe-styling.view.tsx",
+    file: "packages/web/features/zzprobe/probe-styling.view.tsx",
     source: 'export const Probe = () => <Probe className="p-4" />;\n',
   },
   {
     rule: "local/view-hooks-allowlist",
-    file: "packages/web/features/__probe/probe-hooks.view.tsx",
+    file: "packages/web/features/zzprobe/probe-hooks.view.tsx",
     source:
       'import * as React from "react";\n\nexport const Probe = () => {\n  const [n] = React.useState(0);\n  return n;\n};\n',
   },
   {
     rule: "react/forbid-elements",
-    file: "packages/web/features/__probe/probe-intrinsic.view.tsx",
+    file: "packages/web/features/zzprobe/probe-intrinsic.view.tsx",
     source: "export const Probe = () => <div />;\n",
   },
   {
     rule: "local/no-effect-namespace-imports",
-    file: "packages/server/src/__probe-effect-ns.ts",
+    file: "packages/server/src/zzprobe-effect-ns.ts",
     source: 'import { Effect } from "effect";\n\nexport const probe = Effect;\n',
   },
   {
@@ -76,7 +81,7 @@ const PROBES = [
     // every install. This probe is what catches a reinstall that silently
     // dropped it.
     rule: "effecttsgo/global-date",
-    file: "packages/server/src/__probe-global-date.ts",
+    file: "packages/server/src/zzprobe-global-date.ts",
     source: "export const probe = (): Date => new Date();\n",
   },
   {
@@ -84,7 +89,7 @@ const PROBES = [
     // tag reading another module's schema, with the quotes ADR-0020 requires on
     // a reserved word. The rule this replaced could see neither.
     rule: "local/no-cross-schema-sql-access",
-    file: "packages/server/src/modules/todos/queries/__probe-cross-schema.handler.ts",
+    file: "packages/server/src/modules/todos/queries/zzprobe-cross-schema.handler.ts",
     source:
       'import { Database } from "@org/database/index";\n' +
       'import * as Effect from "effect/Effect";\n\n' +
@@ -96,7 +101,7 @@ const PROBES = [
   {
     // The other half of the rule: a table with no schema at all.
     rule: "local/no-cross-schema-sql-access",
-    file: "packages/server/src/modules/todos/queries/__probe-unqualified.handler.ts",
+    file: "packages/server/src/modules/todos/queries/zzprobe-unqualified.handler.ts",
     source:
       'import { Database } from "@org/database/index";\n' +
       'import * as Effect from "effect/Effect";\n\n' +
@@ -104,6 +109,73 @@ const PROBES = [
       "  Database.Database,\n" +
       "  (sql) => sql`SELECT id FROM todos`,\n" +
       ");\n",
+  },
+  {
+    // The alias root differs per package (server: src/, web: package root), so
+    // each aliased package is probed separately — a package missing from the
+    // rule's map makes it silently vacuous there, which is how web went
+    // unenforced while being configured for it.
+    rule: "local/no-deep-relative-imports",
+    file: "packages/server/src/zzprobe/deep/probe.ts",
+    source: 'import { probe as p } from "../../platform/ids";\n\nexport const probe = p;\n',
+  },
+  {
+    rule: "local/no-deep-relative-imports",
+    file: "packages/web/features/zzprobe/deep/probe.view.tsx",
+    source:
+      'import { probe as p } from "../../../services/format/probe";\n\nexport const Probe = () => p;\n',
+  },
+  {
+    rule: "local/no-relative-import-outside-package",
+    file: "packages/server/src/zzprobe-outside-pkg.ts",
+    source:
+      'import { probe as p } from "../../contracts/src/index.js";\n\nexport const probe = p;\n',
+  },
+  {
+    rule: "local/dumb-repository-ports",
+    file: "packages/server/src/modules/todos/domain/todo/zzprobe-dumb.repository.ts",
+    source:
+      "export type ProbeRepositoryShape = {\n  readonly findOneById: (id: string) => string;\n};\n",
+  },
+  {
+    rule: "local/enforce-react-namespace",
+    file: "packages/components/primitives/zzprobe-react-ns.tsx",
+    source: 'import { useState } from "react";\n\nexport const probe = useState;\n',
+  },
+  {
+    rule: "project-structure/components-primitives",
+    file: "packages/components/primitives/zzprobe/probe.tsx",
+    source: "export const Probe = () => null;\n",
+  },
+  {
+    rule: "project-structure/components-patterns",
+    file: "packages/components/patterns/zzprobe/probe.tsx",
+    source: "export const Probe = () => null;\n",
+  },
+  {
+    // The parity half of the taxonomy (21 enforceExistence rules) was entirely
+    // unprobed — only layout was. These three cover its distinct mechanisms:
+    // the cross-folder port trio, a same-folder {node-name}.test.ts, and the
+    // {node-name}.integration.test.ts variant.
+    rule: "project-structure/server-modules",
+    file: "packages/server/src/modules/todos/domain/todo/zzprobe-parity.repository.ts",
+    source:
+      "export type ProbeRepositoryShape = {\n  readonly findOne: (spec: unknown) => unknown;\n};\n",
+  },
+  {
+    rule: "project-structure/server-modules",
+    file: "packages/server/src/modules/todos/commands/zzprobe-parity.handler.ts",
+    source: "export const probeParityHandler = () => null;\n",
+  },
+  {
+    rule: "project-structure/server-modules",
+    file: "packages/server/src/modules/todos/interface/http/zzprobe-parity.endpoint.ts",
+    source: "export const probeParityEndpoint = () => null;\n",
+  },
+  {
+    rule: "project-structure/web-features",
+    file: "packages/web/features/zzprobe/probe.view-model.ts",
+    source: "export const probeAtom = null;\n",
   },
 ];
 

--- a/scripts/lint-rules/no-deep-relative-imports.mjs
+++ b/scripts/lint-rules/no-deep-relative-imports.mjs
@@ -1,6 +1,13 @@
 /* eslint-disable */
 /**
- * @fileoverview prevent relative imports going up more than one level (../../) in client and server packages
+ * @fileoverview prevent relative imports going up more than one level (../../)
+ * in packages that configure a `@/` path alias.
+ *
+ * The alias does not resolve to the same place in every package — server maps
+ * `@/*` to `src/*`, web maps it to the package root — so the root is declared
+ * per package rather than assumed to be `src`. A package absent from the map
+ * has no alias for the fix to point at, so the rule must not run there: telling
+ * an author to "use @/..." in a package with no such path is worse than silence.
  */
 
 import path from "path";
@@ -9,14 +16,18 @@ import path from "path";
 // Rule Definition
 //------------------------------------------------------------------------------
 
-// List of packages where this rule should be enforced and aliases are configured
-const ALIASED_PACKAGES_PREFIX = ["packages/client", "packages/server"];
+// package prefix → the directory its `@/` alias resolves to, relative to the
+// package. Keep in sync with each package's tsconfig `paths`.
+const ALIAS_ROOT_BY_PACKAGE = {
+  "packages/server": "src",
+  "packages/web": ".",
+};
 
 export default {
   meta: {
     docs: {
       description:
-        "prevent relative imports going up more than one level (../../) in client and server packages",
+        "prevent relative imports going up more than one level (../../) in packages with a @/ alias",
       category: "Best Practices",
       recommended: true,
     },
@@ -59,22 +70,22 @@ export default {
       return depth;
     }
 
-    function isInAliasedPackage(filename) {
-      const relativeFilePath = path.relative(context.getCwd(), filename);
-      return ALIASED_PACKAGES_PREFIX.some((prefix) =>
-        relativeFilePath.startsWith(prefix + path.sep),
+    const cwd = context.getCwd();
+
+    // The package prefix governing this file, or null when the package
+    // configures no `@/` alias.
+    function getAliasedPackagePrefix(filename) {
+      const relativeFilePath = path.relative(cwd, filename);
+      return (
+        Object.keys(ALIAS_ROOT_BY_PACKAGE).find((prefix) =>
+          relativeFilePath.startsWith(prefix + path.sep),
+        ) ?? null
       );
     }
 
-    function getPackageSrcRoot(filename) {
-      const relativeFilePath = path.relative(context.getCwd(), filename);
-      for (const prefix of ALIASED_PACKAGES_PREFIX) {
-        if (relativeFilePath.startsWith(prefix + path.sep)) {
-          // Assume alias maps to the 'src' directory within the package
-          return path.join(context.getCwd(), prefix, "src");
-        }
-      }
-      return null; // Should not happen if isInAliasedPackage is true
+    // The absolute directory this package's `@/` resolves to.
+    function getAliasRoot(prefix) {
+      return path.resolve(cwd, prefix, ALIAS_ROOT_BY_PACKAGE[prefix]);
     }
 
     //----------------------------------------------------------------------
@@ -88,8 +99,9 @@ export default {
 
       const fileName = context.filename;
 
-      // Only apply this rule within specific packages
-      if (!isInAliasedPackage(fileName)) {
+      // Only apply this rule within packages that configure the alias.
+      const prefix = getAliasedPackagePrefix(fileName);
+      if (prefix === null) {
         return;
       }
 
@@ -103,43 +115,35 @@ export default {
           fix(fixer) {
             try {
               const fileDir = path.dirname(fileName);
-              const srcRoot = getPackageSrcRoot(fileName);
-              if (!srcRoot) return null; // Cannot determine src root
+              const aliasRoot = getAliasRoot(prefix);
 
               const absoluteImportPath = path.resolve(fileDir, importPath);
 
               // Extract the original extension, if any
               const originalExt = path.extname(importPath);
 
-              // Calculate the path relative to the package's src root
-              let relativeToSrc = path.relative(srcRoot, absoluteImportPath);
+              // Calculate the path relative to the alias root
+              let relativeToRoot = path.relative(aliasRoot, absoluteImportPath);
 
-              // Check if the path is outside the src root.
-              // If it starts with '..' or is absolute (e.g., different drive on Windows),
-              // the import is resolving outside the intended alias scope.
-              if (relativeToSrc.startsWith("..") || path.isAbsolute(relativeToSrc)) {
-                console.warn(
-                  `Import ${importPath} in ${fileName} resolves outside src root ${srcRoot}. Skipping autofix.`,
-                );
-                return null; // Don't apply fix if import is outside src
+              // An import resolving outside the alias root (another package) is
+              // not expressible as `@/...`. `no-relative-import-outside-package`
+              // reports that case with the right advice, so leave it unfixed.
+              if (relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
+                return null;
               }
 
               // If there was no original extension, remove common extensions from the calculated path
               if (!originalExt) {
-                relativeToSrc = relativeToSrc.replace(/\.(js|jsx|ts|tsx|mjs|cjs)$/, "");
+                relativeToRoot = relativeToRoot.replace(/\.(js|jsx|ts|tsx|mjs|cjs)$/, "");
               }
 
               // Ensure path uses forward slashes for consistency
-              relativeToSrc = relativeToSrc.replace(/\\/g, "/");
+              relativeToRoot = relativeToRoot.replace(/\\/g, "/");
 
-              // Re-append the original extension if it existed, otherwise use the potentially extension-less path
-              const finalRelativePath = originalExt ? relativeToSrc : relativeToSrc;
-
-              const aliasedPath = `@/${finalRelativePath}`;
+              const aliasedPath = `@/${relativeToRoot}`;
               const targetNode = node.type === "CallExpression" ? node.arguments[0] : node.source;
               return fixer.replaceText(targetNode, `'${aliasedPath}'`);
             } catch (e) {
-              console.error("Error generating fix for no-deep-relative-imports:", e);
               return null; // Don't apply fix if calculation fails
             }
           },


### PR DESCRIPTION
## The defect

`local/no-deep-relative-imports` was configured for server, web and components, but its own `ALIASED_PACKAGES_PREFIX` listed `packages/client` — a package that does not exist. `isInAliasedPackage` returned false, so the rule **returned early and reported nothing on web and components**, even though `packages/web/tsconfig.json` configures the `@/*` alias the rule exists to enforce.

A second defect in the same rule: `getPackageSrcRoot` hardcoded `<package>/src`, but the alias root differs per package — server maps `@/*` to `src/*`, web maps it to the package root. Fixing only the prefix list would have produced wrong autofix paths for web.

### Fix

`ALIASED_PACKAGES_PREFIX` becomes a package → alias-root map, so each package declares where its `@/` points. `packages/client` is gone, `packages/web` added. **components is dropped from the rule's scope** in `.oxlintrc.json` rather than added to the map: it configures no `@/` alias at all, and advising an alias that does not exist is worse than silence. (This is why `primitives/icon/icon.tsx`'s `../../lib/utils/cn` stays legal — now deliberately rather than accidentally.)

Also removed a `console.warn` from the autofix path that leaked to stderr on ordinary non-`--fix` runs, since fixes are computed eagerly.

Web had zero deep relative imports, so the fix turns nothing red.

## Probe coverage

Six of sixteen configured architectural rules had no probe. The larger gap: the **parity half of the ADR-0008 taxonomy was entirely unprobed** — every `enforceExistence` rule, which is most of the 21 parity rules and most of the didactic messages. Only layout was covered.

Adds eleven probes (13 → 24), including the three distinct parity mechanisms: the cross-folder port trio, a same-folder `{node-name}.test.ts`, and the `{node-name}.integration.test.ts` variant.

## Verification

The web probe reproduces the shipped bug rather than merely passing. Removing `packages/web` from the new map:

```
✓  local/no-deep-relative-imports            fires
✗  local/no-deep-relative-imports            SILENT — rule is vacuous
1 of 24 architectural rules did not fire on a known violation.
```

I also confirmed from the diagnostic text that all four new parity probes fire via `enforceExistence`, not via layout denial.

## One trap found on the way

The first four parity probes were passing **for the wrong reason**. The expected sibling came back rendered as `-probe-parity.handler.test.ts` — the folder-structure plugin mangles a leading underscore when substituting `{node-name}`, so it looks for a file that can never exist:

| probe file | sibling test present? | result |
| --- | --- | --- |
| `__probe-x.handler.ts` | yes | **fires** — sibling ignored |
| `zzprobe-x.handler.ts` | yes | quiet |
| `zzprobe-x.handler.ts` | no | fires |

Any `__`-prefixed file trips `enforceExistence` unconditionally. All 24 probes are now off the `__` prefix, with a comment in the harness explaining why — a parity probe named that way passes vacuously, which is precisely the failure mode this script exists to catch.

Real code is unaffected: nothing in the repo starts with `_`. But it is a live defect in the vendored plugin.

## Checks

`pnpm lint` and `pnpm lint:rules` both green; all 24 rules fire on a known violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
