### PR TITLE
feat(architecture): the manifest states what files and folders may be called

### DIFF
--- a/.claude/rules/architecture-rules.md
+++ b/.claude/rules/architecture-rules.md
@@ -53,6 +53,27 @@ Repo-wide statements — prohibitions that hold everywhere, and restrictions on
 who may import a given exported symbol — sit at the top level as `deny` and
 `exports`.
 
+## Naming
+
+`children` says which stereotypes a folder admits; `name` says what the concept
+name in front of the stereotype may look like — the degree of freedom a taxonomy
+alone leaves open, and the one an agent drifts through first. It takes
+`"kebab-case"`, `"camelCase"`, `"PascalCase"`, `"snake_case"`, `{ regex, message }`
+or `{ like: "{capture}" }`, and it **inherits like `imports`**, so a tier states it
+once.
+
+A file's concept name is its basename up to the **first dot** — `todos` in
+`todos.repository-live.ts` — not what a `*` matched, which would swallow a
+compound stereotype. A folder node's `name` also judges its own segment when its
+key declares a capture, which is what refuses a module folder named `Todos_V2`.
+
+`{ like: "{subdomain}" }` on `domain/{subdomain}/*.root.ts` is the cross-reference
+the other forms cannot express: a subdomain folder is the aggregate, so `todo/`
+holds `todo.root.ts`. This repo declares kebab-case for the server, web,
+components, jobs, cli, mcp and api-client; PascalCase for `contracts/src`
+(Effect-style module names); and two regexes carrying a named exception each —
+`Database.ts` and `features/__root/`.
+
 ## Patterns
 
 Globs over repo-relative paths, matched against **fully resolved** targets:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Effect v4 monorepo, hexagonal architecture, DDD. Full rationale lives in `docs/a
 | Frontend (`packages/web`, `packages/components`)      | `.claude/rules/frontend.md`                      | 0015, 0018, 0019, 0026                  |
 | Any Effect v4 API you are not certain of              | `.claude/rules/effect-v4-source.md`              | —                                       |
 | Writing comments (any package)                        | `.claude/rules/comments.md`                      | —                                       |
-| Any architectural boundary, lint config, rule probes  | `.claude/rules/architecture-rules.md`            | 0008, 0025, 0027, 0028                  |
+| Any architectural boundary, file naming, rule probes  | `.claude/rules/architecture-rules.md`            | 0008, 0025, 0027, 0028                  |
 
 ## Monorepo map
 

--- a/architecture.config.mjs
+++ b/architecture.config.mjs
@@ -312,7 +312,17 @@ export default {
         external: ["effect", "vitest", "@effect/vitest"],
         allow: ["node:**", "~/contracts/**", "vitest.shared.ts"],
       },
-      children: { "**/": { layout: "open", children: {} } },
+      children: {
+        // Every module in src/ is an Effect-style module named for what it
+        // exports, so its concept name is that exported name rather than a
+        // kebab-case slug. The package's own config files are not.
+        "src/": {
+          name: "PascalCase",
+          layout: "open",
+          children: { "**/": { layout: "open", children: {} } },
+        },
+        "**/": { layout: "open", children: {} },
+      },
     },
 
     "~/database/": {
@@ -333,10 +343,29 @@ export default {
         ],
         allow: ["node:**", "~/database/**", "vitest.shared.ts"],
       },
-      children: { "**/": { layout: "open", children: {} } },
+      children: {
+        "src/": {
+          // Database.ts is an Effect-style module named for the service it
+          // exports; the helpers beside it are ordinary kebab-case files.
+          name: {
+            regex: "^(?:Database|[a-z0-9]+(?:-[a-z0-9]+)*)$",
+            message:
+              "A file in @org/database is kebab-case, except Database.ts, which is named for the service it exports.",
+          },
+          layout: "open",
+          children: {
+            // A migration's name is its ordinal and what it does, in the order
+            // the migrator runs them.
+            "migrations/": { name: "snake_case", layout: "open", children: {} },
+            "**/": { name: "kebab-case", layout: "open", children: {} },
+          },
+        },
+        "**/": { layout: "open", children: {} },
+      },
     },
 
     "~/api-client/": {
+      name: "kebab-case",
       message:
         "@org/api-client is the shared typed client and credential store the CLI and the MCP server sit on.",
       layout: "open",
@@ -350,6 +379,7 @@ export default {
     },
 
     "~/cli/": {
+      name: "kebab-case",
       message: "@org/cli is the command-line client: device-flow auth, organizations, todos.",
       layout: "open",
       imports: {
@@ -362,6 +392,7 @@ export default {
     },
 
     "~/mcp/": {
+      name: "kebab-case",
       message: "@org/mcp exposes the CLI surface as MCP tools over stdio.",
       layout: "open",
       imports: {
@@ -374,6 +405,7 @@ export default {
     },
 
     "~/jobs/": {
+      name: "kebab-case",
       message: "@org/jobs runs the background and cron jobs.",
       layout: "open",
       imports: {
@@ -389,6 +421,7 @@ export default {
     // The bespoke component library. Direction: features → patterns →
     // primitives → third-party (ADR-0015). Only primitives touch a UI library.
     "~/components/": {
+      name: "kebab-case",
       message:
         "@org/components holds two trees: primitives/ (atoms) and patterns/ (molecules and organisms), plus the class-name helpers in lib/, the providers/ and the Storybook config. A new folder here is a new tier — declare it deliberately.",
       imports: {
@@ -487,6 +520,7 @@ export default {
     // Next renderer over the Effect BFF. MVVM, and the arrow points one way:
     // Model (services/) ← ViewModel (*.view-model.ts) ← View (*.view.tsx).
     "~/web/": {
+      name: "kebab-case",
       message:
         "packages/web is the Next App Router renderer: app/ holds the routes, features/ the MVVM tiers, services/ the Model, lib/ and test/ the supporting code. There is no fifth folder — a new one is a new tier.",
       imports: {
@@ -530,6 +564,14 @@ export default {
             "Files in packages/web/features/** must carry a view-tier stereotype (ADR-0026): a naked component is *.view.tsx, all behaviour is *.view-model.ts, and tests are *.test.{ts,tsx}. A bare component file has no stereotype — rename it *.view.tsx. There is no presenter tier.",
           children: {
             "{feature}/": {
+              // __root holds the chrome every route shares — a slot in the
+              // layout rather than a feature, and the one folder here that is
+              // not named after one.
+              name: {
+                regex: "^(?:__root|[a-z0-9]+(?:-[a-z0-9]+)*)$",
+                message:
+                  "A feature folder is kebab-case, named after the feature. The one exception is __root, the chrome every route shares.",
+              },
               message:
                 "Files in packages/web/features/** must carry a view-tier stereotype (ADR-0026): *.view.tsx, *.view-model.ts, or *.test.{ts,tsx}. There is no presenter tier.",
               children: {
@@ -621,6 +663,7 @@ export default {
     // cipher. Being reachable from everywhere is exactly why this has to stay
     // the narrowest thing in the repo.
     "@/common/": {
+      name: "kebab-case",
       message:
         "common/ holds leaf utilities with no architectural position: the typed environment and the token cipher. A file here is reachable from every tier, so it may depend on nothing but effect and the node builtins. Anything that needs more than that is not common — it belongs to a tier that can name its dependencies.",
       imports: {
@@ -642,6 +685,7 @@ export default {
     // `@/platform/**` the modules were granted wholesale is now a set of tiers
     // that each say what they are.
     "@/platform/": {
+      name: "kebab-case",
       message:
         "platform/ holds the cross-cutting kernel: branded IDs, the DDD contracts tier, the auth and notification ports, the persistence helpers, and the Lives that bind them. A file here is shared by every module, so it earns its place by being needed by more than one.",
       imports: {
@@ -809,6 +853,7 @@ export default {
     },
 
     "@/modules/{module}/": {
+      name: "kebab-case",
       message:
         "The module root admits only aggregation files: index.ts (barrel), <feature>.module.ts (composed Layer), <feature>.command-handlers.ts / .query-handlers.ts (bus-registration maps), <feature>.event-span-attributes.ts, <feature>.shared-deps.ts. Feature code belongs in a stereotype subfolder (domain/, commands/, queries/, event-handlers/, infrastructure/, interface/, policies/).",
 
@@ -1338,7 +1383,11 @@ export default {
               },
 
               children: {
-                "*.root.ts": {},
+                // A subdomain folder is the aggregate, so its root carries the
+                // folder's own name: todo/ holds todo.root.ts. A root named
+                // anything else means the folder holds two aggregates, or the
+                // wrong one.
+                "*.root.ts": { name: { like: "{subdomain}" } },
                 "*.root-ops.ts": {
                   message:
                     "An aggregate root's operations bag (*.root-ops.ts) owns the invariants, so it carries the test-parity obligation: add the sibling *.root-ops.test.ts. (The *.root.ts data class is a dumb Schema and needs no test.)",

--- a/docs/adr/0028-the-architecture-manifest.md
+++ b/docs/adr/0028-the-architecture-manifest.md
@@ -111,6 +111,42 @@ An`import "server-only"` side-effect import that a regex survey cannot see but
 an AST can. None of these were caught by reading; all were caught by running the
 policy against the real tree or against a planted violation.
 
+### Naming, because a taxonomy is only half a convention
+
+`children` enumerates the stereotypes a folder admits and says nothing about the
+concept name in front of one. `*.handler.ts` is satisfied by
+`create-todo.handler.ts`, `CreateTodo.handler.ts` and `create_TODO.handler.ts`
+alike, and a whole module folder called `Todos_V2` passed every rule we had. That
+is a real degree of freedom, and the one a contributor — or an agent working from
+the manifest — drifts through first, because nothing pushes back.
+
+A node therefore carries a `name`: one of four conventions, a regex with a
+sentence saying why, or `{ like: "{capture}" }`. It **inherits like `imports`**,
+so a tier states it once rather than on each of a hundred stereotype keys.
+
+Two decisions inside that are worth recording.
+
+**A file's concept name is its basename up to the first dot, not what a `*`
+matched.** The key `*-live.ts` matches `todos.repository-live.ts`, where the
+wildcard spans a stereotype segment as well as the concept; judging the wildcard
+would report every compound stereotype in the repo. ADR-0024 already makes the
+dot the delimiter, so the rule reads it the same way.
+
+**A custom regex still owes a counter-example.** The compiler tries a handful of
+candidate names and takes the first the pattern refuses; if the pattern admits
+all of them, the manifest fails to compile. A convention nothing can violate is a
+rule that never reports, and this is the same guarantee the generated probes give
+every other rule — held at the one place a human writes the pattern themselves.
+
+The conventions this repo declares are the ones it already followed: kebab-case
+for the server, web, components, jobs, CLI, MCP and API client (0 exceptions
+across ~900 files); PascalCase for `contracts/src`, whose files are Effect-style
+modules named for what they export; snake_case for the numbered migrations; and
+two regexes each carrying one named exception, `Database.ts` and
+`features/__root/`. Nothing needed a baseline entry. `domain/{subdomain}/*.root.ts`
+gets `{ like: "{subdomain}" }` — a subdomain folder is the aggregate, so `todo/`
+holds `todo.root.ts`, and all twelve already did.
+
 ## Alternatives considered
 
 - **Keep the flat config.** Rejected once the second subtree was ported: the
@@ -151,6 +187,14 @@ list because of two choices:
 govern?" it answers badly, and grep no longer helps. It prints the allowlist in
 force, every prohibition reaching the file with the first sentence of its
 reason, the folder rule that admits it, and the siblings it owes.
+
+### Rejected: a glob quantifier instead of a field
+
+`[a-z0-9-]+.root.ts` as a child key would need only a `+` token in the glob
+compiler, about ten lines. It was rejected because it puts the convention into
+each of a hundred keys, where copies drift; it cannot constrain a folder capture,
+which is where the worst case was (`modules/Todos_V2/`); and it cannot express
+"named after its folder" at all.
 
 ## Follow-ups
 

--- a/packages/oxlint-architecture-rules/src/adapters/cli/run.ts
+++ b/packages/oxlint-architecture-rules/src/adapters/cli/run.ts
@@ -199,6 +199,12 @@ export const explain = (policy: LoadedPolicy, file: string): Effect.Effect<void,
       rule.folder.some((pattern) => pattern.test(path.dirname(relative))),
     );
 
+    const naming = policy.structure.naming.filter(
+      (rule) =>
+        rule.file.some((pattern) => pattern.test(relative)) &&
+        !rule.fileNot.some((pattern) => pattern.test(relative)),
+    );
+
     const firstSentence = (message: string) => `${message.split(". ")[0] ?? message}.`;
 
     yield* report([
@@ -218,6 +224,15 @@ export const explain = (policy: LoadedPolicy, file: string): Effect.Effect<void,
         : prohibitions.map(([rule]) => `    ${rule.name} — ${firstSentence(rule.message)}`)),
       "",
       `  lives in: ${governing.length === 0 ? "a folder no rule governs" : governing.map((rule) => rule.name).join(", ")}`,
+      ...(naming.length === 0
+        ? []
+        : [
+            "  is named by:",
+            ...naming.map(
+              (rule) =>
+                `    ${rule.name} — ${rule.sameAs !== null ? "its folder's own name" : (rule.convention?.source ?? "")}`,
+            ),
+          ]),
       ...(owed.length === 0 ? [] : ["  owes:", ...owed.map((one) => `    ${one}`)]),
     ]);
   });

--- a/packages/oxlint-architecture-rules/src/core/structure.test.ts
+++ b/packages/oxlint-architecture-rules/src/core/structure.test.ts
@@ -1,15 +1,19 @@
 import * as Result from "effect/Result";
 import { describe, expect, it } from "vitest";
 
-import type { StructureConfig } from "../domain/architecture-config.js";
+import type { StructureConfig, StructureNaming } from "../domain/architecture-config.js";
 import { makeFileSystemFake } from "../infrastructure/file-system-fake.js";
 import type { FileSystem } from "../ports/file-system.js";
 import {
+  type CompiledStructure,
   compileStructure,
+  EMPTY_STRUCTURE,
   evaluateStructure,
   requiredSiblingsOf,
   structureRulesFailingTheirProbe,
 } from "./structure.js";
+
+const PROBE_AT = "packages/server/src/modules/alpha/domain/thing";
 
 const MOD = "^packages/server/src/modules/[^/]+";
 
@@ -258,20 +262,12 @@ describe("compileStructure", () => {
 
   it("is empty when the policy declares no structure at all", () => {
     const compiled = compileStructure(undefined);
-    expect(Result.isSuccess(compiled) && compiled.success).toEqual({
-      roots: [],
-      folders: [],
-      parity: [],
-    });
+    expect(Result.isSuccess(compiled) && compiled.success).toEqual(EMPTY_STRUCTURE);
   });
 
   it("is empty when the policy declares a structure with no rules of any kind", () => {
     const compiled = compileStructure({});
-    expect(Result.isSuccess(compiled) && compiled.success).toEqual({
-      roots: [],
-      folders: [],
-      parity: [],
-    });
+    expect(Result.isSuccess(compiled) && compiled.success).toEqual(EMPTY_STRUCTURE);
   });
 
   // A pattern that cannot compile has to surface as a decode failure, not as a
@@ -343,5 +339,143 @@ describe("a required sibling of a file at the repository root", () => {
         "index.ts",
       ),
     ).toEqual(["index.test.ts"]);
+  });
+});
+
+describe("evaluateStructure naming", () => {
+  const kebab = "^[a-z0-9]+(?:-[a-z0-9]+)*$";
+
+  const naming = (rule: StructureNaming | null): CompiledStructure => {
+    const compiled = compileStructure({
+      naming: [
+        rule ?? {
+          name: "concept-name",
+          message: "A concept name here is kebab-case.",
+          probe: { path: `${PROBE_AT}/zzProbeStray.root.ts` },
+          file: [`^${PROBE_AT.replace("alpha", "[^/]+")}/([^/.]+)[^/]*$`],
+          subject: 1,
+          convention: kebab,
+        },
+      ],
+    });
+    if (Result.isFailure(compiled)) throw compiled.failure;
+    return compiled.success;
+  };
+
+  const at = (structure: CompiledStructure, file: string) =>
+    evaluateStructure(structure, ALL_PRESENT, file).map((violation) => violation.subject);
+
+  it("admits a name the convention accepts", () => {
+    expect(at(naming(null), `${PROBE_AT}/create-todo.root.ts`)).toEqual([]);
+  });
+
+  // The concept name is the basename up to the FIRST dot, so a compound
+  // stereotype is not mistaken for part of it.
+  it("judges the concept name, not the whole stem", () => {
+    expect(at(naming(null), `${PROBE_AT}/todos.repository-live.ts`)).toEqual([]);
+    expect(at(naming(null), `${PROBE_AT}/Todos.repository-live.ts`)).toEqual(["Todos"]);
+  });
+
+  it("reports a name the convention rejects, naming it", () => {
+    expect(at(naming(null), `${PROBE_AT}/TodoAggregate.root.ts`)).toEqual(["TodoAggregate"]);
+  });
+
+  it("ignores a file its own fileNot exempts", () => {
+    expect(
+      at(
+        naming({
+          name: "concept-name",
+          message: "A concept name here is kebab-case.",
+          probe: { path: `${PROBE_AT}/zzProbeStray.id.ts` },
+          file: [`^${PROBE_AT.replace("alpha", "[^/]+")}/([^/.]+)[^/]*$`],
+          fileNot: ["\\.root\\.ts$"],
+          subject: 1,
+          convention: kebab,
+        }),
+        `${PROBE_AT}/TodoAggregate.root.ts`,
+      ),
+    ).toEqual([]);
+  });
+
+  // `sameAs` is what "named after its folder" compiles to: two capture groups
+  // from one match, compared to each other.
+  describe("a name that has to equal another capture", () => {
+    const sameAs = naming({
+      name: "named-after-its-folder",
+      message: "A root is named after its folder.",
+      probe: { path: "modules/alpha/domain/beta/zz.root.ts" },
+      file: ["^modules/[^/]+/domain/([^/]+)/([^/.]+)\\.root\\.ts$"],
+      subject: 2,
+      sameAs: 1,
+    });
+
+    it("admits the file whose name is its folder's", () => {
+      expect(at(sameAs, "modules/todos/domain/todo/todo.root.ts")).toEqual([]);
+    });
+
+    it("reports one named after something else", () => {
+      expect(at(sameAs, "modules/todos/domain/todo/user.root.ts")).toEqual(["user"]);
+    });
+  });
+});
+
+describe("structureRulesFailingTheirProbe for naming", () => {
+  // The guard the package exists for: a convention that admits its own probe is
+  // a convention that could never report anything.
+  it("fails a rule whose probe its own convention accepts", () => {
+    const compiled = compileStructure({
+      naming: [
+        {
+          name: "vacuous",
+          message: "x",
+          probe: { path: `${PROBE_AT}/anything.ts` },
+          file: [`^${PROBE_AT.replace("alpha", "[^/]+")}/([^/.]+)[^/]*$`],
+          subject: 1,
+          convention: "^.*$",
+        },
+      ],
+    });
+    if (Result.isFailure(compiled)) throw compiled.failure;
+    expect(structureRulesFailingTheirProbe(compiled.success)).toEqual(["vacuous"]);
+  });
+});
+
+describe("compileStructure naming failures", () => {
+  const broken = "^packages/(unclosed";
+  const valid: StructureNaming = {
+    name: "concept-name",
+    message: "x",
+    probe: { path: "a/zzProbeStray.ts" },
+    file: ["^a/([^/.]+)[^/]*$"],
+    subject: 1,
+    convention: "^[a-z]+$",
+  };
+
+  it.each([
+    ["file", { file: broken }],
+    ["fileNot", { fileNot: [broken] }],
+    ["convention", { convention: broken }],
+  ])("refuses an invalid pattern in %s", (field, override) => {
+    const compiled = compileStructure({ naming: [{ ...valid, ...override }] });
+    expect(Result.isFailure(compiled) && compiled.failure.field).toBe(field);
+  });
+
+  // A `sameAs` pointing at a group the pattern does not have compares against
+  // nothing, so the name can never satisfy it.
+  it("reports a name whose sameAs group the pattern never fills", () => {
+    const { convention: _unused, ...withoutConvention } = valid;
+    const compiled = compileStructure({ naming: [{ ...withoutConvention, sameAs: 7 }] });
+    if (Result.isFailure(compiled)) throw compiled.failure;
+    expect(
+      evaluateStructure(compiled.success, ALL_PRESENT, "a/thing.ts").map((one) => one.subject),
+    ).toEqual(["thing"]);
+  });
+
+  it("ignores a file whose pattern matches without filling the subject", () => {
+    const compiled = compileStructure({
+      naming: [{ ...valid, file: ["^a/[^/]+$"], subject: 1 }],
+    });
+    if (Result.isFailure(compiled)) throw compiled.failure;
+    expect(evaluateStructure(compiled.success, ALL_PRESENT, "a/thing.ts")).toEqual([]);
   });
 });

--- a/packages/oxlint-architecture-rules/src/core/structure.ts
+++ b/packages/oxlint-architecture-rules/src/core/structure.ts
@@ -3,6 +3,7 @@ import * as Result from "effect/Result";
 import type {
   StructureConfig,
   StructureFolder,
+  StructureNaming,
   StructureParity,
   StructureRoot,
 } from "../domain/architecture-config.js";
@@ -35,13 +36,30 @@ export type CompiledStructureParity = {
   readonly probe: string;
 };
 
+export type CompiledStructureNaming = {
+  readonly name: string;
+  readonly message: string;
+  readonly file: ReadonlyArray<RegExp>;
+  readonly fileNot: ReadonlyArray<RegExp>;
+  readonly subject: number;
+  readonly convention: RegExp | null;
+  readonly sameAs: number | null;
+  readonly probe: string;
+};
+
 export type CompiledStructure = {
   readonly roots: ReadonlyArray<CompiledStructureRoot>;
   readonly folders: ReadonlyArray<CompiledStructureFolder>;
   readonly parity: ReadonlyArray<CompiledStructureParity>;
+  readonly naming: ReadonlyArray<CompiledStructureNaming>;
 };
 
-export const EMPTY_STRUCTURE: CompiledStructure = { roots: [], folders: [], parity: [] };
+export const EMPTY_STRUCTURE: CompiledStructure = {
+  roots: [],
+  folders: [],
+  parity: [],
+  naming: [],
+};
 
 const compileRoot = (rule: StructureRoot): Result.Result<CompiledStructureRoot, PatternInvalid> => {
   const path = compilePatterns(rule.name, "path", rule.path);
@@ -87,6 +105,27 @@ const compileParity = (
   });
 };
 
+const compileNaming = (
+  rule: StructureNaming,
+): Result.Result<CompiledStructureNaming, PatternInvalid> => {
+  const file = compilePatterns(rule.name, "file", rule.file);
+  if (Result.isFailure(file)) return Result.fail(file.failure);
+  const fileNot = compilePatterns(rule.name, "fileNot", rule.fileNot);
+  if (Result.isFailure(fileNot)) return Result.fail(fileNot.failure);
+  const convention = compilePatterns(rule.name, "convention", rule.convention);
+  if (Result.isFailure(convention)) return Result.fail(convention.failure);
+  return Result.succeed({
+    name: rule.name,
+    message: rule.message,
+    file: file.success,
+    fileNot: fileNot.success,
+    subject: rule.subject,
+    convention: convention.success[0] ?? null,
+    sameAs: rule.sameAs ?? null,
+    probe: rule.probe.path,
+  });
+};
+
 const compileAll = <A, B>(
   items: ReadonlyArray<A>,
   compile: (item: A) => Result.Result<B, PatternInvalid>,
@@ -111,11 +150,14 @@ export const compileStructure = (
   if (Result.isFailure(folders)) return Result.fail(folders.failure);
   const parity = compileAll(config.parity ?? [], compileParity);
   if (Result.isFailure(parity)) return Result.fail(parity.failure);
+  const naming = compileAll(config.naming ?? [], compileNaming);
+  if (Result.isFailure(naming)) return Result.fail(naming.failure);
 
   return Result.succeed({
     roots: roots.success,
     folders: folders.success,
     parity: parity.success,
+    naming: naming.success,
   });
 };
 
@@ -159,6 +201,37 @@ export const requiredSiblingsOf = (
   );
 };
 
+type NamingMatch = {
+  readonly subject: string;
+  readonly expected: string | null;
+  // Whether the rule asked for a comparison at all. Without this a `sameAs`
+  // naming a group the pattern never fills would fall back to "no convention"
+  // and admit every name — vacuous, in the one family added to stop that.
+  readonly comparing: boolean;
+};
+
+// The rule's pattern carries capture groups; `subject` says which one holds the
+// name being judged, and `sameAs` which one it has to equal.
+const firstNamingMatch = (rule: CompiledStructureNaming, file: string): NamingMatch | null => {
+  for (const pattern of rule.file) {
+    const found = pattern.exec(file);
+    if (found === null) continue;
+    const subject = found[rule.subject];
+    if (subject === undefined) continue;
+    return {
+      subject,
+      expected: rule.sameAs === null ? null : (found[rule.sameAs] ?? null),
+      comparing: rule.sameAs !== null,
+    };
+  }
+  return null;
+};
+
+const namingSatisfied = (rule: CompiledStructureNaming, named: NamingMatch): boolean =>
+  named.comparing
+    ? named.expected !== null && named.subject === named.expected
+    : rule.convention === null || rule.convention.test(named.subject);
+
 export const evaluateStructure = (
   structure: CompiledStructure,
   fileSystem: FileSystem,
@@ -180,6 +253,19 @@ export const evaluateStructure = (
         subject: sibling,
       });
     }
+  }
+
+  for (const rule of structure.naming) {
+    if (anyMatches(rule.fileNot, file)) continue;
+    const named = firstNamingMatch(rule, file);
+    if (named === null || namingSatisfied(rule, named)) continue;
+    violations.push({
+      kind: "structure",
+      ruleName: rule.name,
+      message: rule.message,
+      file,
+      subject: named.subject,
+    });
   }
 
   const governing = structure.folders.filter((rule) => anyMatches(rule.folder, folder));
@@ -225,6 +311,13 @@ export const structureRulesFailingTheirProbe = (
   structure: CompiledStructure,
 ): ReadonlyArray<string> => {
   const failing: Array<string> = [];
+
+  for (const rule of structure.naming) {
+    const named = firstNamingMatch(rule, rule.probe);
+    if (named === null || namingSatisfied(rule, named) || anyMatches(rule.fileNot, rule.probe)) {
+      failing.push(rule.name);
+    }
+  }
 
   for (const rule of structure.parity) {
     const selects = anyMatches(rule.file, rule.probe) && !anyMatches(rule.fileNot, rule.probe);

--- a/packages/oxlint-architecture-rules/src/domain/architecture-config.ts
+++ b/packages/oxlint-architecture-rules/src/domain/architecture-config.ts
@@ -161,10 +161,29 @@ const StructureParity = Schema.Struct({
   requires: Schema.Array(Schema.String),
 });
 
+// What shape the variable part of a name may take. `folders` says which
+// stereotypes a folder admits; this says what the concept name in front of the
+// stereotype may look like — the degree of freedom a taxonomy alone leaves open.
+const StructureNaming = Schema.Struct({
+  name: Schema.String,
+  message: Schema.String,
+  probe: PathProbe,
+  // Matched against the whole repo-relative path, and carrying capture groups:
+  // `subject` says which of them holds the name being judged.
+  file: PatternList,
+  fileNot: Schema.optionalKey(PatternList),
+  subject: Schema.Finite,
+  // The shape the subject must have. Exactly one of these.
+  convention: Schema.optionalKey(Schema.String),
+  // A capture group the subject must equal, for "named after its folder".
+  sameAs: Schema.optionalKey(Schema.Finite),
+});
+
 const StructureConfig = Schema.Struct({
   roots: Schema.optionalKey(Schema.Array(StructureRoot)),
   folders: Schema.optionalKey(Schema.Array(StructureFolder)),
   parity: Schema.optionalKey(Schema.Array(StructureParity)),
+  naming: Schema.optionalKey(Schema.Array(StructureNaming)),
 });
 
 export type ImportRule = (typeof ImportRule)["Type"];
@@ -181,6 +200,7 @@ export type StructureConfig = (typeof StructureConfig)["Type"];
 export type StructureRoot = (typeof StructureRoot)["Type"];
 export type StructureFolder = (typeof StructureFolder)["Type"];
 export type StructureParity = (typeof StructureParity)["Type"];
+export type StructureNaming = (typeof StructureNaming)["Type"];
 
 export const patternsOf = (patterns: string | ReadonlyArray<string>): ReadonlyArray<string> =>
   typeof patterns === "string" ? [patterns] : patterns;

--- a/packages/oxlint-architecture-rules/src/manifest/compile.test.ts
+++ b/packages/oxlint-architecture-rules/src/manifest/compile.test.ts
@@ -448,3 +448,92 @@ describe("export restrictions", () => {
     expect(ruleNamed(lowered.exports, "no-factories").probe.to).toContain("node_modules/pkg");
   });
 });
+
+describe("naming", () => {
+  const tree = (name: unknown, extra: Record<string, unknown> = {}) =>
+    lowerManifest(
+      base({
+        "@/modules/{module}/": {
+          name,
+          children: {
+            "domain/{subdomain}/": {
+              children: { "*.root.ts": extra, "*.id.ts": {} },
+            },
+          },
+        },
+      } as never),
+    );
+
+  it("judges a folder's own segment where its key declares a capture", () => {
+    const rule = ruleNamed(tree("kebab-case").structure.naming, "modules-module/naming-folder");
+    expect(rule.convention).toBe("^[a-z0-9]+(?:-[a-z0-9]+)*$");
+    expect(rule.file[0]).toContain("pkg/src/modules");
+  });
+
+  // A literal key names nothing variable, so it has no segment to judge — only
+  // the files inside it.
+  it("emits no folder rule for a key with no variable segment", () => {
+    const names = tree("kebab-case").structure.naming.map((rule) => rule.name);
+    expect(names).not.toContain("modules-module/domain/{subdomain}/*.root.ts/naming-folder");
+  });
+
+  // Inheritance is the whole ergonomics: one declaration, not one per key.
+  it("carries the convention down to a folder that does not restate it", () => {
+    const names = tree("kebab-case").structure.naming.map((rule) => rule.name);
+    expect(names).toContain("modules-module/domain/{subdomain}/naming");
+  });
+
+  it("states nothing when no tier declares a convention", () => {
+    expect(tree(undefined).structure.naming).toEqual([]);
+  });
+
+  describe("named after an ancestor capture", () => {
+    it("compiles to a comparison between two groups of one match", () => {
+      const rule = ruleNamed(
+        tree("kebab-case", { name: { like: "{subdomain}" } }).structure.naming,
+        "*.root.ts/naming",
+      );
+      expect(rule.sameAs).toBeDefined();
+      expect(rule.subject).not.toBe(rule.sameAs);
+    });
+
+    it("refuses a reference no ancestor path declares", () => {
+      expect(() => tree("kebab-case", { name: { like: "{nowhere}" } })).toThrow(/no ancestor/);
+    });
+  });
+
+  // A convention nothing can violate is a rule that never reports, which is the
+  // one failure this package refuses to ship.
+  it("refuses a custom pattern that admits every name", () => {
+    expect(() => tree({ regex: ".*" })).toThrow(/admits every name/);
+  });
+
+  it("generates a probe its own convention rejects", () => {
+    const rule = ruleNamed(tree("PascalCase").structure.naming, "modules-module/naming");
+    expect(rule.probe.path).toMatch(/zz-probe-stray/);
+  });
+});
+
+describe("naming edge cases", () => {
+  const one = (node: unknown) => lowerManifest(base({ "@/a/": node } as never)).structure.naming;
+
+  it("refuses a convention it does not know", () => {
+    expect(() => one({ name: "SCREAMING_SNAKE", children: { "*.ts": {} } })).toThrow(
+      /unknown naming convention/,
+    );
+  });
+
+  it("carries a custom message rather than the generated one", () => {
+    const [rule] = one({
+      name: { regex: "^x[a-z]+$", message: "A file here starts with x." },
+      children: { "*.ts": {} },
+    });
+    expect(rule?.message).toBe("A file here starts with x.");
+  });
+
+  it.each(["camelCase", "snake_case"])("knows the shape of %s", (convention) => {
+    const [rule] = one({ name: convention, children: { "*.ts": {} } });
+    expect(rule?.message).toContain(convention);
+    expect(rule?.convention).toBeDefined();
+  });
+});

--- a/packages/oxlint-architecture-rules/src/manifest/compile.ts
+++ b/packages/oxlint-architecture-rules/src/manifest/compile.ts
@@ -3,11 +3,18 @@ import type {
   ImportRule,
   MemberRule,
   StructureFolder,
+  StructureNaming,
   StructureParity,
   StructureRoot,
 } from "../domain/architecture-config.js";
 import { anchored, type CaptureIndex, globToRegexSource, prefixed } from "./glob.js";
-import { globsOf, type ImportsSpec, type Manifest, type ManifestNode } from "./manifest.js";
+import {
+  globsOf,
+  type ImportsSpec,
+  type Manifest,
+  type ManifestNode,
+  type NamingSpec,
+} from "./manifest.js";
 
 // The manifest is the authoring surface; these flat rules are the machine's.
 // Lowering rather than interpreting keeps one evaluator, one probe mechanism and
@@ -20,6 +27,7 @@ export type LoweredRules = {
     readonly roots: ReadonlyArray<StructureRoot>;
     readonly folders: ReadonlyArray<StructureFolder>;
     readonly parity: ReadonlyArray<StructureParity>;
+    readonly naming: ReadonlyArray<StructureNaming>;
   };
 };
 
@@ -68,6 +76,8 @@ type Frame = {
   // Accumulated down the tree. `reset` is the only thing that clears it.
   readonly allow: ReadonlyArray<string>;
   readonly importsMessage: string;
+  // Inherited like the allowlist: a tier states its naming convention once.
+  readonly naming: NamingSpec | undefined;
 };
 
 // A probe is the node's own path with its wildcards filled in, so a rule is
@@ -98,6 +108,87 @@ const probeMemberName = (match: string | ReadonlyArray<string> | undefined): str
     // one it admits: `use[A-Z]*` has to be proven with `useA…`, not `use[A-Z]…`.
     .replace(/\[\^?([^\]])[^\]]*\]/g, "$1")
     .replace(/\*/g, "")}ZzProbe`;
+};
+
+// Each convention pairs the shape a name must have with a name that does not
+// have it, so the rule's probe is generated rather than written.
+const CONVENTIONS: Readonly<
+  Record<string, { readonly source: string; readonly violating: string; readonly shape: string }>
+> = {
+  "kebab-case": {
+    source: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+    violating: "zzProbeStray",
+    shape: "lowercase words joined by hyphens",
+  },
+  camelCase: {
+    source: "^[a-z][a-zA-Z0-9]*$",
+    violating: "zz-probe-stray",
+    shape: "a lowercase first word, then capitalised ones, with no separators",
+  },
+  PascalCase: {
+    source: "^[A-Z][a-zA-Z0-9]*$",
+    violating: "zz-probe-stray",
+    shape: "capitalised words with no separators",
+  },
+  snake_case: {
+    source: "^[a-z0-9]+(?:_[a-z0-9]+)*$",
+    violating: "zzProbeStray",
+    shape: "lowercase words joined by underscores",
+  },
+};
+
+// The folder's file list already enforces the stereotype suffix; a naming rule
+// is about the concept name in front of it, so the message says which part it
+// is talking about.
+const namingMessageOf = (spec: NamingSpec, subject: "file" | "folder"): string => {
+  const what =
+    subject === "folder" ? "This folder's name" : "The concept name in front of the stereotype";
+  if (typeof spec === "string") {
+    return `${what} is ${spec} here — ${CONVENTIONS[spec]?.shape ?? ""}.`;
+  }
+  if (spec.message !== undefined) return spec.message;
+  if ("like" in spec) {
+    return "A file here is named after its folder, so its concept name is the folder's own.";
+  }
+  return `${what} matches /${spec.regex}/ here.`;
+};
+
+// A custom convention still owes a counter-example. If none of these fails it,
+// the pattern admits every name and the rule could never report anything —
+// which is the vacuity this package refuses to load.
+const VIOLATING_CANDIDATES = ["zzProbeStray", "zz-probe-stray", "ZZ_PROBE_STRAY", "zz probe.stray"];
+
+const violatingSampleFor = (spec: NamingSpec, ruleName: string): string => {
+  if (typeof spec === "string") {
+    const convention = CONVENTIONS[spec];
+    if (convention === undefined) throw new Error(`unknown naming convention "${spec}"`);
+    return convention.violating;
+  }
+  if ("like" in spec) return "zzprobestray";
+  const matcher = new RegExp(spec.regex);
+  const found = VIOLATING_CANDIDATES.find((candidate) => !matcher.test(candidate));
+  if (found === undefined) {
+    throw new Error(
+      `naming rule "${ruleName}" states /${spec.regex}/, which admits every name this ` +
+        `compiler can think of. A convention nothing can violate is a rule that never reports.`,
+    );
+  }
+  return found;
+};
+
+// The probe is the node's own probe path with the subject replaced by a name the
+// convention rejects — located by matching, so the compiler never has to reason
+// about which segment of a glob the subject came from.
+const namingProbeOf = (
+  patternSource: string,
+  subject: number,
+  probe: string,
+  violating: string,
+): string => {
+  const found = new RegExp(patternSource, "d").exec(probe);
+  const span = found?.indices?.[subject];
+  if (span === undefined) return probe;
+  return probe.slice(0, span[0]) + violating + probe.slice(span[1]);
 };
 
 type Denial = {
@@ -162,6 +253,7 @@ export const lowerManifest = (manifest: Manifest): LoweredRules => {
   const roots: Array<StructureRoot> = [];
   const folders: Array<StructureFolder> = [];
   const parity: Array<StructureParity> = [];
+  const namingRules: Array<StructureNaming> = [];
 
   const walk = (
     key: string,
@@ -224,10 +316,121 @@ export const lowerManifest = (manifest: Manifest): LoweredRules => {
       nextGroup,
       allow: merged.allow,
       importsMessage: merged.importsMessage,
+      naming: node.name ?? parent.naming,
     };
 
     const isFolder = isFolderKey(key) || node.children !== undefined;
     const selfPattern = anchored(pathSource);
+
+    // Naming, in two shapes. A folder judges its own segment (when its key
+    // declares a capture) and the concept name of every file directly inside
+    // it; a file node judges what its own `*` matched, which is where "named
+    // after its folder" lives.
+    //
+    // A file's concept name is its basename up to the FIRST dot, not what a `*`
+    // matched: the key `*-live.ts` matches `todos.repository-live.ts`, whose
+    // wildcard spans a stereotype segment as well as the concept.
+    const naming = frame.naming;
+    if (naming !== undefined) {
+      const declaredHere = Object.keys(compiled.captures).filter(
+        (one) => parent.captures[one] === undefined,
+      );
+      const lastDeclared = declaredHere[declaredHere.length - 1];
+      const isLike = typeof naming === "object" && "like" in naming;
+
+      const emit = (
+        ruleName: string,
+        patterns: ReadonlyArray<string>,
+        subject: number,
+        probe: string,
+        sameAs?: number,
+        judging: "file" | "folder" = "file",
+      ): void => {
+        namingRules.push({
+          name: ruleName,
+          message: namingMessageOf(naming, judging),
+          probe: {
+            path:
+              sameAs === undefined
+                ? namingProbeOf(
+                    patterns[0] ?? "",
+                    subject,
+                    probe,
+                    violatingSampleFor(naming, ruleName),
+                  )
+                : probe,
+          },
+          file: patterns,
+          subject,
+          ...(sameAs === undefined
+            ? {
+                convention:
+                  typeof naming === "string"
+                    ? (CONVENTIONS[naming]?.source ?? "")
+                    : "regex" in naming
+                      ? naming.regex
+                      : "",
+              }
+            : { sameAs }),
+        });
+      };
+
+      if (isFolder && !isLike) {
+        if (lastDeclared !== undefined) {
+          const subject = compiled.captures[lastDeclared];
+          if (subject !== undefined) {
+            emit(
+              `${name}/naming-folder`,
+              [prefixed(`${pathSource}/`)],
+              subject,
+              probePathOf(joinedGlob, "zzprobe.ts"),
+              undefined,
+              "folder",
+            );
+          }
+        }
+        emit(
+          `${name}/naming`,
+          [anchored(`${pathSource}/([^/.]+)[^/]*`)],
+          nextGroup,
+          probePathOf(joinedGlob, "zzprobe.ts"),
+        );
+      }
+
+      if (!isFolder && isLike) {
+        const namingCompiled = alternatives.map((one) =>
+          globToRegexSource(one, parent.captures, {
+            declaring: true,
+            nextGroup: parent.nextGroup,
+            capturing: true,
+          }),
+        );
+        const [firstNaming] = namingCompiled;
+        const subject = firstNaming?.wildcards[firstNaming.wildcards.length - 1];
+        const sameAs =
+          typeof naming === "object" && "like" in naming
+            ? parent.captures[naming.like.replace(/[{}]/g, "")]
+            : undefined;
+        if (typeof naming === "object" && "like" in naming && sameAs === undefined) {
+          throw new Error(
+            `naming at "${key}" is like ${naming.like}, which no ancestor path declares.`,
+          );
+        }
+        if (subject !== undefined && sameAs !== undefined) {
+          emit(
+            `${name}/naming`,
+            namingCompiled.map((one) =>
+              anchored(
+                parent.pathSource === "" ? one.source : `${parent.pathSource}/${one.source}`,
+              ),
+            ),
+            subject,
+            probePathOf(joinedGlob, ""),
+            sameAs,
+          );
+        }
+      }
+    }
 
     const childEntries = Object.entries(node.children ?? {});
     // The nearest descendants — at any depth — that state their own import
@@ -445,6 +648,7 @@ export const lowerManifest = (manifest: Manifest): LoweredRules => {
     nextGroup: 1,
     allow: [],
     importsMessage: "This import is not on this folder's allowlist.",
+    naming: undefined,
   };
 
   // Repo-wide prohibitions: `from` is every file, so no tier can be written
@@ -523,5 +727,10 @@ export const lowerManifest = (manifest: Manifest): LoweredRules => {
     });
   }
 
-  return { imports, exports, members, structure: { roots, folders, parity } };
+  return {
+    imports,
+    exports,
+    members,
+    structure: { roots, folders, parity, naming: namingRules },
+  };
 };

--- a/packages/oxlint-architecture-rules/src/manifest/glob.test.ts
+++ b/packages/oxlint-architecture-rules/src/manifest/glob.test.ts
@@ -70,3 +70,26 @@ describe("single-character wildcards and back-references", () => {
     expect(referenced.source).toContain("$1");
   });
 });
+
+describe("capturing wildcards", () => {
+  // Off by default, and it has to stay that way: a stray group would renumber
+  // the back-references `{capture}` compiles to.
+  it("leaves * uncaptured unless asked", () => {
+    expect(compile("*.root.ts").wildcards).toEqual([]);
+    expect(compile("*.root.ts").source).toContain("[^/]*");
+  });
+
+  it("captures each * in source order when asked, alongside the named ones", () => {
+    const compiled = globToRegexSource(
+      "{module}/deep/*.test.ts",
+      {},
+      {
+        declaring: true,
+        nextGroup: 1,
+        capturing: true,
+      },
+    );
+    expect(compiled.captures).toEqual({ module: 1 });
+    expect(compiled.wildcards).toEqual([2]);
+  });
+});

--- a/packages/oxlint-architecture-rules/src/manifest/glob.ts
+++ b/packages/oxlint-architecture-rules/src/manifest/glob.ts
@@ -26,6 +26,9 @@ const TOKENS = new RegExp(`(${TOKEN_SOURCE})`, "g");
 export type GlobCompilation = {
   readonly source: string;
   readonly captures: CaptureIndex;
+  // Group indices for the `*`s, in source order, when `capturing` asked for
+  // them. A naming rule judges what one of these matched.
+  readonly wildcards: ReadonlyArray<number>;
 };
 
 // `declaring` compiles `{name}` to a new capture group and records its position;
@@ -34,9 +37,17 @@ export type GlobCompilation = {
 export const globToRegexSource = (
   glob: string,
   captures: CaptureIndex,
-  options: { readonly declaring: boolean; readonly nextGroup: number },
+  options: {
+    readonly declaring: boolean;
+    readonly nextGroup: number;
+    // Compile `*` to a capture rather than to `[^/]*`, so a caller can ask what
+    // the variable part of a name actually was. Off everywhere else: a stray
+    // group would renumber the back-references `{capture}` compiles to.
+    readonly capturing?: boolean;
+  },
 ): GlobCompilation => {
   const declared: Record<string, number> = { ...captures };
+  const wildcards: Array<number> = [];
   let group = options.nextGroup;
   let out = "";
 
@@ -48,7 +59,11 @@ export const globToRegexSource = (
       continue;
     }
     if (part === "*") {
-      out += "[^/]*";
+      if (options.capturing === true) {
+        wildcards.push(group);
+        out += "([^/]*)";
+        group += 1;
+      } else out += "[^/]*";
       continue;
     }
     if (part === "?") {
@@ -85,7 +100,7 @@ export const globToRegexSource = (
   }
 
   // `a/**` should match `a` itself, not just its descendants.
-  return { source: out.replace(/\/\.\*$/, "(/.*)?"), captures: declared };
+  return { source: out.replace(/\/\.\*$/, "(/.*)?"), captures: declared, wildcards };
 };
 
 export const anchored = (source: string): string => `^${source}$`;

--- a/packages/oxlint-architecture-rules/src/manifest/manifest.ts
+++ b/packages/oxlint-architecture-rules/src/manifest/manifest.ts
@@ -58,6 +58,19 @@ const ImportedBy = Schema.Struct({
   matchNot: Schema.optionalKey(Globs),
 });
 
+// What shape the variable part of a name must have. A folder's `children` keys
+// already say which stereotypes it admits; this says what the concept name in
+// front of the stereotype may look like, which is the degree of freedom a
+// taxonomy alone leaves open.
+//
+// `like` names an ancestor capture the name must equal — a subdomain folder's
+// root is named after the folder, and nothing else could say so.
+const Naming = Schema.Union([
+  Schema.Literals(["kebab-case", "camelCase", "PascalCase", "snake_case"]),
+  Schema.Struct({ regex: Schema.String, message: Schema.optionalKey(Schema.String) }),
+  Schema.Struct({ like: Schema.String, message: Schema.optionalKey(Schema.String) }),
+]);
+
 const Members = Schema.Struct({
   message: Schema.String,
   subject: Schema.Literals(["type-members", "calls"]),
@@ -93,6 +106,9 @@ export type ManifestNode = {
   // library is, by design — says so, rather than carrying a layout rule that
   // could never reject anything.
   readonly layout?: "open";
+  // Inherited by the subtree, like `imports`, so a tier states its convention
+  // once rather than on every stereotype it admits.
+  readonly name?: typeof Naming.Type;
   readonly imports?: typeof Imports.Type;
   readonly importedBy?: typeof ImportedBy.Type;
   readonly members?: ReadonlyArray<typeof Members.Type>;
@@ -112,6 +128,7 @@ const ManifestNodeSchema: Schema.Codec<ManifestNode> = Schema.suspend(() =>
     message: Schema.optionalKey(Schema.String),
     partial: Schema.optionalKey(Schema.Boolean),
     layout: Schema.optionalKey(Schema.Literal("open")),
+    name: Schema.optionalKey(Naming),
     imports: Schema.optionalKey(Imports),
     importedBy: Schema.optionalKey(ImportedBy),
     members: Schema.optionalKey(Schema.Array(Members)),
@@ -143,6 +160,7 @@ export type Manifest = typeof Manifest.Type;
 export type ImportsSpec = typeof Imports.Type;
 export type ImportedBySpec = typeof ImportedBy.Type;
 export type MembersSpec = typeof Members.Type;
+export type NamingSpec = typeof Naming.Type;
 export type ExportRestriction = typeof ExportRestriction.Type;
 
 export const globsOf = (globs: string | ReadonlyArray<string>): ReadonlyArray<string> =>

--- a/scripts/lint-rule-probes.mjs
+++ b/scripts/lint-rule-probes.mjs
@@ -33,6 +33,20 @@ const PROBES = [
     source: "export const Probe = () => null;\n",
   },
   {
+    // Naming: the stereotype suffix is right, the concept name in front of it
+    // is not. Without this the layout rule admits the file and nothing else
+    // looks at the name.
+    rule: "architecture/structure",
+    file: "packages/server/src/modules/todos/commands/zzProbeStray.handler.ts",
+    source: "export const probe = 1;\n",
+  },
+  {
+    // Named after its folder: the right shape, the wrong aggregate.
+    rule: "architecture/structure",
+    file: "packages/server/src/modules/todos/domain/todo/zzprobe-stray.root.ts",
+    source: "export const probe = 1;\n",
+  },
+  {
     rule: "architecture/exports",
     file: "packages/server/src/modules/todos/commands/zzprobe-bus.handler.ts",
     source:

--- a/website/src/content/docs/getting-started/introduction.mdx
+++ b/website/src/content/docs/getting-started/introduction.mdx
@@ -24,6 +24,7 @@ families.
 | Which importers may name this exported symbol? | `exports`   |
 | Which names may this file declare or call?     | `members`   |
 | Which files may live in this folder?           | `structure` |
+| What may they be called?                       | `structure` |
 | Which siblings does this file owe?             | `structure` |
 
 ## The two properties everything rests on

--- a/website/src/content/docs/manifest/index.mdx
+++ b/website/src/content/docs/manifest/index.mdx
@@ -54,6 +54,7 @@ real.
   imports: { reset: true, external: ["effect"], allow: ["@/modules/{module}/domain/**"] },
   children: {
     "*.root.ts": {
+      name: { like: "{subdomain}" },
       requires: ["{base}.root.test.ts"],
     },
     "*.repository.ts": {
@@ -80,6 +81,7 @@ real.
 | `imports`     | what may this reach?                            | [Imports](/oxlint-architecture-rules/manifest/imports/)         |
 | `importedBy`  | who may reach this?                             | [Imported by](/oxlint-architecture-rules/manifest/imported-by/) |
 | `members`     | which names may it declare or call?             | [Members](/oxlint-architecture-rules/manifest/members/)         |
+| `name`        | what may the variable part of a name look like? | [Structure](/oxlint-architecture-rules/manifest/structure/)     |
 | `requires`    | which siblings does this file owe?              | [Structure](/oxlint-architecture-rules/manifest/structure/)     |
 | `requiresNot` | which filenames does that obligation skip?      | [Structure](/oxlint-architecture-rules/manifest/structure/)     |
 | `children`    | which files and folders does this folder admit? | [Structure](/oxlint-architecture-rules/manifest/structure/)     |

--- a/website/src/content/docs/manifest/inheritance.mdx
+++ b/website/src/content/docs/manifest/inheritance.mdx
@@ -38,6 +38,22 @@ narrow:
 },
 ```
 
+## `name` inherits the same way
+
+A naming convention is inherited by the whole subtree, and a descendant that states its own
+replaces it. There is no `reset` for naming, because a convention is a single value rather
+than a list: restating it _is_ the reset.
+
+```js
+"~/database/src/": {
+  name: { regex: "^(?:Database|[a-z0-9]+(?:-[a-z0-9]+)*)$" },
+  children: {
+    "migrations/": { name: "snake_case" },   // narrower, and stated
+    "**/": { name: "kebab-case" },
+  },
+},
+```
+
 ## Prohibitions only accumulate
 
 A `deny` is emitted **once**, over the subtree of the node that declares it, and descendants

--- a/website/src/content/docs/manifest/structure.mdx
+++ b/website/src/content/docs/manifest/structure.mdx
@@ -1,14 +1,14 @@
 ---
 title: Structure
-description: Which files a folder admits, which siblings a file owes, and the stray-folder catch-all.
+description: Which files a folder admits, what they may be called, which siblings they owe, and the stray-folder catch-all.
 ---
 
 The structure family is the inverse of the other three. They ask whether a file is doing
 something it should not; structure asks whether the file is allowed to _exist_ where it is,
 and whether the files that must exist beside it do.
 
-It comes from two fields — `children` and `requires` — and compiles into three kinds of
-rule.
+It comes from three fields — `children`, `name` and `requires` — and compiles into four
+kinds of rule.
 
 ## Layout: `children`
 
@@ -54,6 +54,74 @@ It still emits a layout rule — one admitting any filename — so the folder is
 That matters: the catch-all below fires on folders no rule governs, and an open folder that
 emitted nothing would trip it. The rule is skipped by the probe check, since a rule that
 admits everything has no path it must reject.
+
+## Naming: `name`
+
+`children` says which stereotypes a folder admits. It says nothing about the **concept
+name in front of the stereotype**: `*.handler.ts` is satisfied by `create-todo.handler.ts`,
+`CreateTodo.handler.ts` and `create_TODO.handler.ts` alike. That is the degree of freedom a
+taxonomy alone leaves open, and `name` closes it.
+
+```js
+"~/server/src/": { name: "kebab-case" },      // inherited by the whole subtree
+"~/contracts/src/": { name: "PascalCase" },
+"migrations/": { name: "snake_case" },
+```
+
+| Value                 | Shape                                         |
+| --------------------- | --------------------------------------------- |
+| `"kebab-case"`        | lowercase words joined by hyphens             |
+| `"camelCase"`         | a lowercase first word, then capitalised ones |
+| `"PascalCase"`        | capitalised words, no separators              |
+| `"snake_case"`        | lowercase words joined by underscores         |
+| `{ regex, message? }` | anything else, with a sentence saying why     |
+| `{ like, message? }`  | equal to an ancestor capture                  |
+
+`name` **inherits like `imports`**: state it once at a package root and every folder beneath
+it is covered. That is what keeps it to a handful of declarations rather than one per
+stereotype.
+
+### What it judges
+
+A folder node's `name` judges two things:
+
+- **its own segment**, when its key declares a capture — `@/modules/{module}/` with
+  `kebab-case` refuses a module folder named `Todos_V2`;
+- **the concept name of every file directly inside it.**
+
+A file's concept name is its basename **up to the first dot**, not what a `*` matched. That
+distinction matters: the key `*-live.ts` matches `todos.repository-live.ts`, whose wildcard
+spans a stereotype segment as well as the concept. The dot is the delimiter, so `todos` is
+the name and `repository-live` is the stereotype.
+
+### Named after its folder
+
+```js
+"@/modules/{module}/domain/{subdomain}/": {
+  children: {
+    "*.root.ts": { name: { like: "{subdomain}" } },
+  },
+},
+```
+
+`like` names an ancestor capture the concept name must **equal**. A subdomain folder is the
+aggregate, so `todo/` holds `todo.root.ts`; a `user.root.ts` sitting there means the folder
+holds two aggregates, or the wrong one. Nothing but a cross-reference can say that, and it
+is the one place `name` belongs on a file node rather than a folder.
+
+The reference is resolved against captures declared by the file's **ancestors**, so a `like`
+naming a capture no ancestor path declares fails to compile rather than never firing.
+
+### Probes for a convention
+
+A naming rule proves itself like everything else: its probe is the node's own probe path
+with the concept name replaced by one the convention rejects — `zzProbeStray` for
+kebab-case, `zz-probe-stray` for PascalCase.
+
+For a custom `regex`, the compiler tries a handful of candidate names and takes the first
+the pattern refuses. **If the pattern admits all of them, the manifest fails to compile**: a
+convention nothing can violate is a rule that never reports, which is the one thing this
+package will not ship.
 
 ## Parity: `requires`
 


### PR DESCRIPTION
`children` says which stereotypes a folder admits, and nothing about the concept
name in front of one. So `*.handler.ts` was satisfied by `create-todo.handler.ts`,
`CreateTodo.handler.ts` and `create_TODO.handler.ts` alike — and a whole module
folder named `Todos_V2` passed every rule in the manifest.

That is the degree of freedom a taxonomy alone leaves open, and the one anyone
working from the manifest drifts through first, because nothing pushes back.

Four violations planted against `main`, and against this branch:

| Planted | before | after |
| --- | --- | --- |
| `domain/todo/TodoAggregate.root.ts` | accepted | caught |
| `commands/create_TODO.handler.ts` | only the missing test sibling | caught |
| `modules/Todos_V2/domain/MyThing/Thing.root.ts` | accepted | caught, four ways |
| `domain/todo/user.root.ts` | accepted | caught |

## The field

A node carries a `name`, inherited like `imports` so a tier states it once rather
than on each of a hundred stereotype keys:

```js
"~/contracts/src/":   { name: "PascalCase" },
"@/modules/{module}/": { name: "kebab-case" },
"migrations/":        { name: "snake_case" },

"@/modules/{module}/domain/{subdomain}/": {
  children: {
    "*.root.ts": { name: { like: "{subdomain}" } },
  },
},
```

It takes one of four conventions, a `{ regex, message }` for anything else, or
`{ like: "{capture}" }`. A folder node's `name` judges two things: **its own
segment**, when its key declares a capture, and **the concept name of every file
directly inside it**. `structure` gains a fourth rule kind beside roots, folders
and parity; 219 rules become 290.

`{ like }` is the cross-reference none of the other forms can express. A subdomain
folder is the aggregate, so `todo/` holds `todo.root.ts`; a `user.root.ts` sitting
there means the folder holds two aggregates, or the wrong one.

## Three decisions worth reviewing

**A file's concept name is its basename up to the first dot, not what a `*`
matched.** The key `*-live.ts` matches `todos.repository-live.ts`, whose wildcard
spans a stereotype segment as well as the concept — judging the wildcard would
have reported every compound stereotype in the repo. ADR-0024 already makes the
dot the delimiter, so the rule reads names the same way the taxonomy does. This
was caught by testing the compound case before wiring the manifest, not after.

**A custom regex still owes a counter-example.** The compiler tries a handful of
candidate names and takes the first the pattern refuses. If the pattern admits all
of them the manifest fails to compile:

```
Error: naming rule "src/modules/{module}/naming" states /.*/, which admits every
name this compiler can think of. A convention nothing can violate is a rule that
never reports.
```

That is the same guarantee the generated probes give every other rule, held at the
one place a human writes the pattern themselves.

**`*` captures only in a separate pass.** Making it capturing in the shared glob
compiler would renumber the groups that `{capture}` back-references compile to,
and `$1` in an `imports.allow` would quietly start pointing at the wrong segment —
a whole-policy corruption that would still lint green. The naming pass compiles
its own patterns.

## One latent hole closed

A `sameAs` pointing at a capture group the pattern never fills fell through to
"no convention" and admitted every name — vacuous, in the family added to stop
vacuity. It now fails closed, with a test.

## No baseline entries

The conventions declared are the ones the repo already followed:

| Tier | Convention | Exceptions |
| --- | --- | --- |
| server, web, components, jobs, cli, mcp, api-client | `kebab-case` | none, in ~900 files |
| `contracts/src` | `PascalCase` | none — Effect-style modules named for what they export |
| `database/src/migrations` | `snake_case` | none |
| `database/src` | regex | `Database.ts`, named for the service it exports |
| `web/features/{feature}` | regex | `__root`, the chrome every route shares |
| `domain/{subdomain}/*.root.ts` | `like: {subdomain}` | none — all twelve already matched |

Each exception is a regex carrying its own sentence saying why, rather than a
baseline entry nobody would revisit.

## Verification

`pnpm check:all` green. 283 package tests. Two probes added to `pnpm lint:rules`
(30 rules now) — one for a convention, one for the cross-reference — so both
halves of the feature are proven to fire on a planted violation.

Docs: a Naming section on the manifest Structure page, the inheritance page, the
field tables, `.claude/rules/architecture-rules.md`, and a decision record in
ADR-0028 including the rejected alternative (a `+` quantifier in the glob, which
would have put the convention into each of a hundred keys and still could not
constrain a folder capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iGmEyben6w5u4pxNQnt9k
